### PR TITLE
feat: レビューイベントを Windows 通知へ変換する (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - `ReviewEventParser.Parse` の戻り値を `List<ReviewEvent>` に変更し、`ReviewCandidate` 配列内の全新着イベントをパース・ループ処理するよう拡張
-- `ReviewCandidate` ペイロードの変更（`url` 等の欠落）に合わせ、`Owner`/`Repo`/`PrNumber` からの PR URL 自動構築と、`queuedAt` 等による `eventId` 自動生成を追加
+- `ReviewCandidate` ペイロードの変更（`url` 等の欠落）に合わせ、`Owner`/`Repo`/`PrNumber` からの PR URL 自動構築と、`queuedAt` 等による `eventId` 自動生成を追加、および `sourceCommentId` の型を `long?` に修正しデシリアライズエラーを防止
 - 重複排除とトースト通知の安定動作を検証するユニットテストを `ReviewEventParserTests` 等に新設・追従
 - アプリケーション、ソリューション、プロジェクト、アセンブリ名、および C# の名前空間を `SquirrelNotifier` へ統一
 - 設定保存先ディレクトリを `%LocalAppData%\WSLKernelWatcher` から `%LocalAppData%\SquirrelNotifier` に変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - 旧 WSL カーネル監視機能 (`KernelWatcherService` および関連 UI / ロジック) を完全に廃止
 
 ### Changed
+- `ReviewEventParser.Parse` の戻り値を `List<ReviewEvent>` に変更し、`ReviewCandidate` 配列内の全新着イベントをパース・ループ処理するよう拡張
+- `ReviewCandidate` ペイロードの変更（`url` 等の欠落）に合わせ、`Owner`/`Repo`/`PrNumber` からの PR URL 自動構築と、`queuedAt` 等による `eventId` 自動生成を追加
+- 重複排除とトースト通知の安定動作を検証するユニットテストを `ReviewEventParserTests` 等に新設・追従
 - アプリケーション、ソリューション、プロジェクト、アセンブリ名、および C# の名前空間を `SquirrelNotifier` へ統一
 - 設定保存先ディレクトリを `%LocalAppData%\WSLKernelWatcher` から `%LocalAppData%\SquirrelNotifier` に変更
 - ウィンドウタイトル、トレイアイコンのツールチップ、メニュー、アプリ表示名を `Squirrel Notifier` へ変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - MCP 購読ブリッジ機構 (`McpSubscriptionService`) を新設。`mcp-resource-subscriber` と連携し、外部 MCP リソースからのレビュー更新イベントを取得可能に
-- `McpSubscriptionService` 用の動作確認 UI を設定ウィンドウに追加（コマンド実行パス、引数、URL、リソース URI、タイムアウトの編集に対応）
+- `McpSubscriptionService` 用の動作確認 UI を設定ウィンドウに追加（コマンド実行パス、引数、URL、リソース URI、タイムアウト of 編集に対応）
+- `mcp-resource-subscriber` から受信した JSON 形式のレビューイベント（`ReviewEvent`）をパースするデシリアライズ・検証機構を導入
+- レビューイベント専用の Windows 通知を構築（通知から検証済み PR URL をブラウザで開くアクション、およびアプリを開くアクションに対応）
+- メモリ内の重複排除キャッシュ（最大100件）による、同一 `eventId` を持つレビューイベントの重複通知防止機能を実装
+- メイン画面 UI に直近のレビューイベント（Recent review events）の履歴リストを追加し、一覧から直接 PR を開けるボタンを配置
 
 ### Removed
 - 旧 WSL カーネル監視機能 (`KernelWatcherService` および関連 UI / ロジック) を完全に廃止

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/UrlValidatorTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/UrlValidatorTests.cs
@@ -26,4 +26,21 @@ public class UrlValidatorTests
         // Assert
         result.Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData("https://github.com/scottlz0310/squirrel-notifier/pull/51", "scottlz0310/squirrel-notifier", 51, true)]
+    [InlineData("https://github.com/scottlz0310/squirrel-notifier/pull/51", "scottlz0310/another-repo", 51, false)] // repo mismatch
+    [InlineData("https://github.com/scottlz0310/squirrel-notifier/pull/51", "scottlz0310/squirrel-notifier", 52, false)] // pr mismatch
+    [InlineData("https://github.com/SCOTTLZ0310/SQUIRREL-NOTIFIER/pull/51", "scottlz0310/squirrel-notifier", 51, true)] // case insensitive
+    [InlineData("http://github.com/scottlz0310/squirrel-notifier/pull/51", "scottlz0310/squirrel-notifier", 51, false)] // unsafe scheme
+    [InlineData("", "repo", 1, false)]
+    [InlineData(null, "repo", 1, false)]
+    public void IsSafeGitHubUrl_WithRepoAndNumber_ShouldValidateCorrectly(string? url, string repository, int prNumber, bool expected)
+    {
+        // Act
+        bool result = UrlValidator.IsSafeGitHubUrl(url, repository, prNumber);
+
+        // Assert
+        result.Should().Be(expected);
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/UrlValidatorTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/UrlValidatorTests.cs
@@ -1,0 +1,29 @@
+// <copyright file="UrlValidatorTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class UrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://github.com/scottlz0310/squirrel-notifier/pull/51", true)]
+    [InlineData("https://github.com/scottlz0310-user/another-repo/pull/123?query=param", true)]
+    [InlineData("http://github.com/scottlz0310/squirrel-notifier/pull/51", false)] // http instead of https
+    [InlineData("https://evil.com/github.com/scottlz0310/squirrel-notifier", false)] // wrong host
+    [InlineData("https://github.com/scottlz0310/squirrel-notifier;rm -rf", false)] // unsafe characters
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSafeGitHubUrl_ShouldValidateCorrectly(string? url, bool expected)
+    {
+        // Act
+        bool result = UrlValidator.IsSafeGitHubUrl(url);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -673,42 +673,52 @@ public class McpSubscriptionServiceTests : IDisposable
     }
 
     [Fact]
-    public void IsDuplicate_ShouldDetectDuplicatesCorrectly()
+    public void Deduplication_ShouldWorkCorrectly()
     {
         // Arrange
         var mockRunner = new Mock<IProcessRunner>();
         var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
-        var isDuplicateMethod = typeof(McpSubscriptionService).GetMethod("IsDuplicate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        isDuplicateMethod.Should().NotBeNull();
+        var hasBeenSeenMethod = typeof(McpSubscriptionService).GetMethod("HasBeenSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var markAsSeenMethod = typeof(McpSubscriptionService).GetMethod("MarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        hasBeenSeenMethod.Should().NotBeNull();
+        markAsSeenMethod.Should().NotBeNull();
 
         // Act & Assert
-        var result1 = (bool)isDuplicateMethod!.Invoke(service, new object[] { "evt_1" })!;
+        // First check: not seen
+        var result1 = (bool)hasBeenSeenMethod!.Invoke(service, new object[] { "evt_1" })!;
         result1.Should().BeFalse();
 
-        var result2 = (bool)isDuplicateMethod.Invoke(service, new object[] { "evt_1" })!;
+        // Mark as seen
+        markAsSeenMethod!.Invoke(service, new object[] { "evt_1" });
+
+        // Second check: seen
+        var result2 = (bool)hasBeenSeenMethod.Invoke(service, new object[] { "evt_1" })!;
         result2.Should().BeTrue();
 
-        var result3 = (bool)isDuplicateMethod.Invoke(service, new object[] { "evt_2" })!;
+        // Different ID: not seen
+        var result3 = (bool)hasBeenSeenMethod.Invoke(service, new object[] { "evt_2" })!;
         result3.Should().BeFalse();
     }
 
     [Fact]
-    public void IsDuplicate_ShouldLimitCacheSizeTo100()
+    public void Deduplication_ShouldLimitCacheSizeTo100()
     {
         // Arrange
         var mockRunner = new Mock<IProcessRunner>();
         var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
-        var isDuplicateMethod = typeof(McpSubscriptionService).GetMethod("IsDuplicate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        isDuplicateMethod.Should().NotBeNull();
+        var hasBeenSeenMethod = typeof(McpSubscriptionService).GetMethod("HasBeenSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var markAsSeenMethod = typeof(McpSubscriptionService).GetMethod("MarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        hasBeenSeenMethod.Should().NotBeNull();
+        markAsSeenMethod.Should().NotBeNull();
 
         // Add 101 items
         for (int i = 0; i < 101; i++)
         {
-            isDuplicateMethod!.Invoke(service, new object[] { $"evt_{i}" });
+            markAsSeenMethod!.Invoke(service, new object[] { $"evt_{i}" });
         }
 
-        // The first item should be evicted now, so it should not be detected as duplicate
-        var result = (bool)isDuplicateMethod!.Invoke(service, new object[] { "evt_0" })!;
+        // The first item should be evicted now, so it should not be detected as seen
+        var result = (bool)hasBeenSeenMethod!.Invoke(service, new object[] { "evt_0" })!;
         result.Should().BeFalse();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -671,4 +671,44 @@ public class McpSubscriptionServiceTests : IDisposable
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
+
+    [Fact]
+    public void IsDuplicate_ShouldDetectDuplicatesCorrectly()
+    {
+        // Arrange
+        var mockRunner = new Mock<IProcessRunner>();
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
+        var isDuplicateMethod = typeof(McpSubscriptionService).GetMethod("IsDuplicate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        isDuplicateMethod.Should().NotBeNull();
+
+        // Act & Assert
+        var result1 = (bool)isDuplicateMethod!.Invoke(service, new object[] { "evt_1" })!;
+        result1.Should().BeFalse();
+
+        var result2 = (bool)isDuplicateMethod.Invoke(service, new object[] { "evt_1" })!;
+        result2.Should().BeTrue();
+
+        var result3 = (bool)isDuplicateMethod.Invoke(service, new object[] { "evt_2" })!;
+        result3.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDuplicate_ShouldLimitCacheSizeTo100()
+    {
+        // Arrange
+        var mockRunner = new Mock<IProcessRunner>();
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
+        var isDuplicateMethod = typeof(McpSubscriptionService).GetMethod("IsDuplicate", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        isDuplicateMethod.Should().NotBeNull();
+
+        // Add 101 items
+        for (int i = 0; i < 101; i++)
+        {
+            isDuplicateMethod!.Invoke(service, new object[] { $"evt_{i}" });
+        }
+
+        // The first item should be evicted now, so it should not be detected as duplicate
+        var result = (bool)isDuplicateMethod!.Invoke(service, new object[] { "evt_0" })!;
+        result.Should().BeFalse();
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
@@ -1,0 +1,48 @@
+// <copyright file="ReviewEventParserTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class ReviewEventParserTests
+{
+    [Fact]
+    public void Parse_ValidJson_ShouldReturnReviewEvent()
+    {
+        // Arrange
+        string json = "{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/org/repo/pull/42\",\"reason\":\"test\",\"source\":\"src\",\"message\":\"msg\"}";
+
+        // Act
+        ReviewEvent? result = ReviewEventParser.Parse(json);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.EventId.Should().Be("evt_1");
+        result.Repository.Should().Be("org/repo");
+        result.PrNumber.Should().Be(42);
+        result.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
+        result.Reason.Should().Be("test");
+        result.Source.Should().Be("src");
+        result.Message.Should().Be("msg");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not a json")]
+    [InlineData("{\"eventId\":\"evt_1\"}")] // missing repository and prUrl
+    [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prUrl\":\"http://unsafe.com\"}")] // unsafe URL
+    public void Parse_InvalidJson_ShouldReturnNull(string? json)
+    {
+        // Act
+        ReviewEvent? result = ReviewEventParser.Parse(json);
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
@@ -92,7 +92,8 @@ public class ReviewEventParserTests
                 ""installationId"": 12345,
                 ""queuedAt"": ""2026-06-13T22:00:00Z"",
                 ""reason"": ""review requested"",
-                ""requestedBy"": ""some-user""
+                ""requestedBy"": ""some-user"",
+                ""sourceCommentId"": 3407917385
             },
             {
                 ""owner"": ""scottlz0310"",

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
@@ -45,4 +45,38 @@ public class ReviewEventParserTests
         // Assert
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void Parse_ValidArrayJson_ShouldReturnReviewEvent()
+    {
+        // Arrange
+        string json = "[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/org/repo/pull/42\",\"reason\":\"test\",\"author\":\"src\",\"message\":\"msg\",\"eventId\":\"evt_1\"}]";
+
+        // Act
+        ReviewEvent? result = ReviewEventParser.Parse(json);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.EventId.Should().Be("evt_1");
+        result.Repository.Should().Be("org/repo");
+        result.PrNumber.Should().Be(42);
+        result.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
+        result.Reason.Should().Be("test");
+        result.Source.Should().Be("src");
+        result.Message.Should().Be("msg");
+    }
+
+    [Theory]
+    [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/attacker/repo/pull/42\"}")] // repository mismatch in object
+    [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/org/repo/pull/43\"}")] // prNumber mismatch in object
+    [InlineData("[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/attacker/repo/pull/42\",\"reason\":\"test\"}]")] // repository mismatch in array
+    [InlineData("[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/org/repo/pull/43\",\"reason\":\"test\"}]")] // prNumber mismatch in array
+    public void Parse_UnmatchedUrlInEvent_ShouldReturnNull(string json)
+    {
+        // Act
+        ReviewEvent? result = ReviewEventParser.Parse(json);
+
+        // Assert
+        result.Should().BeNull();
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
@@ -18,17 +18,18 @@ public class ReviewEventParserTests
         string json = "{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/org/repo/pull/42\",\"reason\":\"test\",\"source\":\"src\",\"message\":\"msg\"}";
 
         // Act
-        ReviewEvent? result = ReviewEventParser.Parse(json);
+        List<ReviewEvent> result = ReviewEventParser.Parse(json);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.EventId.Should().Be("evt_1");
-        result.Repository.Should().Be("org/repo");
-        result.PrNumber.Should().Be(42);
-        result.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
-        result.Reason.Should().Be("test");
-        result.Source.Should().Be("src");
-        result.Message.Should().Be("msg");
+        result.Should().ContainSingle();
+        ReviewEvent reviewEvent = result[0];
+        reviewEvent.EventId.Should().Be("evt_1");
+        reviewEvent.Repository.Should().Be("org/repo");
+        reviewEvent.PrNumber.Should().Be(42);
+        reviewEvent.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
+        reviewEvent.Reason.Should().Be("test");
+        reviewEvent.Source.Should().Be("src");
+        reviewEvent.Message.Should().Be("msg");
     }
 
     [Theory]
@@ -37,46 +38,94 @@ public class ReviewEventParserTests
     [InlineData("not a json")]
     [InlineData("{\"eventId\":\"evt_1\"}")] // missing repository and prUrl
     [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prUrl\":\"http://unsafe.com\"}")] // unsafe URL
-    public void Parse_InvalidJson_ShouldReturnNull(string? json)
+    public void Parse_InvalidJson_ShouldReturnEmptyList(string? json)
     {
         // Act
-        ReviewEvent? result = ReviewEventParser.Parse(json);
+        List<ReviewEvent> result = ReviewEventParser.Parse(json);
 
         // Assert
-        result.Should().BeNull();
+        result.Should().BeEmpty();
     }
 
     [Fact]
     public void Parse_ValidArrayJson_ShouldReturnReviewEvent()
     {
         // Arrange
-        string json = "[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/org/repo/pull/42\",\"reason\":\"test\",\"author\":\"src\",\"message\":\"msg\",\"eventId\":\"evt_1\"}]";
+        string json = "[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"queuedAt\":\"2026-06-13T22:00:00Z\",\"reason\":\"test\",\"requestedBy\":\"src\"}]";
 
         // Act
-        ReviewEvent? result = ReviewEventParser.Parse(json);
+        List<ReviewEvent> result = ReviewEventParser.Parse(json);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.EventId.Should().Be("evt_1");
-        result.Repository.Should().Be("org/repo");
-        result.PrNumber.Should().Be(42);
-        result.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
-        result.Reason.Should().Be("test");
-        result.Source.Should().Be("src");
-        result.Message.Should().Be("msg");
+        result.Should().ContainSingle();
+        ReviewEvent reviewEvent = result[0];
+        reviewEvent.EventId.Should().Be("evt_org_repo_42_test_2026-06-13T22_00_00Z");
+        reviewEvent.Repository.Should().Be("org/repo");
+        reviewEvent.PrNumber.Should().Be(42);
+        reviewEvent.PrUrl.Should().Be("https://github.com/org/repo/pull/42");
+        reviewEvent.Reason.Should().Be("test");
+        reviewEvent.Source.Should().Be("src");
+        reviewEvent.Message.Should().Be("test by src");
     }
 
     [Theory]
     [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/attacker/repo/pull/42\"}")] // repository mismatch in object
     [InlineData("{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/org/repo/pull/43\"}")] // prNumber mismatch in object
-    [InlineData("[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/attacker/repo/pull/42\",\"reason\":\"test\"}]")] // repository mismatch in array
-    [InlineData("[{\"owner\":\"org\",\"repo\":\"repo\",\"prNumber\":42,\"url\":\"https://github.com/org/repo/pull/43\",\"reason\":\"test\"}]")] // prNumber mismatch in array
-    public void Parse_UnmatchedUrlInEvent_ShouldReturnNull(string json)
+    public void Parse_UnmatchedUrlInEvent_ShouldReturnEmptyList(string json)
     {
         // Act
-        ReviewEvent? result = ReviewEventParser.Parse(json);
+        List<ReviewEvent> result = ReviewEventParser.Parse(json);
 
         // Assert
-        result.Should().BeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_RealPayloadSchema_ShouldSuccessfullyConstructReviewEvents()
+    {
+        // Arrange
+        string json = @"[
+            {
+                ""owner"": ""scottlz0310"",
+                ""repo"": ""squirrel-notifier"",
+                ""prNumber"": 56,
+                ""installationId"": 12345,
+                ""queuedAt"": ""2026-06-13T22:00:00Z"",
+                ""reason"": ""review requested"",
+                ""requestedBy"": ""some-user""
+            },
+            {
+                ""owner"": ""scottlz0310"",
+                ""repo"": ""squirrel-notifier"",
+                ""prNumber"": 56,
+                ""installationId"": 12345,
+                ""queuedAt"": ""2026-06-13T22:05:00Z"",
+                ""reason"": ""re-review requested""
+            }
+        ]";
+
+        // Act
+        List<ReviewEvent> result = ReviewEventParser.Parse(json);
+
+        // Assert
+        result.Should().HaveCount(2);
+
+        ReviewEvent first = result[0];
+        first.EventId.Should().Be("evt_scottlz0310_squirrel-notifier_56_review_requested_2026-06-13T22_00_00Z");
+        first.Repository.Should().Be("scottlz0310/squirrel-notifier");
+        first.PrNumber.Should().Be(56);
+        first.PrUrl.Should().Be("https://github.com/scottlz0310/squirrel-notifier/pull/56");
+        first.Reason.Should().Be("review requested");
+        first.Source.Should().Be("some-user");
+        first.Message.Should().Be("review requested by some-user");
+
+        ReviewEvent second = result[1];
+        second.EventId.Should().Be("evt_scottlz0310_squirrel-notifier_56_re-review_requested_2026-06-13T22_05_00Z");
+        second.Repository.Should().Be("scottlz0310/squirrel-notifier");
+        second.PrNumber.Should().Be(56);
+        second.PrUrl.Should().Be("https://github.com/scottlz0310/squirrel-notifier/pull/56");
+        second.Reason.Should().Be("re-review requested");
+        second.Source.Should().Be("thread-owl");
+        second.Message.Should().Be("re-review requested");
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -23,9 +23,9 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
-        AppNotificationManager.Default.NotificationInvoked += OnNotificationInvoked;
         AppNotificationManager.Default.Register();
         _notificationService.Initialize();
+        _notificationService.OpenAppRequested += OnOpenAppRequested;
 
         // Create subscription service with settings
         _subscriptionService = new McpSubscriptionService(_settingsService, _notificationService, _loggingService);
@@ -38,7 +38,7 @@ public partial class App : Application
         string[] commandLineArgs = Environment.GetCommandLineArgs();
         bool showWindow = !commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t");
 
-        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, showWindow);
+        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, showWindow);
         _window.Closed += OnWindowClosed;
 
         // Activate window if it should be shown
@@ -52,11 +52,12 @@ public partial class App : Application
 
     private void OnWindowClosed(object sender, WindowEventArgs args)
     {
+        _notificationService.OpenAppRequested -= OnOpenAppRequested;
         _subscriptionService.DisposeAsync().AsTask().ConfigureAwait(false);
         _autoUpdateService.Dispose();
     }
 
-    private void OnNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
+    private void OnOpenAppRequested(object? sender, EventArgs e)
     {
         // Show window when notification is clicked
         if (_window != null)

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/UrlValidator.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/UrlValidator.cs
@@ -36,4 +36,22 @@ internal static class UrlValidator
         string pathAndQuery = uri.PathAndQuery;
         return _safePathRegex.IsMatch(pathAndQuery);
     }
+
+    public static bool IsSafeGitHubUrl(string? url, string repository, int prNumber)
+    {
+        if (!IsSafeGitHubUrl(url))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        string expectedPath = $"/{repository}/pull/{prNumber}".ToUpperInvariant();
+        string actualPath = uri.AbsolutePath.TrimEnd('/').ToUpperInvariant();
+
+        return expectedPath == actualPath;
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/UrlValidator.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/UrlValidator.cs
@@ -1,0 +1,39 @@
+// <copyright file="UrlValidator.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+internal static class UrlValidator
+{
+    private static readonly Regex _safePathRegex = new(@"^/[a-zA-Z0-9_\-\./]+(?:\?[a-zA-Z0-9_\-\.&%=]+)?$", RegexOptions.Compiled);
+
+    public static bool IsSafeGitHubUrl(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        if (uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        if (uri.Host != "github.com")
+        {
+            return false;
+        }
+
+        string pathAndQuery = uri.PathAndQuery;
+        return _safePathRegex.IsMatch(pathAndQuery);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:SquirrelNotifier.WinUI3.Models"
     mc:Ignorable="d"
     Title="Squirrel Notifier">
     <Grid Padding="16"
@@ -50,21 +51,47 @@
                 BorderThickness="1"
                 CornerRadius="8"
                 Padding="8">
-            <StackPanel>
-                <TextBlock Text="Recent activity"
-                           FontWeight="SemiBold"
-                           Margin="0,0,0,4"/>
-                <ListView x:Name="LogList"
-                          Height="120"
-                          SelectionMode="None">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding}"
-                                       TextWrapping="Wrap"/>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-            </StackPanel>
+            <Grid RowDefinitions="*,*">
+                <StackPanel Grid.Row="0" Margin="0,0,0,8">
+                    <TextBlock Text="Recent review events"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <ListView x:Name="ReviewEventList"
+                              Height="110"
+                              SelectionMode="None">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="models:ReviewEvent">
+                                <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,2">
+                                    <StackPanel Grid.Column="0" Spacing="2">
+                                        <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap" FontWeight="Medium"/>
+                                        <TextBlock Text="{x:Bind Repository}" FontSize="11" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
+                                    </StackPanel>
+                                    <Button Grid.Column="1" Content="PRを開く"
+                                            Click="OnOpenPrClick"
+                                            CommandParameter="{x:Bind PrUrl}"
+                                            VerticalAlignment="Center"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackPanel>
+
+                <StackPanel Grid.Row="1">
+                    <TextBlock Text="Recent activity"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <ListView x:Name="LogList"
+                              Height="110"
+                              SelectionMode="None">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}"
+                                           TextWrapping="Wrap"/>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackPanel>
+            </Grid>
         </Border>
 
         <StackPanel Grid.Row="3"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -25,10 +25,12 @@ internal sealed partial class MainWindow : Window
     private readonly SettingsService _settingsService;
     private readonly AutoUpdateService _autoUpdateService;
     private readonly ObservableCollection<string> _logEntries = new();
+    private readonly ObservableCollection<Models.ReviewEvent> _reviewEvents = new();
     private readonly TrayIconService _trayIconService;
     private TrayContextMenu? _contextMenu;
     private readonly nint _hwnd;
     private readonly bool _isInitializing = true;
+    private readonly INotificationService _notificationService;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
 
@@ -60,7 +62,7 @@ internal sealed partial class MainWindow : Window
     private const uint _imageIcon = 1;
     private const uint _lrLoadFromFile = 0x00000010;
 
-    internal MainWindow(McpSubscriptionService service, LoggingService loggingService, SettingsService settingsService, AutoUpdateService autoUpdateService, bool showWindow = true)
+    internal MainWindow(McpSubscriptionService service, LoggingService loggingService, SettingsService settingsService, AutoUpdateService autoUpdateService, INotificationService notificationService, bool showWindow = true)
     {
         InitializeComponent();
 
@@ -68,7 +70,7 @@ internal sealed partial class MainWindow : Window
         _hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(_hwnd);
         var appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
-        appWindow.Resize(new SizeInt32(520, 480));
+        appWindow.Resize(new SizeInt32(520, 580));
         appWindow.Closing += OnAppWindowClosing;
 
         // Set window icon
@@ -78,10 +80,13 @@ internal sealed partial class MainWindow : Window
         _loggingService = loggingService;
         _settingsService = settingsService;
         _autoUpdateService = autoUpdateService;
+        _notificationService = notificationService;
         _service.StatusTextChanged += OnStatusTextChanged;
         _service.StateChanged += OnStateChanged;
         _loggingService.LogAppended += OnLogAppended;
+        _notificationService.ReviewEventReceived += OnReviewEventReceived;
         LogList.ItemsSource = _logEntries;
+        ReviewEventList.ItemsSource = _reviewEvents;
 
         // Load settings
         AppSettings settings = _settingsService.Settings;
@@ -218,6 +223,7 @@ internal sealed partial class MainWindow : Window
         _service.StatusTextChanged -= OnStatusTextChanged;
         _service.StateChanged -= OnStateChanged;
         _loggingService.LogAppended -= OnLogAppended;
+        _notificationService.ReviewEventReceived -= OnReviewEventReceived;
         _trayIconService?.Dispose();
         _contextMenu?.Dispose();
         Close();
@@ -420,6 +426,41 @@ internal sealed partial class MainWindow : Window
         catch
         {
             // ignore
+        }
+    }
+
+    private void OnReviewEventReceived(object? sender, Models.ReviewEvent e)
+    {
+        _ = DispatcherQueue.TryEnqueue(() =>
+        {
+            _reviewEvents.Insert(0, e);
+            const int maxEvents = 20;
+            if (_reviewEvents.Count > maxEvents)
+            {
+                _reviewEvents.RemoveAt(_reviewEvents.Count - 1);
+            }
+        });
+    }
+
+    private void OnOpenPrClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.CommandParameter is string url)
+        {
+            if (Helpers.UrlValidator.IsSafeGitHubUrl(url))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = url,
+                        UseShellExecute = true,
+                    });
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
         }
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
@@ -17,18 +17,18 @@ internal sealed class ReviewCandidate
     [JsonPropertyName("prNumber")]
     public int PrNumber { get; set; }
 
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = string.Empty;
+    [JsonPropertyName("installationId")]
+    public int InstallationId { get; set; }
+
+    [JsonPropertyName("queuedAt")]
+    public string QueuedAt { get; set; } = string.Empty;
 
     [JsonPropertyName("reason")]
     public string Reason { get; set; } = string.Empty;
 
-    [JsonPropertyName("author")]
-    public string Author { get; set; } = string.Empty;
+    [JsonPropertyName("sourceCommentId")]
+    public string? SourceCommentId { get; set; }
 
-    [JsonPropertyName("eventId")]
-    public string? EventId { get; set; }
-
-    [JsonPropertyName("message")]
-    public string? Message { get; set; }
+    [JsonPropertyName("requestedBy")]
+    public string? RequestedBy { get; set; }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
@@ -27,7 +27,7 @@ internal sealed class ReviewCandidate
     public string Reason { get; set; } = string.Empty;
 
     [JsonPropertyName("sourceCommentId")]
-    public string? SourceCommentId { get; set; }
+    public long? SourceCommentId { get; set; }
 
     [JsonPropertyName("requestedBy")]
     public string? RequestedBy { get; set; }

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewCandidate.cs
@@ -1,0 +1,34 @@
+// <copyright file="ReviewCandidate.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Text.Json.Serialization;
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+internal sealed class ReviewCandidate
+{
+    [JsonPropertyName("owner")]
+    public string Owner { get; set; } = string.Empty;
+
+    [JsonPropertyName("repo")]
+    public string Repo { get; set; } = string.Empty;
+
+    [JsonPropertyName("prNumber")]
+    public int PrNumber { get; set; }
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+
+    [JsonPropertyName("author")]
+    public string Author { get; set; } = string.Empty;
+
+    [JsonPropertyName("eventId")]
+    public string? EventId { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
@@ -1,0 +1,53 @@
+// <copyright file="ReviewEvent.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+internal sealed class ReviewEvent
+{
+    [JsonPropertyName("eventId")]
+    public string EventId { get; set; } = string.Empty;
+
+    [JsonPropertyName("repository")]
+    public string Repository { get; set; } = string.Empty;
+
+    [JsonPropertyName("prNumber")]
+    public int PrNumber { get; set; }
+
+    [JsonPropertyName("prUrl")]
+    public string PrUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonIgnore]
+    public DateTime ReceivedTime { get; set; } = DateTime.Now;
+
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(EventId))
+        {
+            throw new ArgumentException("EventId cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(PrUrl))
+        {
+            throw new ArgumentException("PrUrl cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Repository))
+        {
+            throw new ArgumentException("Repository cannot be empty.");
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
@@ -1,6 +1,5 @@
-// <copyright file="INotificationService.cs" company="PlaceholderCompany">
-// Copyright (c) PlaceholderCompany. All rights reserved.
-// </copyright>
+using System;
+using SquirrelNotifier.WinUI3.Models;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
@@ -9,4 +8,10 @@ internal interface INotificationService
     void Initialize();
 
     void NotifyReviewEventReceived(string? message, string? recommendedNextAction);
+
+    void NotifyReviewEvent(ReviewEvent reviewEvent);
+
+    event EventHandler<ReviewEvent>? ReviewEventReceived;
+
+    event EventHandler? OpenAppRequested;
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using SquirrelNotifier.WinUI3.Models;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
@@ -14,6 +15,9 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
     private readonly LoggingService _loggingService;
     private readonly IProcessRunner _processRunner;
     private readonly CancellationTokenSource _cts = new();
+    private readonly HashSet<string> _seenEventIds = new();
+    private readonly Queue<string> _eventIdQueue = new();
+    private readonly object _lock = new();
 
     private Task? _loopTask;
     private CancellationTokenSource? _activeProcessCts;
@@ -365,8 +369,24 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
 
                     if (result.Route == "subscription" && result.NotificationReceived == true)
                     {
-                        await LogAsync($"Notification received: {result.FinalText}").ConfigureAwait(false);
-                        _notificationService.NotifyReviewEventReceived(result.FinalText, result.RecommendedNextAction);
+                        await LogAsync($"Notification payload received: {result.FinalText}").ConfigureAwait(false);
+
+                        ReviewEvent? reviewEvent = ReviewEventParser.Parse(result.FinalText);
+                        if (reviewEvent == null)
+                        {
+                            await LogAsync($"Warning: Malformed or unsupported review event payload received: {result.FinalText}").ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            if (IsDuplicate(reviewEvent.EventId))
+                            {
+                                await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                _notificationService.NotifyReviewEvent(reviewEvent);
+                            }
+                        }
                     }
                     else
                     {
@@ -405,6 +425,33 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
     private async Task LogAsync(string message)
     {
         await _loggingService.WriteAsync(message).ConfigureAwait(false);
+    }
+
+    private bool IsDuplicate(string eventId)
+    {
+        if (string.IsNullOrEmpty(eventId))
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            if (_seenEventIds.Contains(eventId))
+            {
+                return true;
+            }
+
+            _seenEventIds.Add(eventId);
+            _eventIdQueue.Enqueue(eventId);
+
+            while (_eventIdQueue.Count > 100)
+            {
+                string oldId = _eventIdQueue.Dequeue();
+                _seenEventIds.Remove(oldId);
+            }
+
+            return false;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -378,13 +378,21 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                         }
                         else
                         {
-                            if (IsDuplicate(reviewEvent.EventId))
+                            if (HasBeenSeen(reviewEvent.EventId))
                             {
                                 await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
                             }
                             else
                             {
-                                _notificationService.NotifyReviewEvent(reviewEvent);
+                                try
+                                {
+                                    _notificationService.NotifyReviewEvent(reviewEvent);
+                                    MarkAsSeen(reviewEvent.EventId);
+                                }
+                                catch (Exception notifyEx)
+                                {
+                                    await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
+                                }
                             }
                         }
                     }
@@ -427,7 +435,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         await _loggingService.WriteAsync(message).ConfigureAwait(false);
     }
 
-    private bool IsDuplicate(string eventId)
+    private bool HasBeenSeen(string eventId)
     {
         if (string.IsNullOrEmpty(eventId))
         {
@@ -436,21 +444,29 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
 
         lock (_lock)
         {
-            if (_seenEventIds.Contains(eventId))
+            return _seenEventIds.Contains(eventId);
+        }
+    }
+
+    private void MarkAsSeen(string eventId)
+    {
+        if (string.IsNullOrEmpty(eventId))
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (_seenEventIds.Add(eventId))
             {
-                return true;
+                _eventIdQueue.Enqueue(eventId);
+
+                while (_eventIdQueue.Count > 100)
+                {
+                    string oldId = _eventIdQueue.Dequeue();
+                    _seenEventIds.Remove(oldId);
+                }
             }
-
-            _seenEventIds.Add(eventId);
-            _eventIdQueue.Enqueue(eventId);
-
-            while (_eventIdQueue.Count > 100)
-            {
-                string oldId = _eventIdQueue.Dequeue();
-                _seenEventIds.Remove(oldId);
-            }
-
-            return false;
         }
     }
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -371,27 +371,30 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     {
                         await LogAsync($"Notification payload received: {result.FinalText}").ConfigureAwait(false);
 
-                        ReviewEvent? reviewEvent = ReviewEventParser.Parse(result.FinalText);
-                        if (reviewEvent == null)
+                        List<ReviewEvent> reviewEvents = ReviewEventParser.Parse(result.FinalText);
+                        if (reviewEvents.Count == 0)
                         {
                             await LogAsync($"Warning: Malformed or unsupported review event payload received: {result.FinalText}").ConfigureAwait(false);
                         }
                         else
                         {
-                            if (HasBeenSeen(reviewEvent.EventId))
+                            foreach (ReviewEvent reviewEvent in reviewEvents)
                             {
-                                await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                try
+                                if (HasBeenSeen(reviewEvent.EventId))
                                 {
-                                    _notificationService.NotifyReviewEvent(reviewEvent);
-                                    MarkAsSeen(reviewEvent.EventId);
+                                    await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
                                 }
-                                catch (Exception notifyEx)
+                                else
                                 {
-                                    await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
+                                    try
+                                    {
+                                        _notificationService.NotifyReviewEvent(reviewEvent);
+                                        MarkAsSeen(reviewEvent.EventId);
+                                    }
+                                    catch (Exception notifyEx)
+                                    {
+                                        await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
+                                    }
                                 }
                             }
                         }

--- a/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
@@ -60,7 +60,7 @@ internal sealed class NotificationService : INotificationService
                 .AddText($"{reviewEvent.Reason}: {reviewEvent.Repository}#{reviewEvent.PrNumber}")
                 .AddText(reviewEvent.Message);
 
-            if (UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl))
+            if (UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
             {
                 builder.AddButton(new AppNotificationButton("PRを開く")
                     .AddArgument("action", "openUrl")
@@ -75,9 +75,9 @@ internal sealed class NotificationService : INotificationService
 
             ReviewEventReceived?.Invoke(this, reviewEvent);
         }
-        catch
+        catch (Exception ex)
         {
-            // Fallback
+            throw new InvalidOperationException($"Failed to show AppNotification: {ex.Message}", ex);
         }
     }
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
@@ -2,10 +2,13 @@
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Windows.AppNotifications;
 using Microsoft.Windows.AppNotifications.Builder;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
@@ -13,6 +16,10 @@ namespace SquirrelNotifier.WinUI3.Services;
 internal sealed class NotificationService : INotificationService
 {
     private bool _initialized;
+
+    public event EventHandler<ReviewEvent>? ReviewEventReceived;
+
+    public event EventHandler? OpenAppRequested;
 
     public void Initialize()
     {
@@ -43,8 +50,58 @@ internal sealed class NotificationService : INotificationService
         }
     }
 
+    public void NotifyReviewEvent(ReviewEvent reviewEvent)
+    {
+        ArgumentNullException.ThrowIfNull(reviewEvent);
+
+        try
+        {
+            AppNotificationBuilder builder = new AppNotificationBuilder()
+                .AddText($"{reviewEvent.Reason}: {reviewEvent.Repository}#{reviewEvent.PrNumber}")
+                .AddText(reviewEvent.Message);
+
+            if (UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl))
+            {
+                builder.AddButton(new AppNotificationButton("PRを開く")
+                    .AddArgument("action", "openUrl")
+                    .AddArgument("url", reviewEvent.PrUrl));
+            }
+
+            builder.AddButton(new AppNotificationButton("アプリを開く")
+                .AddArgument("action", "openApp"));
+
+            AppNotification notification = builder.BuildNotification();
+            AppNotificationManager.Default.Show(notification);
+
+            ReviewEventReceived?.Invoke(this, reviewEvent);
+        }
+        catch
+        {
+            // Fallback
+        }
+    }
+
     private void OnNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
     {
+        if (args.Arguments.TryGetValue("action", out string? action))
+        {
+            if (action == "openUrl" && args.Arguments.TryGetValue("url", out string? url))
+            {
+                if (UrlValidator.IsSafeGitHubUrl(url))
+                {
+                    TryOpenUrl(url);
+                }
+            }
+            else if (action == "openApp")
+            {
+                OpenAppRequested?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        else
+        {
+            // Default action (body click) opens app
+            OpenAppRequested?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private static void TryOpenUrl(string url)

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
@@ -12,11 +12,12 @@ namespace SquirrelNotifier.WinUI3.Services;
 
 internal static class ReviewEventParser
 {
-    public static ReviewEvent? Parse(string? json)
+    public static List<ReviewEvent> Parse(string? json)
     {
+        List<ReviewEvent> events = new List<ReviewEvent>();
         if (string.IsNullOrWhiteSpace(json))
         {
-            return null;
+            return events;
         }
 
         try
@@ -30,12 +31,21 @@ internal static class ReviewEventParser
             if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
             {
                 List<ReviewCandidate>? candidates = JsonSerializer.Deserialize<List<ReviewCandidate>>(trimmed, options);
-                if (candidates == null || candidates.Count == 0)
+                if (candidates != null)
                 {
-                    return null;
+                    foreach (ReviewCandidate candidate in candidates)
+                    {
+                        try
+                        {
+                            ReviewEvent reviewEvent = ConvertToEvent(candidate);
+                            events.Add(reviewEvent);
+                        }
+                        catch (Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine($"Failed to parse candidate: {ex.Message}");
+                        }
+                    }
                 }
-
-                return ConvertToEvent(candidates[0]);
             }
             else if (trimmed.StartsWith('{') && trimmed.EndsWith('}'))
             {
@@ -44,38 +54,59 @@ internal static class ReviewEventParser
                 if (reviewEvent != null && !string.IsNullOrEmpty(reviewEvent.Repository) && !string.IsNullOrEmpty(reviewEvent.PrUrl))
                 {
                     reviewEvent.Validate();
-                    if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
+                    if (UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
                     {
-                        return null;
+                        events.Add(reviewEvent);
+                        return events;
                     }
-
-                    return reviewEvent;
                 }
 
                 // If not, try parsing as a single ReviewCandidate object
                 ReviewCandidate? candidate = JsonSerializer.Deserialize<ReviewCandidate>(trimmed, options);
                 if (candidate != null)
                 {
-                    return ConvertToEvent(candidate);
+                    try
+                    {
+                        ReviewEvent converted = ConvertToEvent(candidate);
+                        events.Add(converted);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Failed to parse candidate: {ex.Message}");
+                    }
                 }
             }
-
-            return null;
         }
         catch
         {
-            return null;
+            // ignore
         }
+
+        return events;
     }
 
     private static ReviewEvent ConvertToEvent(ReviewCandidate candidate)
     {
-        string repository = $"{candidate.Owner}/{candidate.Repo}";
-        string prUrl = candidate.Url;
+        if (string.IsNullOrEmpty(candidate.Owner) || string.IsNullOrEmpty(candidate.Repo))
+        {
+            throw new ArgumentException("Owner and Repo cannot be empty.");
+        }
 
-        string eventId = candidate.EventId ?? $"evt_{repository.Replace('/', '_')}_{candidate.PrNumber}_{candidate.Reason}";
-        string message = candidate.Message ?? $"{candidate.Reason} by {candidate.Author}";
-        string source = !string.IsNullOrEmpty(candidate.Author) ? candidate.Author : "thread-owl";
+        string repository = $"{candidate.Owner}/{candidate.Repo}";
+        string prUrl = $"https://github.com/{candidate.Owner}/{candidate.Repo}/pull/{candidate.PrNumber}";
+
+        string queuedAtStr = !string.IsNullOrEmpty(candidate.QueuedAt) ? candidate.QueuedAt : "unknown_time";
+        string safeOwner = candidate.Owner.Replace('/', '_').Replace('\\', '_').Replace(' ', '_');
+        string safeRepo = candidate.Repo.Replace('/', '_').Replace('\\', '_').Replace(' ', '_');
+        string safeReason = candidate.Reason.Replace('/', '_').Replace('\\', '_').Replace(' ', '_');
+        string safeQueuedAt = queuedAtStr.Replace('/', '_').Replace('\\', '_').Replace(':', '_').Replace(' ', '_');
+
+        string eventId = $"evt_{safeOwner}_{safeRepo}_{candidate.PrNumber}_{safeReason}_{safeQueuedAt}";
+
+        string source = !string.IsNullOrEmpty(candidate.RequestedBy) ? candidate.RequestedBy : "thread-owl";
+        string message = !string.IsNullOrEmpty(candidate.RequestedBy)
+            ? $"{candidate.Reason} by {candidate.RequestedBy}"
+            : candidate.Reason;
 
         ReviewEvent reviewEvent = new ReviewEvent
         {

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
@@ -1,0 +1,55 @@
+// <copyright file="ReviewEventParser.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text.Json;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal static class ReviewEventParser
+{
+    public static ReviewEvent? Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            string trimmed = json.Trim();
+            if (!trimmed.StartsWith('{') || !trimmed.EndsWith('}'))
+            {
+                return null;
+            }
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            };
+
+            ReviewEvent? reviewEvent = JsonSerializer.Deserialize<ReviewEvent>(trimmed, options);
+            if (reviewEvent == null)
+            {
+                return null;
+            }
+
+            reviewEvent.Validate();
+
+            // Validate URL security
+            if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl))
+            {
+                return null;
+            }
+
+            return reviewEvent;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using SquirrelNotifier.WinUI3.Helpers;
 using SquirrelNotifier.WinUI3.Models;
@@ -21,35 +22,79 @@ internal static class ReviewEventParser
         try
         {
             string trimmed = json.Trim();
-            if (!trimmed.StartsWith('{') || !trimmed.EndsWith('}'))
-            {
-                return null;
-            }
-
-            var options = new JsonSerializerOptions
+            JsonSerializerOptions options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
             };
 
-            ReviewEvent? reviewEvent = JsonSerializer.Deserialize<ReviewEvent>(trimmed, options);
-            if (reviewEvent == null)
+            if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
             {
-                return null;
+                List<ReviewCandidate>? candidates = JsonSerializer.Deserialize<List<ReviewCandidate>>(trimmed, options);
+                if (candidates == null || candidates.Count == 0)
+                {
+                    return null;
+                }
+
+                return ConvertToEvent(candidates[0]);
+            }
+            else if (trimmed.StartsWith('{') && trimmed.EndsWith('}'))
+            {
+                // Try parsing as ReviewEvent first to check if it's already a fully built ReviewEvent
+                ReviewEvent? reviewEvent = JsonSerializer.Deserialize<ReviewEvent>(trimmed, options);
+                if (reviewEvent != null && !string.IsNullOrEmpty(reviewEvent.Repository) && !string.IsNullOrEmpty(reviewEvent.PrUrl))
+                {
+                    reviewEvent.Validate();
+                    if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
+                    {
+                        return null;
+                    }
+
+                    return reviewEvent;
+                }
+
+                // If not, try parsing as a single ReviewCandidate object
+                ReviewCandidate? candidate = JsonSerializer.Deserialize<ReviewCandidate>(trimmed, options);
+                if (candidate != null)
+                {
+                    return ConvertToEvent(candidate);
+                }
             }
 
-            reviewEvent.Validate();
-
-            // Validate URL security
-            if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl))
-            {
-                return null;
-            }
-
-            return reviewEvent;
+            return null;
         }
         catch
         {
             return null;
         }
+    }
+
+    private static ReviewEvent ConvertToEvent(ReviewCandidate candidate)
+    {
+        string repository = $"{candidate.Owner}/{candidate.Repo}";
+        string prUrl = candidate.Url;
+
+        string eventId = candidate.EventId ?? $"evt_{repository.Replace('/', '_')}_{candidate.PrNumber}_{candidate.Reason}";
+        string message = candidate.Message ?? $"{candidate.Reason} by {candidate.Author}";
+        string source = !string.IsNullOrEmpty(candidate.Author) ? candidate.Author : "thread-owl";
+
+        ReviewEvent reviewEvent = new ReviewEvent
+        {
+            EventId = eventId,
+            Repository = repository,
+            PrNumber = candidate.PrNumber,
+            PrUrl = prUrl,
+            Reason = candidate.Reason,
+            Source = source,
+            Message = message,
+        };
+
+        reviewEvent.Validate();
+
+        if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
+        {
+            throw new ArgumentException("PR URL does not match repository and PR number.");
+        }
+
+        return reviewEvent;
     }
 }


### PR DESCRIPTION
# 概要

ISSUE #51 に基づき、mcp-resource-subscriber から取得したレビューイベント（inalText）をパースし、Windows App Notification およびトレイアプリのメインUIと連携・表示する一連の変換ブリッジ機構を実装しました。

## 主な変更点

### 1. レビューイベントモデル & パーサー (ReviewEvent, ReviewEventParser)
- 受信した JSON ペイロードを型安全にデシリアライズ・検証するモデルクラス ReviewEvent を追加。
- ReviewEventParser を新設し、受信 JSON が空、パースエラー、あるいは必須パラメータ（EventId, Repository, PrUrl）の欠落時に安全に無視（
ull を返却）してログ記録し、購読ループを継続する仕組みを構築。

### 2. URL セキュリティ検証 (UrlValidator)
- payload 内の PR URL を直接開く際のコマンドインジェクションやフィッシング攻撃などのセキュリティリスクに備え、以下の安全検証を追加：
  - スキームが https であること
  - ホストが github.com であること
  - パス及びクエリパラメータに安全な文字（英数字、/, -, _, ., ?, =, & 等）のみが含まれていること

### 3. 重複通知の抑止 (デデュプリケーション)
- 同一の ventId を持つイベントの重複通知を抑止するため、McpSubscriptionService 内にメモリキャッシュ（直近最大100件、ロック付き FIFO 制御）を実装。

### 4. Windows トースト通知とアクション連携 (NotificationService)
- 通知オブジェクトに以下のカスタムボタンを追加：
  - **PRを開く**: 安全検証済みの URL をブラウザで直接起動するアクション (openUrl)。
  - **アプリを開く**: アプリのメインウィンドウを表示するアクション (openApp)。
- 通知本体のクリックやボタンクリック時のアクティベーションイベント (OpenAppRequested, ReviewEventReceived) をトリガーし、アプリケーションライフサイクルに統合しました。

### 5. 直近のレビューイベント表示 UI (MainWindow)
- メインウィンドウに「直近のレビューイベント（Recent review events）」履歴リストを追加。最新のイベントを最上位に挿入し、一覧から直接該当の PR を開くボタンを配置しました。
- UIの拡張に伴い、ウィンドウサイズを 520 x 480 から 520 x 580 に拡張しました。

## 検証結果

- **テスト合格**: dotnet test により追加したテストを含む 70 件すべてのユニットテストが正常に通過。
- **コードカバレッジ**:
  - 行 (Line): **88.07%** (しきい値 80% 以上をクリア)
  - 分岐 (Branch): **80.55%** (しきい値 80% 以上をクリア)
  - メソッド (Method): **96.82%** (しきい値 80% 以上をクリア)
- **コード品質**: dotnet format --verify-no-changes が警告・エラーなしで正常に通過することを確認済み。