### PR TITLE
feat: ユーザー起点の安全な外部 launcher を実装する (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- ユーザー起点の安全な外部 launcher (`ReviewLauncherService`) を実装。通知またはアプリ UI から、設定された外部レビューアクションを安全に起動可能に
+- 安全な引数置換機構 (`LauncherArgumentBuilder`) を導入。プレースホルダー (`{owner}`, `{repo}`, `{prNumber}`, `{prUrl}`) を用いて、シェルインジェクションを完全に防ぎつつ安全に引数を構築
+- 設定ウィンドウに外部 launcher 用の設定項目 (Launcher Path, Launcher Args, Launcher Timeout) を追加
+- トースト通知に「レビューを起動」ボタンを追加し、通知から即座にレビュー実行をトリガー可能に
+- レビュー実行中のステータス表示、ユーザーからのキャンセル、実行完了後の詳細な結果 (終了コード、stdout/stderr) を表示するダイアログ UI を MainWindow に追加
 - MCP 購読ブリッジ機構 (`McpSubscriptionService`) を新設。`mcp-resource-subscriber` と連携し、外部 MCP リソースからのレビュー更新イベントを取得可能に
 - `McpSubscriptionService` 用の動作確認 UI を設定ウィンドウに追加（コマンド実行パス、引数、URL、リソース URI、タイムアウト of 編集に対応）
 - `mcp-resource-subscriber` から受信した JSON 形式のレビューイベント（`ReviewEvent`）をパースするデシリアライズ・検証機構を導入

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/LauncherArgumentBuilderTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/LauncherArgumentBuilderTests.cs
@@ -1,0 +1,111 @@
+// <copyright file="LauncherArgumentBuilderTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class LauncherArgumentBuilderTests
+{
+    [Fact]
+    public void BuildArguments_ShouldSubstitutePlaceholdersSafely()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-1",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Message = "Test message"
+        };
+        string template = "review --repo {owner}/{repo} --pr {prNumber} --url {prUrl}";
+
+        // Act
+        List<string> result = LauncherArgumentBuilder.BuildArguments(template, reviewEvent);
+
+        // Assert
+        result.Should().HaveCount(7);
+        result[0].Should().Be("review");
+        result[1].Should().Be("--repo");
+        result[2].Should().Be("scottlz0310/squirrel-notifier");
+        result[3].Should().Be("--pr");
+        result[4].Should().Be("52");
+        result[5].Should().Be("--url");
+        result[6].Should().Be("https://github.com/scottlz0310/squirrel-notifier/pull/52");
+    }
+
+    [Theory]
+    [InlineData("invalid;owner/repo")]
+    [InlineData("owner/repo&bad")]
+    [InlineData("owner/repo|cmd")]
+    [InlineData("owner/repo;rm")]
+    public void BuildArguments_ShouldThrowArgumentExceptionForUnsafeRepositoryNames(string unsafeRepo)
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-2",
+            Repository = unsafeRepo,
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Message = "Test message"
+        };
+        string template = "--repo {owner}/{repo}";
+
+        // Act
+        Action act = () => LauncherArgumentBuilder.BuildArguments(template, reviewEvent);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildArguments_ShouldThrowArgumentExceptionForInvalidPrUrl()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-3",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://malicious.com/pull/52",
+            Message = "Test message"
+        };
+        string template = "--url {prUrl}";
+
+        // Act
+        Action act = () => LauncherArgumentBuilder.BuildArguments(template, reviewEvent);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildArguments_ShouldReturnEmptyListIfTemplateIsEmpty()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-4",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Message = "Test message"
+        };
+
+        // Act
+        List<string> result1 = LauncherArgumentBuilder.BuildArguments(string.Empty, reviewEvent);
+        List<string> result2 = LauncherArgumentBuilder.BuildArguments(null!, reviewEvent);
+
+        // Assert
+        result1.Should().BeEmpty();
+        result2.Should().BeEmpty();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -204,7 +204,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldPassArgumentsAndSecretsCorrectly()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", "queue://res", 30000);
+        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", "queue://res", 30000, "review-raven", "", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", "super-secret-token");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -360,7 +360,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldSkipTokenAndArgumentsWhenEmpty()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", "queue://res", 30000);
+        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", "queue://res", 30000, "review-raven", "", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", null);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -552,7 +552,7 @@ public class McpSubscriptionServiceTests : IDisposable
         await File.WriteAllTextAsync(testCmd, "@echo off\r\nif \"%1\"==\"--help\" (\r\n    exit /b 0\r\n)\r\nexit /b 1\r\n", Encoding.ASCII);
 
         var settingsService = new SettingsService(tempDir);
-        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", "queue://res", 30000);
+        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", "queue://res", 30000, "review-raven", "", 300000);
 
         var runner = new ProcessRunner();
         await using var service = new McpSubscriptionService(settingsService, _notificationService, _loggingService, runner);

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -1,0 +1,207 @@
+// <copyright file="ReviewLauncherServiceTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class ReviewLauncherServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+
+    public ReviewLauncherServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ReviewLauncherTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _settingsService = new SettingsService(_tempDir);
+        _loggingService = new LoggingService(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    private Mock<IProcessInstance> CreateMockProcess(int exitCode, string stdout, string stderr, int delayMs = 0)
+    {
+        var mockProcess = new Mock<IProcessInstance>();
+        mockProcess.SetupGet(p => p.ExitCode).Returns(exitCode);
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout))));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
+
+        if (delayMs > 0)
+        {
+            mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
+                .Returns(async (CancellationToken t) => await Task.Delay(delayMs, t));
+        }
+        else
+        {
+            mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+        }
+
+        return mockProcess;
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldRunSuccessfullyAndReturnExitCodeZero()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-1",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+        };
+
+        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Success Output", "");
+        ProcessStartInfo? capturedPsi = null;
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act
+        LauncherResult result = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ExitCode.Should().Be(0);
+        result.Stdout.Should().Be("Success Output");
+        result.Stderr.Should().BeEmpty();
+
+        capturedPsi.Should().NotBeNull();
+        capturedPsi!.FileName.Should().Contain("launcher-cmd");
+        capturedPsi.ArgumentList.Should().Contain("--launcher-arg");
+        mockProcess.Verify(p => p.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldPreventDoubleActivation()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-2",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+        };
+
+        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Success Output", "", delayMs: 1000);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act & Assert
+        Task<LauncherResult> firstRunTask = service.LaunchAsync(reviewEvent, CancellationToken.None);
+
+        // Wait a small delay to make sure the first run has set _isRunning to true
+        await Task.Delay(100);
+
+        LauncherResult secondResult = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+        secondResult.Success.Should().BeFalse();
+        secondResult.ErrorMessage.Should().Contain("already running");
+
+        LauncherResult firstResult = await firstRunTask;
+        firstResult.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldSupportCancellation()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-3",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+        };
+
+        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+
+        // Delay mock process to simulate execution time
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Pending...", "", delayMs: 5000);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        Task<LauncherResult> launchTask = service.LaunchAsync(reviewEvent, cts.Token);
+
+        await Task.Delay(100);
+        cts.Cancel();
+
+        LauncherResult result = await launchTask;
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("cancelled by user");
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldTimeoutProcess()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-4",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+        };
+
+        // Timeout is set to 200ms
+        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 200);
+
+        // Process takes 5000ms
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Slow...", "", delayMs: 5000);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act
+        LauncherResult result = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("timed out");
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -55,7 +55,7 @@ public class SettingsServiceTests : IDisposable
     public void UpdateSettings_ShouldUpdateSettings()
     {
         // Act
-        _settingsService.UpdateSettings("custom-cmd", "--arg", "https://example.com/gw", "queue://custom", 120000);
+        _settingsService.UpdateSettings("custom-cmd", "--arg", "https://example.com/gw", "queue://custom", 120000, "launcher-cmd", "--launcher-arg", 150000);
 
         // Assert
         _settingsService.Settings.SubscriberCommandPath.Should().Be("custom-cmd");
@@ -63,18 +63,22 @@ public class SettingsServiceTests : IDisposable
         _settingsService.Settings.GatewayUrl.Should().Be("https://example.com/gw");
         _settingsService.Settings.ResourceUri.Should().Be("queue://custom");
         _settingsService.Settings.NotificationTimeoutMs.Should().Be(120000);
+        _settingsService.Settings.LauncherCommandPath.Should().Be("launcher-cmd");
+        _settingsService.Settings.LauncherArguments.Should().Be("--launcher-arg");
+        _settingsService.Settings.LauncherTimeoutMs.Should().Be(150000);
     }
 
     [Theory]
-    [InlineData("", "--arg", "http://localhost:3000", "queue://custom", 60000)] // Empty command path
-    [InlineData("cmd", "--arg", "invalid-url", "queue://custom", 60000)] // Invalid URL
-    [InlineData("cmd", "--arg", "ftp://localhost:3000", "queue://custom", 60000)] // Non-http/https URL
-    [InlineData("cmd", "--arg", "http://localhost:3000", "", 60000)] // Empty resource URI
+    [InlineData("", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", 60000)] // Empty command path
+    [InlineData("cmd", "--arg", "invalid-url", "queue://custom", 60000, "launcher-cmd", 60000)] // Invalid URL
+    [InlineData("cmd", "--arg", "ftp://localhost:3000", "queue://custom", 60000, "launcher-cmd", 60000)] // Non-http/https URL
+    [InlineData("cmd", "--arg", "http://localhost:3000", "", 60000, "launcher-cmd", 60000)] // Empty resource URI
+    [InlineData("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "", 60000)] // Empty launcher path
     public void UpdateSettings_ShouldThrowArgumentExceptionForInvalidInputs(
-        string cmd, string args, string url, string uri, int timeout)
+        string cmd, string args, string url, string uri, int timeout, string launcherCmd, int launcherTimeout)
     {
         // Act & Assert
-        Action act = () => _settingsService.UpdateSettings(cmd, args, url, uri, timeout);
+        Action act = () => _settingsService.UpdateSettings(cmd, args, url, uri, timeout, launcherCmd, "--launcher-arg", launcherTimeout);
         act.Should().Throw<ArgumentException>();
     }
 
@@ -85,8 +89,11 @@ public class SettingsServiceTests : IDisposable
     public void UpdateSettings_ShouldThrowArgumentOutOfRangeExceptionForInvalidTimeout(int invalidTimeout)
     {
         // Act & Assert
-        Action act = () => _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", invalidTimeout);
-        act.Should().Throw<ArgumentOutOfRangeException>();
+        Action act1 = () => _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", invalidTimeout, "launcher-cmd", "--launcher-arg", 60000);
+        act1.Should().Throw<ArgumentOutOfRangeException>();
+
+        Action act2 = () => _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", "--launcher-arg", invalidTimeout);
+        act2.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Fact]
@@ -140,7 +147,7 @@ public class SettingsServiceTests : IDisposable
         _settingsService.SettingsChanged += (_, _) => eventRaised = true;
 
         // Act
-        _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000);
+        _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", "--launcher-arg", 60000);
 
         // Assert
         eventRaised.Should().BeTrue();

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -19,6 +19,7 @@ public partial class App : Application
     private readonly SettingsService _settingsService = new();
     private readonly McpSubscriptionService _subscriptionService;
     private readonly AutoUpdateService _autoUpdateService;
+    private readonly ReviewLauncherService _launcherService;
 
     public App()
     {
@@ -29,6 +30,7 @@ public partial class App : Application
 
         // Create subscription service with settings
         _subscriptionService = new McpSubscriptionService(_settingsService, _notificationService, _loggingService);
+        _launcherService = new ReviewLauncherService(_settingsService, _loggingService);
         _autoUpdateService = new AutoUpdateService(_loggingService);
     }
 
@@ -38,7 +40,7 @@ public partial class App : Application
         string[] commandLineArgs = Environment.GetCommandLineArgs();
         bool showWindow = !commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t");
 
-        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, showWindow);
+        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, showWindow);
         _window.Closed += OnWindowClosed;
 
         // Activate window if it should be shown

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/LauncherArgumentBuilder.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/LauncherArgumentBuilder.cs
@@ -1,0 +1,75 @@
+// <copyright file="LauncherArgumentBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+internal static class LauncherArgumentBuilder
+{
+    private static readonly Regex _safeNameRegex = new(@"^[a-zA-Z0-9_\-\.]+$", RegexOptions.Compiled);
+
+    public static List<string> BuildArguments(string template, ReviewEvent reviewEvent)
+    {
+        ArgumentNullException.ThrowIfNull(reviewEvent);
+
+        if (string.IsNullOrEmpty(template))
+        {
+            return new List<string>();
+        }
+
+        // Parse arguments structure safely (quotes, backslashes, spaces)
+        List<string> rawArgs = McpSubscriptionService.ParseArguments(template);
+
+        string owner = string.Empty;
+        string repo = string.Empty;
+        if (!string.IsNullOrEmpty(reviewEvent.Repository))
+        {
+            string[] parts = reviewEvent.Repository.Split('/', 2);
+            if (parts.Length == 2)
+            {
+                owner = parts[0];
+                repo = parts[1];
+            }
+            else
+            {
+                repo = reviewEvent.Repository;
+            }
+        }
+
+        // Validate names for security (allow only alphanumeric, hyphen, underscore, dot)
+        if (!string.IsNullOrEmpty(owner) && !_safeNameRegex.IsMatch(owner))
+        {
+            throw new ArgumentException("Invalid owner name in repository field.", nameof(reviewEvent));
+        }
+
+        if (!string.IsNullOrEmpty(repo) && !_safeNameRegex.IsMatch(repo))
+        {
+            throw new ArgumentException("Invalid repository name.", nameof(reviewEvent));
+        }
+
+        // Validate PR Url
+        if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
+        {
+            throw new ArgumentException("Invalid PR URL.", nameof(reviewEvent));
+        }
+
+        List<string> result = new();
+        foreach (string arg in rawArgs)
+        {
+            string replaced = arg
+                .Replace("{owner}", owner, StringComparison.Ordinal)
+                .Replace("{repo}", repo, StringComparison.Ordinal)
+                .Replace("{prNumber}", reviewEvent.PrNumber.ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
+                .Replace("{prUrl}", reviewEvent.PrUrl, StringComparison.Ordinal);
+            result.Add(replaced);
+        }
+
+        return result;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -23,7 +23,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="180">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -42,6 +42,15 @@
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Timeout (ms):" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="4" Grid.Column="1" x:Name="TimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Launcher Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" x:Name="LauncherPathBox" TextChanged="OnSettingChanged"/>
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Launcher Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="LauncherArgumentsBox" TextChanged="OnSettingChanged"/>
+
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
+                    <NumberBox Grid.Row="7" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
                 </Grid>
             </ScrollViewer>
         </Expander>
@@ -57,8 +66,8 @@
                                FontWeight="SemiBold"
                                Margin="0,0,0,4"/>
                     <ListView x:Name="ReviewEventList"
-                              Height="110"
-                              SelectionMode="None">
+                               Height="110"
+                               SelectionMode="None">
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="models:ReviewEvent">
                                 <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,2">
@@ -66,10 +75,14 @@
                                         <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap" FontWeight="Medium"/>
                                         <TextBlock Text="{x:Bind Repository}" FontSize="11" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
                                     </StackPanel>
-                                    <Button Grid.Column="1" Content="PRを開く"
-                                            Click="OnOpenPrClick"
-                                            CommandParameter="{x:Bind PrUrl}"
-                                            VerticalAlignment="Center"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                                        <Button Content="PRを開く"
+                                                Click="OnOpenPrClick"
+                                                CommandParameter="{x:Bind PrUrl}"/>
+                                        <Button Content="レビュー起動"
+                                                Click="OnLaunchReviewClick"
+                                                CommandParameter="{x:Bind}"/>
+                                    </StackPanel>
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -10,7 +10,9 @@ using System.Threading;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
 using SquirrelNotifier.WinUI3.Services;
+using Windows.Foundation;
 using Windows.Graphics;
 using WinRT;
 
@@ -31,6 +33,7 @@ internal sealed partial class MainWindow : Window
     private readonly nint _hwnd;
     private readonly bool _isInitializing = true;
     private readonly INotificationService _notificationService;
+    private readonly IReviewLauncherService _launcherService;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
 
@@ -62,7 +65,14 @@ internal sealed partial class MainWindow : Window
     private const uint _imageIcon = 1;
     private const uint _lrLoadFromFile = 0x00000010;
 
-    internal MainWindow(McpSubscriptionService service, LoggingService loggingService, SettingsService settingsService, AutoUpdateService autoUpdateService, INotificationService notificationService, bool showWindow = true)
+    internal MainWindow(
+        McpSubscriptionService service,
+        LoggingService loggingService,
+        SettingsService settingsService,
+        AutoUpdateService autoUpdateService,
+        INotificationService notificationService,
+        IReviewLauncherService launcherService,
+        bool showWindow = true)
     {
         InitializeComponent();
 
@@ -81,10 +91,12 @@ internal sealed partial class MainWindow : Window
         _settingsService = settingsService;
         _autoUpdateService = autoUpdateService;
         _notificationService = notificationService;
+        _launcherService = launcherService;
         _service.StatusTextChanged += OnStatusTextChanged;
         _service.StateChanged += OnStateChanged;
         _loggingService.LogAppended += OnLogAppended;
         _notificationService.ReviewEventReceived += OnReviewEventReceived;
+        _notificationService.LaunchReviewRequested += OnLaunchReviewRequested;
         LogList.ItemsSource = _logEntries;
         ReviewEventList.ItemsSource = _reviewEvents;
 
@@ -95,6 +107,9 @@ internal sealed partial class MainWindow : Window
         GatewayUrlBox.Text = settings.GatewayUrl;
         ResourceUriBox.Text = settings.ResourceUri;
         TimeoutBox.Value = settings.NotificationTimeoutMs;
+        LauncherPathBox.Text = settings.LauncherCommandPath;
+        LauncherArgumentsBox.Text = settings.LauncherArguments;
+        LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
 
         _isInitializing = false;
 
@@ -224,6 +239,7 @@ internal sealed partial class MainWindow : Window
         _service.StateChanged -= OnStateChanged;
         _loggingService.LogAppended -= OnLogAppended;
         _notificationService.ReviewEventReceived -= OnReviewEventReceived;
+        _notificationService.LaunchReviewRequested -= OnLaunchReviewRequested;
         _trayIconService?.Dispose();
         _contextMenu?.Dispose();
         Close();
@@ -336,7 +352,19 @@ internal sealed partial class MainWindow : Window
             string resourceUri = ResourceUriBox.Text;
             int timeoutMs = double.IsNaN(TimeoutBox.Value) ? 60000 : (int)TimeoutBox.Value;
 
-            _settingsService.UpdateSettings(commandPath, arguments, gatewayUrl, resourceUri, timeoutMs);
+            string launcherPath = LauncherPathBox.Text;
+            string launcherArguments = LauncherArgumentsBox.Text;
+            int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 300000 : (int)LauncherTimeoutBox.Value;
+
+            _settingsService.UpdateSettings(
+                commandPath,
+                arguments,
+                gatewayUrl,
+                resourceUri,
+                timeoutMs,
+                launcherPath,
+                launcherArguments,
+                launcherTimeoutMs);
         }
         catch
         {
@@ -461,6 +489,142 @@ internal sealed partial class MainWindow : Window
                     // ignore
                 }
             }
+        }
+    }
+
+    private void OnLaunchReviewRequested(object? sender, string eventId)
+    {
+        _ = DispatcherQueue.TryEnqueue(async () =>
+        {
+            Models.ReviewEvent? targetEvent = null;
+            foreach (Models.ReviewEvent ev in _reviewEvents)
+            {
+                if (ev.EventId == eventId)
+                {
+                    targetEvent = ev;
+                    break;
+                }
+            }
+
+            if (targetEvent == null)
+            {
+                await _loggingService.WriteAsync($"Launch request ignored: event with ID {eventId} not found in history.").ConfigureAwait(false);
+                return;
+            }
+
+            ShowWindowFromTray();
+            await ExecuteReviewAsync(targetEvent).ConfigureAwait(false);
+        });
+    }
+
+    private async void OnLaunchReviewClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.CommandParameter is Models.ReviewEvent reviewEvent)
+        {
+            await ExecuteReviewAsync(reviewEvent).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ExecuteReviewAsync(Models.ReviewEvent reviewEvent)
+    {
+        if (_launcherService.IsRunning)
+        {
+            ContentDialog dialog = new ContentDialog
+            {
+                Title = "レビュー実行エラー",
+                Content = "別のレビューアクションが既に実行中です。",
+                CloseButtonText = "閉じる",
+                XamlRoot = Content.XamlRoot,
+            };
+            await dialog.ShowAsync(ContentDialogPlacement.Popup);
+            return;
+        }
+
+        try
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+
+            ProgressRing progressRing = new ProgressRing { IsActive = true, Margin = new Thickness(0, 16, 0, 0) };
+            StackPanel panel = new StackPanel();
+            panel.Children.Add(new TextBlock { Text = $"{reviewEvent.Repository}#{reviewEvent.PrNumber} のレビューを実行しています..." });
+            panel.Children.Add(progressRing);
+
+            ContentDialog dialog = new ContentDialog
+            {
+                Title = "レビュー実行中",
+                Content = panel,
+                CloseButtonText = "キャンセル",
+                XamlRoot = Content.XamlRoot,
+            };
+
+            Task<LauncherResult> launchTask = _launcherService.LaunchAsync(reviewEvent, cts.Token);
+            IAsyncOperation<ContentDialogResult> dialogTask = dialog.ShowAsync(ContentDialogPlacement.Popup);
+
+            Task completedTask = await Task.WhenAny(launchTask, dialogTask.AsTask()).ConfigureAwait(true);
+
+            if (completedTask == launchTask)
+            {
+                dialog.Hide();
+                LauncherResult result = await launchTask.ConfigureAwait(true);
+
+                StackPanel resultPanel = new StackPanel { Spacing = 8 };
+                if (result.Success)
+                {
+                    resultPanel.Children.Add(new TextBlock { Text = "レビューの実行に成功しました。", FontWeight = Microsoft.UI.Text.FontWeights.Bold });
+                }
+                else
+                {
+                    string err = string.IsNullOrEmpty(result.ErrorMessage) ? "レビューが異常終了しました。" : result.ErrorMessage;
+                    resultPanel.Children.Add(new TextBlock
+                    {
+                        Text = $"エラー: {err}",
+                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
+                    });
+                }
+
+                if (result.ExitCode.HasValue)
+                {
+                    resultPanel.Children.Add(new TextBlock { Text = $"終了コード: {result.ExitCode}" });
+                }
+
+                if (!string.IsNullOrWhiteSpace(result.Stdout))
+                {
+                    resultPanel.Children.Add(new TextBlock { Text = "標準出力:", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
+                    resultPanel.Children.Add(new TextBox { Text = result.Stdout, TextWrapping = TextWrapping.Wrap, IsReadOnly = true, MaxHeight = 120, AcceptsReturn = true });
+                }
+
+                if (!string.IsNullOrWhiteSpace(result.Stderr))
+                {
+                    resultPanel.Children.Add(new TextBlock { Text = "標準エラー出力:", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
+                    resultPanel.Children.Add(new TextBox { Text = result.Stderr, TextWrapping = TextWrapping.Wrap, IsReadOnly = true, MaxHeight = 120, AcceptsReturn = true });
+                }
+
+                ContentDialog resultDialog = new ContentDialog
+                {
+                    Title = result.Success ? "レビュー実行成功" : "レビュー実行失敗",
+                    Content = resultPanel,
+                    CloseButtonText = "閉じる",
+                    XamlRoot = Content.XamlRoot,
+                };
+                await resultDialog.ShowAsync(ContentDialogPlacement.Popup);
+            }
+            else
+            {
+                cts.Cancel();
+                _launcherService.Cancel();
+                await launchTask.ConfigureAwait(true);
+            }
+        }
+        catch (Exception ex)
+        {
+            ContentDialog errDialog = new ContentDialog
+            {
+                Title = "エラー",
+                Content = $"レビューの実行中に予期しないエラーが発生しました:\n{ex.Message}",
+                CloseButtonText = "閉じる",
+                XamlRoot = Content.XamlRoot,
+            };
+            await errDialog.ShowAsync(ContentDialogPlacement.Popup);
         }
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherResult.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherResult.cs
@@ -1,0 +1,18 @@
+// <copyright file="LauncherResult.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+internal sealed class LauncherResult
+{
+    public bool Success { get; set; }
+
+    public int? ExitCode { get; set; }
+
+    public string Stdout { get; set; } = string.Empty;
+
+    public string Stderr { get; set; } = string.Empty;
+
+    public string ErrorMessage { get; set; } = string.Empty;
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
@@ -11,7 +11,9 @@ internal interface INotificationService
 
     void NotifyReviewEvent(ReviewEvent reviewEvent);
 
-    event EventHandler<ReviewEvent>? ReviewEventReceived;
+    event System.EventHandler<ReviewEvent>? ReviewEventReceived;
 
-    event EventHandler? OpenAppRequested;
+    event System.EventHandler? OpenAppRequested;
+
+    event System.EventHandler<string>? LaunchReviewRequested;
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
@@ -1,0 +1,18 @@
+// <copyright file="IReviewLauncherService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal interface IReviewLauncherService
+{
+    bool IsRunning { get; }
+
+    Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, CancellationToken cancellationToken);
+
+    void Cancel();
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
@@ -50,6 +50,8 @@ internal sealed class NotificationService : INotificationService
         }
     }
 
+    public event EventHandler<string>? LaunchReviewRequested;
+
     public void NotifyReviewEvent(ReviewEvent reviewEvent)
     {
         ArgumentNullException.ThrowIfNull(reviewEvent);
@@ -66,6 +68,10 @@ internal sealed class NotificationService : INotificationService
                     .AddArgument("action", "openUrl")
                     .AddArgument("url", reviewEvent.PrUrl));
             }
+
+            builder.AddButton(new AppNotificationButton("レビューを起動")
+                .AddArgument("action", "launchReview")
+                .AddArgument("eventId", reviewEvent.EventId));
 
             builder.AddButton(new AppNotificationButton("アプリを開く")
                 .AddArgument("action", "openApp"));
@@ -90,6 +96,13 @@ internal sealed class NotificationService : INotificationService
                 if (UrlValidator.IsSafeGitHubUrl(url))
                 {
                     TryOpenUrl(url);
+                }
+            }
+            else if (action == "launchReview" && args.Arguments.TryGetValue("eventId", out string? eventId))
+            {
+                if (!string.IsNullOrEmpty(eventId))
+                {
+                    LaunchReviewRequested?.Invoke(this, eventId);
                 }
             }
             else if (action == "openApp")

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -1,0 +1,197 @@
+// <copyright file="ReviewLauncherService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal sealed class ReviewLauncherService : IReviewLauncherService
+{
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+    private readonly IProcessRunner _processRunner;
+    private readonly object _lock = new();
+
+    private bool _isRunning;
+    private IProcessInstance? _activeProcess;
+    private CancellationTokenSource? _activeCts;
+
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _isRunning;
+            }
+        }
+    }
+
+    public ReviewLauncherService(
+        SettingsService settingsService,
+        LoggingService loggingService,
+        IProcessRunner? processRunner = null)
+    {
+        _settingsService = settingsService;
+        _loggingService = loggingService;
+        _processRunner = processRunner ?? new ProcessRunner();
+    }
+
+    public async Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reviewEvent);
+
+        lock (_lock)
+        {
+            if (_isRunning)
+            {
+                return new LauncherResult
+                {
+                    Success = false,
+                    ErrorMessage = "A review action is already running.",
+                };
+            }
+
+            _isRunning = true;
+        }
+
+        await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber}").ConfigureAwait(false);
+
+        AppSettings settings = _settingsService.Settings;
+        string commandPath = settings.LauncherCommandPath;
+        string argumentsTemplate = settings.LauncherArguments;
+        int timeoutMs = settings.LauncherTimeoutMs;
+
+        _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _activeCts.CancelAfter(timeoutMs);
+        CancellationToken combinedToken = _activeCts.Token;
+
+        try
+        {
+            string resolvedPath = SettingsService.ResolveCommandPath(commandPath);
+            if (string.IsNullOrWhiteSpace(resolvedPath))
+            {
+                throw new InvalidOperationException("Launcher command path is empty or invalid.");
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = resolvedPath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            // Build and add safe arguments
+            System.Collections.Generic.List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
+            foreach (string arg in args)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            await LogAsync($"Launching: {commandPath} with safe arguments").ConfigureAwait(false);
+
+            lock (_lock)
+            {
+                combinedToken.ThrowIfCancellationRequested();
+
+                _activeProcess = _processRunner.Start(psi);
+            }
+
+            // Start reading stdout / stderr as tasks to avoid deadlock
+            Task<string> stdoutTask = _activeProcess.StandardOutput.ReadToEndAsync(combinedToken);
+            Task<string> stderrTask = _activeProcess.StandardError.ReadToEndAsync(combinedToken);
+
+            await _activeProcess.WaitForExitAsync(combinedToken).ConfigureAwait(false);
+
+            string stdout = await stdoutTask.ConfigureAwait(false);
+            string stderr = await stderrTask.ConfigureAwait(false);
+
+            int exitCode = _activeProcess.ExitCode;
+
+            await LogAsync($"Review process finished. ExitCode={exitCode}").ConfigureAwait(false);
+
+            return new LauncherResult
+            {
+                Success = exitCode == 0,
+                ExitCode = exitCode,
+                Stdout = stdout,
+                Stderr = stderr,
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            string reason = cancellationToken.IsCancellationRequested ? "cancelled by user" : "timed out";
+            await LogAsync($"Review process was {reason}.").ConfigureAwait(false);
+
+            KillActiveProcess();
+
+            return new LauncherResult
+            {
+                Success = false,
+                ErrorMessage = $"Review process was {reason}.",
+            };
+        }
+        catch (Exception ex)
+        {
+            await LogAsync($"Failed to run review process: {ex.Message}").ConfigureAwait(false);
+
+            KillActiveProcess();
+
+            return new LauncherResult
+            {
+                Success = false,
+                ErrorMessage = ex.Message,
+            };
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _activeProcess?.Dispose();
+                _activeProcess = null;
+                _activeCts?.Dispose();
+                _activeCts = null;
+                _isRunning = false;
+            }
+        }
+    }
+
+    public void Cancel()
+    {
+        lock (_lock)
+        {
+            _activeCts?.Cancel();
+            KillActiveProcess();
+        }
+    }
+
+    private void KillActiveProcess()
+    {
+        if (_activeProcess != null)
+        {
+            try
+            {
+                _activeProcess.Kill(entireProcessTree: true);
+            }
+            catch (Exception logEx)
+            {
+                // Ignore process kill errors
+                _ = LogAsync($"Failed to kill process tree: {logEx.Message}");
+            }
+        }
+    }
+
+    private async Task LogAsync(string message)
+    {
+        await _loggingService.WriteAsync(message).ConfigureAwait(false);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -45,7 +45,7 @@ internal sealed class SettingsService
         }
     }
 
-    private static string ResolveCommandPath(string command)
+    internal static string ResolveCommandPath(string command)
     {
         if (File.Exists(command))
         {
@@ -123,7 +123,15 @@ internal sealed class SettingsService
         }
     }
 
-    public void UpdateSettings(string commandPath, string arguments, string gatewayUrl, string resourceUri, int timeoutMs)
+    public void UpdateSettings(
+        string commandPath,
+        string arguments,
+        string gatewayUrl,
+        string resourceUri,
+        int timeoutMs,
+        string launcherCommandPath,
+        string launcherArguments,
+        int launcherTimeoutMs)
     {
         if (string.IsNullOrWhiteSpace(commandPath))
         {
@@ -145,11 +153,24 @@ internal sealed class SettingsService
             throw new ArgumentOutOfRangeException(nameof(timeoutMs), "Timeout must be between 1 and 300000 ms");
         }
 
+        if (string.IsNullOrWhiteSpace(launcherCommandPath))
+        {
+            throw new ArgumentException("Launcher command path cannot be empty", nameof(launcherCommandPath));
+        }
+
+        if (launcherTimeoutMs <= 0 || launcherTimeoutMs > 300000)
+        {
+            throw new ArgumentOutOfRangeException(nameof(launcherTimeoutMs), "Launcher timeout must be between 1 and 300000 ms");
+        }
+
         _settings.SubscriberCommandPath = commandPath;
         _settings.SubscriberArguments = arguments;
         _settings.GatewayUrl = gatewayUrl;
         _settings.ResourceUri = resourceUri;
         _settings.NotificationTimeoutMs = timeoutMs;
+        _settings.LauncherCommandPath = launcherCommandPath;
+        _settings.LauncherArguments = launcherArguments;
+        _settings.LauncherTimeoutMs = launcherTimeoutMs;
         SaveSettings();
     }
 }
@@ -165,4 +186,10 @@ internal sealed class AppSettings
     public string ResourceUri { get; set; } = "queue://review/queue";
 
     public int NotificationTimeoutMs { get; set; } = 60000;
+
+    public string LauncherCommandPath { get; set; } = "review-raven";
+
+    public string LauncherArguments { get; set; } = "review --interactive --repo {owner}/{repo} --pr {prNumber}";
+
+    public int LauncherTimeoutMs { get; set; } = 300000;
 }


### PR DESCRIPTION
## 概要
ユーザーが通知またはアプリ UI から明示的に操作した場合のみ、設定済みの外部レビューアクション（`review-raven` 等のCLIツール）を安全に起動する launcher 機構を実装しました。

本実装は、固定の `pwsh -Command` や `docker exec` をアプリへ埋め込まず、将来の `Mcp-Docker` のオーケストレーションや自動設定生成とのインターフェイス（契約）を確定した上で、セキュリティ条件を完全に満たすように設計されています。

## 主な変更内容
1. **ランチャーサービスの実装 (`ReviewLauncherService`)**
   - 設定された外部レビューコマンドを `IProcessRunner` を使用して安全にバックグラウンド実行します。
   - 同時実行を1つに制限するシングルトン実行制御を搭載。
   - プロセスツリー全体のタイムアウト監視（デフォルト5分）およびユーザーからの明示的なキャンセル処理に対応。

2. **安全な引数構築 (`LauncherArgumentBuilder`)**
   - `{owner}`, `{repo}`, `{prNumber}`, `{prUrl}` プレースホルダーの安全な置換に対応。
   - シェルインジェクションを防ぐため、シェル展開や `pwsh -Command` を使用せず、引数を配列形式で構築。
   - リポジトリ名などの入力値に対する無害化バリデーション、および `UrlValidator.IsSafeGitHubUrl` を用いた PR URL 検証を徹底。

3. **設定の拡張 (`SettingsService`)**
   - 設定ファイル (`settings.json`) に `LauncherCommandPath`, `LauncherArguments`, `LauncherTimeoutMs` を追加。

4. **UI/UXとの統合**
   - **トースト通知**: 「レビューを起動」ボタンを追加し、通知から即座にレビュー実行をトリガー可能に。
   - **メイン UI**:
     - 設定画面へランチャー設定用の項目を追加。
     - 直近のイベントリストへ「レビュー起動」ボタンを追加。
     - 実行中の進捗表示およびキャンセルが可能な `ContentDialog` を表示。
     - 完了後に終了コード、stdout/stderr の結果をスクロール表示するダイアログを実装。

## セキュリティ条件の充足状況
- [x] event payload から raw command line を構築しない（プレースホルダーによる配列ベースの引数構築）
- [x] executable path を event payload から受け取らない（`settings.json` の設定値のみを使用）
- [x] shell expansion、`Invoke-Expression`、`pwsh -Command`、固定 `docker exec` を使用しない
- [x] allowlist 外の event field を process argument に渡さない（`owner`/`repo`/`prNumber`/`prUrl` のみ許可）
- [x] 自動受信だけで起動せず、必ずユーザー操作を要求する

## テスト結果
- 正常系・多重起動防止・キャンセル・タイムアウト・不正な入力値に対するユニットテストを新規追加。
- `dotnet test` が 93 件すべてパス。
- テストカバレッジ：**行 85.9% / 分岐 80.27% / メソッド 95.55%**（80%以上を維持）
