### PR TITLE
feat: アプリ内タスクスケジューラ管理機能を追加 (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- アプリ内から Windows タスクスケジューラへの自動起動タスク登録・解除・修復が可能になった。設定パネルに「自動起動」トグルとタスク状態表示・修復ボタンを追加（`ITaskSchedulerService` / `TaskSchedulerService`）
 - エラー状態（`SubscriptionState.Error`）時にトレイアイコンを警告マーク付きアイコン（`squirrel-notifier-error.ico`）に自動で差し替え、エラー内容をツールチップに表示するように変更
 - エラー状態への初回遷移時にトレイバルーン通知（Windows 標準 `NIF_INFO` / `NIIF_WARNING`）でエラーメッセージを通知する機能を追加。エラーが解消されて再度エラー状態になった場合は再通知する
 - `TrayIconService` に `UpdateIcon(string iconFileName)`（アイコン差し替え）および `ShowBalloonTip(string title, string text)`（バルーン通知）メソッドを追加

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
@@ -89,9 +89,11 @@ public class TaskSchedulerServiceTests
         capturedPsi.Should().NotBeNull();
         capturedPsi!.FileName.Should().Be("schtasks.exe");
         capturedPsi.Arguments.Should().Contain("/Create");
-        capturedPsi.Arguments.Should().Contain("SquirrelNotifier");
+        capturedPsi.Arguments.Should().Contain("Squirrel Notifier");
         capturedPsi.Arguments.Should().Contain("--tray");
         capturedPsi.Arguments.Should().Contain("ONLOGON");
+        capturedPsi.Arguments.Should().Contain("/RU");
+        capturedPsi.Arguments.Should().Contain("/IT");
     }
 
     [Fact]
@@ -113,10 +115,10 @@ public class TaskSchedulerServiceTests
     }
 
     [Fact]
-    public async Task UnregisterAsync_IgnoresExitCode()
+    public async Task UnregisterAsync_WhenExitCodeZero_Succeeds()
     {
         // Arrange
-        Mock<IProcessInstance> mockProcess = CreateMockProcess(1);
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0);
         ProcessStartInfo? capturedPsi = null;
 
         var mockRunner = new Mock<IProcessRunner>();
@@ -131,19 +133,41 @@ public class TaskSchedulerServiceTests
 
         // Assert
         capturedPsi!.Arguments.Should().Contain("/Delete");
-        capturedPsi.Arguments.Should().Contain("SquirrelNotifier");
+        capturedPsi.Arguments.Should().Contain("Squirrel Notifier");
     }
 
     [Fact]
-    public async Task RepairAsync_CallsUnregisterThenRegister()
+    public async Task UnregisterAsync_WhenExitCodeNonZero_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(1, "Access is denied.");
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        Func<Task> act = () => service.UnregisterAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*タスクスケジューラからの削除に失敗しました*");
+    }
+
+    [Fact]
+    public async Task RepairAsync_WhenRegistered_CallsGetStatusThenDeleteThenCreate()
     {
         // Arrange
         var callOrder = new System.Collections.Generic.List<string>();
 
+        Mock<IProcessInstance> queryMock = CreateMockProcess(0);
         Mock<IProcessInstance> deleteMock = CreateMockProcess(0);
         Mock<IProcessInstance> createMock = CreateMockProcess(0);
 
         var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Query"))))
+            .Callback<ProcessStartInfo>(_ => callOrder.Add("Query"))
+            .Returns(queryMock.Object);
         mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Delete"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Delete"))
             .Returns(deleteMock.Object);
@@ -157,6 +181,32 @@ public class TaskSchedulerServiceTests
         await service.RepairAsync();
 
         // Assert
-        callOrder.Should().Equal("Delete", "Create");
+        callOrder.Should().Equal("Query", "Delete", "Create");
+    }
+
+    [Fact]
+    public async Task RepairAsync_WhenNotRegistered_SkipsDeleteAndCallsCreate()
+    {
+        // Arrange
+        var callOrder = new System.Collections.Generic.List<string>();
+
+        Mock<IProcessInstance> queryMock = CreateMockProcess(1);
+        Mock<IProcessInstance> createMock = CreateMockProcess(0);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Query"))))
+            .Callback<ProcessStartInfo>(_ => callOrder.Add("Query"))
+            .Returns(queryMock.Object);
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Create"))))
+            .Callback<ProcessStartInfo>(_ => callOrder.Add("Create"))
+            .Returns(createMock.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        await service.RepairAsync();
+
+        // Assert
+        callOrder.Should().Equal("Query", "Create");
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
@@ -1,0 +1,162 @@
+// <copyright file="TaskSchedulerServiceTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class TaskSchedulerServiceTests
+{
+    private static Mock<IProcessInstance> CreateMockProcess(int exitCode, string stderr = "")
+    {
+        var mock = new Mock<IProcessInstance>();
+        mock.SetupGet(p => p.ExitCode).Returns(exitCode);
+        mock.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
+        mock.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(2, false)]
+    public async Task GetStatusAsync_ReturnsStatusBasedOnExitCode(int exitCode, bool expectRegistered)
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(exitCode);
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        TaskRegistrationStatus status = await service.GetStatusAsync();
+
+        // Assert
+        if (expectRegistered)
+        {
+            status.Should().Be(TaskRegistrationStatus.Registered);
+        }
+        else
+        {
+            status.Should().Be(TaskRegistrationStatus.NotRegistered);
+        }
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_WhenStartThrows_ReturnsNotRegistered()
+    {
+        // Arrange
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Throws(new System.ComponentModel.Win32Exception());
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        TaskRegistrationStatus status = await service.GetStatusAsync();
+
+        // Assert
+        status.Should().Be(TaskRegistrationStatus.NotRegistered);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenExitCodeZero_Succeeds()
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0);
+        ProcessStartInfo? capturedPsi = null;
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        await service.RegisterAsync();
+
+        // Assert
+        capturedPsi.Should().NotBeNull();
+        capturedPsi!.FileName.Should().Be("schtasks.exe");
+        capturedPsi.Arguments.Should().Contain("/Create");
+        capturedPsi.Arguments.Should().Contain("SquirrelNotifier");
+        capturedPsi.Arguments.Should().Contain("--tray");
+        capturedPsi.Arguments.Should().Contain("ONLOGON");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenExitCodeNonZero_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(1, "Access is denied.");
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        Func<Task> act = () => service.RegisterAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*タスクスケジューラへの登録に失敗しました*");
+    }
+
+    [Fact]
+    public async Task UnregisterAsync_IgnoresExitCode()
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(1);
+        ProcessStartInfo? capturedPsi = null;
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        await service.UnregisterAsync();
+
+        // Assert
+        capturedPsi!.Arguments.Should().Contain("/Delete");
+        capturedPsi.Arguments.Should().Contain("SquirrelNotifier");
+    }
+
+    [Fact]
+    public async Task RepairAsync_CallsUnregisterThenRegister()
+    {
+        // Arrange
+        var callOrder = new System.Collections.Generic.List<string>();
+
+        Mock<IProcessInstance> deleteMock = CreateMockProcess(0);
+        Mock<IProcessInstance> createMock = CreateMockProcess(0);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Delete"))))
+            .Callback<ProcessStartInfo>(_ => callOrder.Add("Delete"))
+            .Returns(deleteMock.Object);
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Create"))))
+            .Callback<ProcessStartInfo>(_ => callOrder.Add("Create"))
+            .Returns(createMock.Object);
+
+        var service = new TaskSchedulerService(mockRunner.Object);
+
+        // Act
+        await service.RepairAsync();
+
+        // Assert
+        callOrder.Should().Equal("Delete", "Create");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -21,6 +21,7 @@ public partial class App : Application
     private readonly McpSubscriptionService _subscriptionService;
     private readonly AutoUpdateService _autoUpdateService;
     private readonly ReviewLauncherService _launcherService;
+    private readonly TaskSchedulerService _taskSchedulerService = new();
 
     public App()
     {
@@ -64,7 +65,7 @@ public partial class App : Application
         string[] commandLineArgs = Environment.GetCommandLineArgs();
         bool showWindow = !commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t");
 
-        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, showWindow);
+        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, showWindow);
         _window.Closed += OnWindowClosed;
 
         // Activate window if it should be shown

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -23,7 +23,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="180">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -51,6 +51,17 @@
 
                     <TextBlock Grid.Row="7" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="7" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="8" Grid.Column="1" x:Name="AutoStartToggle"
+                                  OnContent="有効" OffContent="無効"
+                                  Toggled="OnAutoStartToggled"/>
+
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                        <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
+                        <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
+                    </StackPanel>
                 </Grid>
             </ScrollViewer>
         </Expander>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -34,8 +34,10 @@ internal sealed partial class MainWindow : Window
     private readonly bool _isInitializing = true;
     private readonly INotificationService _notificationService;
     private readonly IReviewLauncherService _launcherService;
+    private readonly ITaskSchedulerService _taskSchedulerService;
     private bool _isCheckingForUpdates;
     private bool _hasShownErrorBalloon;
+    private bool _isAutoStartToggling;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
 
@@ -74,6 +76,7 @@ internal sealed partial class MainWindow : Window
         AutoUpdateService autoUpdateService,
         INotificationService notificationService,
         IReviewLauncherService launcherService,
+        ITaskSchedulerService taskSchedulerService,
         bool showWindow = true)
     {
         InitializeComponent();
@@ -94,6 +97,7 @@ internal sealed partial class MainWindow : Window
         _autoUpdateService = autoUpdateService;
         _notificationService = notificationService;
         _launcherService = launcherService;
+        _taskSchedulerService = taskSchedulerService;
         _service.StatusTextChanged += OnStatusTextChanged;
         _service.StateChanged += OnStateChanged;
         _loggingService.LogAppended += OnLogAppended;
@@ -114,6 +118,9 @@ internal sealed partial class MainWindow : Window
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
 
         _isInitializing = false;
+
+        // Check auto-start registration status
+        _ = RefreshAutoStartStatusAsync();
 
         // Setup tray icon
         _trayIconService = new TrayIconService(this);
@@ -666,5 +673,92 @@ internal sealed partial class MainWindow : Window
             };
             await errDialog.ShowAsync(ContentDialogPlacement.Popup);
         }
+    }
+
+    private async void OnAutoStartToggled(object sender, RoutedEventArgs e)
+    {
+        if (_isAutoStartToggling)
+        {
+            return;
+        }
+
+        _isAutoStartToggling = true;
+        try
+        {
+            if (AutoStartToggle.IsOn)
+            {
+                await _taskSchedulerService.RegisterAsync().ConfigureAwait(true);
+            }
+            else
+            {
+                await _taskSchedulerService.UnregisterAsync().ConfigureAwait(true);
+            }
+        }
+        catch (Exception ex)
+        {
+            ContentDialog dialog = new ContentDialog
+            {
+                Title = "自動起動の設定に失敗しました",
+                Content = ex.Message,
+                CloseButtonText = "閉じる",
+                XamlRoot = Content.XamlRoot,
+            };
+            await dialog.ShowAsync(ContentDialogPlacement.Popup);
+        }
+        finally
+        {
+            _isAutoStartToggling = false;
+        }
+
+        await RefreshAutoStartStatusAsync().ConfigureAwait(true);
+    }
+
+    private async void OnRepairAutoStartClick(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _taskSchedulerService.RepairAsync().ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            ContentDialog dialog = new ContentDialog
+            {
+                Title = "タスク修復に失敗しました",
+                Content = ex.Message,
+                CloseButtonText = "閉じる",
+                XamlRoot = Content.XamlRoot,
+            };
+            await dialog.ShowAsync(ContentDialogPlacement.Popup);
+        }
+
+        await RefreshAutoStartStatusAsync().ConfigureAwait(true);
+    }
+
+    private async Task RefreshAutoStartStatusAsync()
+    {
+        TaskRegistrationStatus status = await _taskSchedulerService.GetStatusAsync().ConfigureAwait(true);
+        _ = DispatcherQueue.TryEnqueue(() =>
+        {
+            _isAutoStartToggling = true;
+            try
+            {
+                if (status == TaskRegistrationStatus.Registered)
+                {
+                    AutoStartToggle.IsOn = true;
+                    AutoStartStatusText.Text = "登録済み";
+                    RepairAutoStartButton.IsEnabled = true;
+                }
+                else
+                {
+                    AutoStartToggle.IsOn = false;
+                    AutoStartStatusText.Text = "未登録";
+                    RepairAutoStartButton.IsEnabled = false;
+                }
+            }
+            finally
+            {
+                _isAutoStartToggling = false;
+            }
+        });
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/ITaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ITaskSchedulerService.cs
@@ -17,9 +17,9 @@ internal interface ITaskSchedulerService
 
 internal enum TaskRegistrationStatus
 {
-    /// <summary>タスクスケジューラに未登録。.</summary>
+    /// <summary>タスクスケジューラに未登録.</summary>
     NotRegistered,
 
-    /// <summary>タスクスケジューラに登録済み。.</summary>
+    /// <summary>タスクスケジューラに登録済み.</summary>
     Registered,
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/ITaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ITaskSchedulerService.cs
@@ -1,0 +1,25 @@
+// <copyright file="ITaskSchedulerService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal interface ITaskSchedulerService
+{
+    Task<TaskRegistrationStatus> GetStatusAsync();
+
+    Task RegisterAsync();
+
+    Task UnregisterAsync();
+
+    Task RepairAsync();
+}
+
+internal enum TaskRegistrationStatus
+{
+    /// <summary>タスクスケジューラに未登録。.</summary>
+    NotRegistered,
+
+    /// <summary>タスクスケジューラに登録済み。.</summary>
+    Registered,
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
@@ -8,7 +8,7 @@ namespace SquirrelNotifier.WinUI3.Services;
 
 internal sealed class TaskSchedulerService : ITaskSchedulerService
 {
-    private const string _taskName = "SquirrelNotifier";
+    private const string _taskName = "Squirrel Notifier";
     private readonly IProcessRunner _processRunner;
 
     public TaskSchedulerService()
@@ -48,10 +48,11 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
     public async Task RegisterAsync()
     {
         string exePath = GetExePath();
+        string userName = Environment.UserName;
         var psi = new ProcessStartInfo
         {
             FileName = "schtasks.exe",
-            Arguments = $"/Create /TN \"{_taskName}\" /TR \"\\\"{exePath}\\\" --tray\" /SC ONLOGON /RL LIMITED /F",
+            Arguments = $"/Create /TN \"{_taskName}\" /TR \"\\\"{exePath}\\\" --tray\" /SC ONLOGON /RU \"{userName}\" /IT /RL LIMITED /F",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -59,11 +60,12 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
         };
 
         using IProcessInstance proc = _processRunner.Start(psi);
+        Task<string> errorTask = proc.StandardError.ReadToEndAsync();
         await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
         if (proc.ExitCode != 0)
         {
-            string error = await proc.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            string error = await errorTask.ConfigureAwait(false);
             throw new InvalidOperationException($"タスクスケジューラへの登録に失敗しました: {error}");
         }
     }
@@ -81,15 +83,27 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
         };
 
         using IProcessInstance proc = _processRunner.Start(psi);
+        Task<string> errorTask = proc.StandardError.ReadToEndAsync();
         await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        if (proc.ExitCode != 0)
+        {
+            string error = await errorTask.ConfigureAwait(false);
+            throw new InvalidOperationException($"タスクスケジューラからの削除に失敗しました: {error}");
+        }
     }
 
     public async Task RepairAsync()
     {
-        await UnregisterAsync().ConfigureAwait(false);
+        TaskRegistrationStatus status = await GetStatusAsync().ConfigureAwait(false);
+        if (status == TaskRegistrationStatus.Registered)
+        {
+            await UnregisterAsync().ConfigureAwait(false);
+        }
+
         await RegisterAsync().ConfigureAwait(false);
     }
 
     private static string GetExePath()
-        => Path.Combine(AppContext.BaseDirectory, "SquirrelNotifier.WinUI3.exe");
+        => Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "SquirrelNotifier.WinUI3.exe");
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
@@ -1,0 +1,95 @@
+// <copyright file="TaskSchedulerService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal sealed class TaskSchedulerService : ITaskSchedulerService
+{
+    private const string _taskName = "SquirrelNotifier";
+    private readonly IProcessRunner _processRunner;
+
+    public TaskSchedulerService()
+        : this(new ProcessRunner())
+    {
+    }
+
+    internal TaskSchedulerService(IProcessRunner processRunner)
+    {
+        _processRunner = processRunner;
+    }
+
+    public async Task<TaskRegistrationStatus> GetStatusAsync()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "schtasks.exe",
+            Arguments = $"/Query /TN \"{_taskName}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            using IProcessInstance proc = _processRunner.Start(psi);
+            await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            return proc.ExitCode == 0 ? TaskRegistrationStatus.Registered : TaskRegistrationStatus.NotRegistered;
+        }
+        catch
+        {
+            return TaskRegistrationStatus.NotRegistered;
+        }
+    }
+
+    public async Task RegisterAsync()
+    {
+        string exePath = GetExePath();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "schtasks.exe",
+            Arguments = $"/Create /TN \"{_taskName}\" /TR \"\\\"{exePath}\\\" --tray\" /SC ONLOGON /RL LIMITED /F",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        using IProcessInstance proc = _processRunner.Start(psi);
+        await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        if (proc.ExitCode != 0)
+        {
+            string error = await proc.StandardError.ReadToEndAsync().ConfigureAwait(false);
+            throw new InvalidOperationException($"タスクスケジューラへの登録に失敗しました: {error}");
+        }
+    }
+
+    public async Task UnregisterAsync()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "schtasks.exe",
+            Arguments = $"/Delete /TN \"{_taskName}\" /F",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        using IProcessInstance proc = _processRunner.Start(psi);
+        await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    public async Task RepairAsync()
+    {
+        await UnregisterAsync().ConfigureAwait(false);
+        await RegisterAsync().ConfigureAwait(false);
+    }
+
+    private static string GetExePath()
+        => Path.Combine(AppContext.BaseDirectory, "SquirrelNotifier.WinUI3.exe");
+}


### PR DESCRIPTION
## Summary

- `ITaskSchedulerService` / `TaskSchedulerService` を新設し、`schtasks.exe` を `IProcessRunner` 経由で呼び出してタスクの登録・解除・修復を実装
- 設定パネル（Settings Expander）に「自動起動」トグルスイッチ・タスク状態テキスト・修復ボタンを追加
- `MainWindow` 起動時に `GetStatusAsync()` でタスク登録状態を確認し、トグルの初期値を反映
- `TaskSchedulerServiceTests` を追加（全 118 件テスト合格）

## Changes

### 新規ファイル
- `Services/ITaskSchedulerService.cs` — `GetStatusAsync / RegisterAsync / UnregisterAsync / RepairAsync` インターフェース + `TaskRegistrationStatus` enum
- `Services/TaskSchedulerService.cs` — `schtasks.exe` 呼び出し実装（`IProcessRunner` DI でモック可能）
- `Tests/Services/TaskSchedulerServiceTests.cs` — 7 件のパラメータ化テスト

### 変更ファイル
- `MainWindow.xaml` — Settings Grid に Row 8（自動起動トグル）・Row 9（タスク状態 + 修復ボタン）を追加
- `MainWindow.xaml.cs` — `ITaskSchedulerService` フィールド追加、コンストラクタ引数追加、`OnAutoStartToggled` / `OnRepairAutoStartClick` / `RefreshAutoStartStatusAsync` を実装
- `App.xaml.cs` — `TaskSchedulerService` をフィールドとして初期化、`MainWindow` コンストラクタへ渡すよう変更
- `CHANGELOG.md` — Unreleased セクションに機能追加を記載

## Test plan

- [ ] `OnAutoStartToggled(IsOn=true)` → `RegisterAsync` が呼ばれタスクが登録され、状態テキストが「登録済み」になることを確認
- [ ] `OnAutoStartToggled(IsOn=false)` → `UnregisterAsync` が呼ばれ、状態テキストが「未登録」になることを確認
- [ ] `RegisterAsync` 失敗時（権限不足等）にエラーダイアログが表示され、トグルが正しい状態に戻ることを確認
- [ ] 「修復」ボタンクリック → `RepairAsync`（`UnregisterAsync` + `RegisterAsync`）が実行されることを確認
- [ ] 起動時に既登録の場合、トグルが ON で「登録済み」・修復ボタン有効になることを確認
- [ ] 起動時に未登録の場合、トグルが OFF で「未登録」・修復ボタン無効になることを確認

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)