### PR TITLE
fix: WixQuietExec の CustomActionData 受け渡しを修正（MSI インストール失敗）

### DIFF
--- a/winui3/SquirrelNotifier.Installer/Package.wxs
+++ b/winui3/SquirrelNotifier.Installer/Package.wxs
@@ -56,7 +56,7 @@
       WixQuietExec カスタムアクションでサイレント実行する。
       /RU [%USERNAME] でログオン中ユーザーとして登録し /IT で対話セッション限定にする。
     -->
-    <SetProperty Id="RegisterScheduledTaskCmdLine"
+    <SetProperty Id="RegisterScheduledTask"
                  Value="&quot;[SystemFolder]schtasks.exe&quot; /Create /TN &quot;Squirrel Notifier&quot; /TR &quot;\&quot;[INSTALLFOLDER]SquirrelNotifier.WinUI3.exe\&quot; --tray&quot; /SC ONLOGON /RU &quot;[%USERNAME]&quot; /IT /RL LIMITED /F"
                  Before="RegisterScheduledTask"
                  Sequence="execute" />
@@ -68,7 +68,7 @@
                   Return="check" />
 
     <!-- Task Scheduler 削除 (アンインストール時) -->
-    <SetProperty Id="UnregisterScheduledTaskCmdLine"
+    <SetProperty Id="UnregisterScheduledTask"
                  Value="&quot;[SystemFolder]schtasks.exe&quot; /Delete /TN &quot;Squirrel Notifier&quot; /F"
                  Before="UnregisterScheduledTask"
                  Sequence="execute" />


### PR DESCRIPTION
## 原因

`SetProperty` の `Id` がカスタムアクション名と異なっていたため、`WixQuietExec` が `CustomActionData` を取得できずにエラー `0x80070057` が発生し、インストールがロールバックされていた。

```
WixQuietExec: Error 0x80070057: Failed to get command line data
```

WiX の `deferred` カスタムアクションへデータを渡すには、`SetProperty` の `Id` をカスタムアクション名と**同一**にする必要がある（`CustomActionData` 経由で受け渡されるため）。

## 変更内容

`winui3/SquirrelNotifier.Installer/Package.wxs`:

| 変更前 | 変更後 |
|--------|--------|
| `SetProperty Id="RegisterScheduledTaskCmdLine"` | `SetProperty Id="RegisterScheduledTask"` |
| `SetProperty Id="UnregisterScheduledTaskCmdLine"` | `SetProperty Id="UnregisterScheduledTask"` |

## Test plan

- [ ] MSI インストールが正常に完了すること
- [ ] タスクスケジューラに「Squirrel Notifier」タスクが登録されること
- [ ] アンインストール時にタスクが削除されること
- [ ] CI pass

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)