### PR TITLE
fix: MSI ONLOGON タスク登録ソフト化・.cmd ラッパー追加・WinUI3 zip 廃止

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,16 +88,6 @@ jobs:
         echo "MSI_NAME=$msiName" >> $env:GITHUB_OUTPUT
         Write-Host "MSI: $msiName"
 
-    - name: Create archive
-      shell: pwsh
-      run: |
-        $version = "${{ steps.version.outputs.VERSION }}"
-        $platform = "${{ matrix.platform }}"
-        $archiveName = "SquirrelNotifier-WinUI3-$version-$platform.zip"
-        Compress-Archive -Path ./publish/$platform/* -DestinationPath ./$archiveName
-        echo "ARCHIVE_NAME=$archiveName" >> $env:GITHUB_OUTPUT
-      id: archive
-
     - name: Create installer bundle
       shell: pwsh
       run: |
@@ -106,7 +96,7 @@ jobs:
         $bundleDir = Join-Path -Path "." -ChildPath "installer/$platform"
         New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
         Copy-Item -Path "./publish/$platform/*" -Destination $bundleDir -Recurse -Force
-        Copy-Item -Path "scripts/install.ps1","scripts/uninstall.ps1","scripts/create-shortcuts.ps1" -Destination $bundleDir -Force
+        Copy-Item -Path "scripts/install.ps1","scripts/install.cmd","scripts/uninstall.ps1","scripts/uninstall.cmd","scripts/create-shortcuts.ps1","scripts/create-shortcuts.cmd" -Destination $bundleDir -Force
         $installerArchive = "SquirrelNotifier-Setup-$version-$platform.zip"
         Compress-Archive -Path "$bundleDir/*" -DestinationPath "./$installerArchive" -Force
         echo "INSTALLER_ARCHIVE=$installerArchive" >> $env:GITHUB_OUTPUT
@@ -116,7 +106,6 @@ jobs:
       shell: pwsh
       run: |
         $archives = @(
-          "${{ steps.archive.outputs.ARCHIVE_NAME }}",
           "${{ steps.installer.outputs.INSTALLER_ARCHIVE }}",
           "${{ steps.msi.outputs.MSI_NAME }}"
         )
@@ -131,7 +120,6 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          ${{ steps.archive.outputs.ARCHIVE_NAME }}
           ${{ steps.installer.outputs.INSTALLER_ARCHIVE }}
           ${{ steps.msi.outputs.MSI_NAME }}
           checksums-${{ matrix.platform }}.txt
@@ -146,7 +134,6 @@ jobs:
       with:
         name: SquirrelNotifier-${{ matrix.platform }}
         path: |
-          ${{ steps.archive.outputs.ARCHIVE_NAME }}
           ${{ steps.installer.outputs.INSTALLER_ARCHIVE }}
           ${{ steps.msi.outputs.MSI_NAME }}
           checksums-${{ matrix.platform }}.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- MSI: `schtasks /SC ONLOGON` が非昇格環境（UAC 有効）で Access denied になる場合にインストールがロールバックされていた問題を修正。`RegisterScheduledTask` カスタムアクションを `Return="ignore"` に変更し、タスク登録失敗でもインストールを続行するようにした。タスク登録はインストール後にアプリ内 UI またはセットアップ Zip の `install.cmd` / `install.ps1` から行う（#79）
+- MSI: `[SystemFolder]` は 32-bit コンテキストで `SysWOW64` に解決されるため `[System64Folder]` に変更し 64-bit `schtasks.exe` を明示
+
+### Added
+- `scripts/install.cmd`・`scripts/uninstall.cmd`・`scripts/create-shortcuts.cmd` を追加。PowerShell の ExecutionPolicy に関わらずダブルクリックで実行可能な `.cmd` ラッパー（#79）
+- セットアップ Zip（`SquirrelNotifier-Setup-*.zip`）に `.cmd` ラッパーを同梱
+
+### Removed
+- リリース成果物から `SquirrelNotifier-WinUI3-*.zip`（バイナリのみ zip）を廃止。`SquirrelNotifier-Setup-*.zip`（バイナリ＋スクリプト同梱）に一本化
+
 ## [0.1.1] - 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,44 +67,52 @@ dotnet build winui3\SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64
 
 リリースページ（例: https://github.com/scottlz0310/squirrel-notifier/releases/latest ）に以下の x64 向け配布物を公開しています（0.1.0 以降）：
 
-- **MSI インストーラー**（`SquirrelNotifier-Setup-<version>-x64.msi`）: ウィザード形式のインストーラー。ダブルクリックで実行できます。
-- **セットアップ Zip**（`SquirrelNotifier-Setup-<version>-x64.zip`）: 実行ファイルと `install.ps1` / `uninstall.ps1` / `create-shortcuts.ps1` を同梱。展開後に `install.ps1` を実行してください。
+- **MSI インストーラー**（`SquirrelNotifier-Setup-<version>-x64.msi`）: ウィザード形式のインストーラー。ダブルクリックで実行できます。環境によってはインストール完了後に自動起動タスクが登録されない場合があります（その場合はセットアップ Zip の `install.cmd` から登録してください）。
+- **セットアップ Zip**（`SquirrelNotifier-Setup-<version>-x64.zip`）: 実行ファイルと `install.cmd` / `install.ps1` / `uninstall.cmd` / `uninstall.ps1` / `create-shortcuts.cmd` / `create-shortcuts.ps1` を同梱。
 
 #### タスクスケジューラ登録
-PowerShell でインストールスクリプトを実行して自動起動を設定できます:
+
+セットアップ Zip を展開したフォルダで `install.cmd` を実行してください（PowerShell の ExecutionPolicy に関わらず動作します）:
+
+```cmd
+REM トレイに最小化して自動起動を設定（推奨）
+install.cmd -StartMinimized
+
+REM 標準インストール（ログイン時にウィンドウ表示）
+install.cmd
+```
+
+PowerShell スクリプトを直接実行することもできます:
 
 ```powershell
-# 標準インストール（ログイン時にウィンドウ表示）
-.\scripts\install.ps1
-
 # トレイに最小化してインストール（推奨）
-.\scripts\install.ps1 -StartMinimized
+.\install.ps1 -StartMinimized
 
 # カスタムパスを指定してインストール
-.\scripts\install.ps1 -ExePath "C:\Path\To\SquirrelNotifier.WinUI3.exe" -StartMinimized
+.\install.ps1 -ExePath "C:\Path\To\SquirrelNotifier.WinUI3.exe" -StartMinimized
 ```
 
 インストールすると、次回のログインから自動的に起動します。
 
 #### ショートカット作成（必要に応じて）
-展開したセットアップ Zip に含まれる `create-shortcuts.ps1` を使って、スタートメニューやデスクトップにショートカットを作成できます:
+展開したセットアップ Zip に含まれる `create-shortcuts.cmd` を使って、スタートメニューやデスクトップにショートカットを作成できます:
 
-```powershell
-# スタートメニューにショートカットを作成
-.\scripts\create-shortcuts.ps1
+```cmd
+REM スタートメニューにショートカットを作成
+create-shortcuts.cmd
 
-# トレイ起動用ショートカットをスタートメニューとデスクトップに作成
-.\scripts\create-shortcuts.ps1 -Tray -Desktop
+REM トレイ起動用ショートカットをスタートメニューとデスクトップに作成
+create-shortcuts.cmd -Tray -Desktop
 ```
 
 ### アンインストール
 
-```powershell
-# タスクと設定を削除
-.\scripts\uninstall.ps1
+```cmd
+REM タスクと設定を削除
+uninstall.cmd
 
-# タスクのみ削除（設定は保持）
-.\scripts\uninstall.ps1 -KeepSettings
+REM タスクのみ削除（設定は保持）
+uninstall.cmd -KeepSettings
 ```
 
 ### 手動起動

--- a/scripts/create-shortcuts.cmd
+++ b/scripts/create-shortcuts.cmd
@@ -1,0 +1,2 @@
+@echo off
+PowerShell -ExecutionPolicy Bypass -File "%~dp0create-shortcuts.ps1" %*

--- a/scripts/create-shortcuts.cmd
+++ b/scripts/create-shortcuts.cmd
@@ -1,2 +1,2 @@
 @echo off
-PowerShell -ExecutionPolicy Bypass -File "%~dp0create-shortcuts.ps1" %*
+%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0create-shortcuts.ps1" %*

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -1,0 +1,2 @@
+@echo off
+PowerShell -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*

--- a/scripts/install.cmd
+++ b/scripts/install.cmd
@@ -1,2 +1,2 @@
 @echo off
-PowerShell -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*
+%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*

--- a/scripts/uninstall.cmd
+++ b/scripts/uninstall.cmd
@@ -1,2 +1,2 @@
 @echo off
-PowerShell -ExecutionPolicy Bypass -File "%~dp0uninstall.ps1" %*
+%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0uninstall.ps1" %*

--- a/scripts/uninstall.cmd
+++ b/scripts/uninstall.cmd
@@ -1,0 +1,2 @@
+@echo off
+PowerShell -ExecutionPolicy Bypass -File "%~dp0uninstall.ps1" %*

--- a/winui3/SquirrelNotifier.Installer/Package.wxs
+++ b/winui3/SquirrelNotifier.Installer/Package.wxs
@@ -74,7 +74,7 @@
 
     <!-- Task Scheduler 削除 (アンインストール時) -->
     <SetProperty Id="UnregisterScheduledTask"
-                 Value="&quot;[SystemFolder]schtasks.exe&quot; /Delete /TN &quot;Squirrel Notifier&quot; /F"
+                 Value="&quot;[System64Folder]schtasks.exe&quot; /Delete /TN &quot;Squirrel Notifier&quot; /F"
                  Before="UnregisterScheduledTask"
                  Sequence="execute" />
     <CustomAction Id="UnregisterScheduledTask"

--- a/winui3/SquirrelNotifier.Installer/Package.wxs
+++ b/winui3/SquirrelNotifier.Installer/Package.wxs
@@ -56,8 +56,13 @@
       WixQuietExec カスタムアクションでサイレント実行する。
       /RU [%USERNAME] でログオン中ユーザーとして登録し /IT で対話セッション限定にする。
     -->
+    <!--
+      /SC ONLOGON は非昇格プロセスからは Access denied になる環境があるため Return="ignore" にする (#79)。
+      インストール後はアプリ内 UI または Setup Zip の install.cmd / install.ps1 からタスク登録可能。
+      [System64Folder] を使い 64-bit schtasks.exe を明示する。
+    -->
     <SetProperty Id="RegisterScheduledTask"
-                 Value="&quot;[SystemFolder]schtasks.exe&quot; /Create /TN &quot;Squirrel Notifier&quot; /TR &quot;\&quot;[INSTALLFOLDER]SquirrelNotifier.WinUI3.exe\&quot; --tray&quot; /SC ONLOGON /RU &quot;[%USERNAME]&quot; /IT /RL LIMITED /F"
+                 Value="&quot;[System64Folder]schtasks.exe&quot; /Create /TN &quot;Squirrel Notifier&quot; /TR &quot;\&quot;[INSTALLFOLDER]SquirrelNotifier.WinUI3.exe\&quot; --tray&quot; /SC ONLOGON /RU &quot;[%USERNAME]&quot; /IT /RL LIMITED /F"
                  Before="RegisterScheduledTask"
                  Sequence="execute" />
     <CustomAction Id="RegisterScheduledTask"
@@ -65,7 +70,7 @@
                   DllEntry="WixQuietExec"
                   Execute="deferred"
                   Impersonate="yes"
-                  Return="check" />
+                  Return="ignore" />
 
     <!-- Task Scheduler 削除 (アンインストール時) -->
     <SetProperty Id="UnregisterScheduledTask"


### PR DESCRIPTION
## Summary

- **MSI (#79)**: `RegisterScheduledTask` CA を `Return="ignore"` に変更。UAC 有効環境で `schtasks /SC ONLOGON` が Access denied になってもインストールを続行できるようにした。`[SystemFolder]` → `[System64Folder]` で 64-bit schtasks を明示。
- **.cmd ラッパー追加**: `scripts/install.cmd` / `uninstall.cmd` / `create-shortcuts.cmd` を新規作成。PowerShell の ExecutionPolicy に関わらずダブルクリックで実行可能。Setup Zip に同梱。
- **WinUI3 zip 廃止**: `release.yml` から `SquirrelNotifier-WinUI3-*.zip`（バイナリのみ）を削除。`SquirrelNotifier-Setup-*.zip`（バイナリ＋スクリプト）に一本化。

## Test plan

- [ ] PR CI が通ること
- [ ] Setup Zip に install.cmd / uninstall.cmd / create-shortcuts.cmd が含まれること（次回リリース時に確認）
- [ ] WinUI3-*.zip がリリース成果物に存在しないこと（次回リリース時に確認）
- [ ] MSI インストールが完了すること（タスク登録失敗でロールバックされないこと）

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)