### PR TITLE
fix: 自動起動 Access denied 修正・pnpm コマンドパス自動検索 (#86, #88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,9 @@ PATCHES/
 docker-compose.override.yml
 out/
 
+# MSI build artifacts
+msi/
+
 # .NET build artifacts
 bin/
 obj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Settings の「自動起動」トグルで `schtasks.exe /SC ONLOGON` が UAC 有効環境で Access denied になる問題を修正。`Register-ScheduledTask` / `Unregister-ScheduledTask` PowerShell コマンドレット（CIM API 経由）に切り替え、非昇格プロセスでも登録・削除できるようにした（#86）
+
+### Changed
+- 「自動起動」トグルのオン・オフ時に確認ダイアログを表示するようにした。「いいえ」を選択するとトグルが元の状態に戻り、操作を中断できる（#86）
+
 ## [0.1.2] - 2026-06-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - 「自動起動」トグルのオン・オフ時に確認ダイアログを表示するようにした。「いいえ」を選択するとトグルが元の状態に戻り、操作を中断できる（#86）
+- `mcp-resource-subscriber` コマンドの自動検索に `pnpm bin -g` によるグローバル bin ディレクトリのフォールバックを追加。PATH に含まれない環境でも自動解決できるようになった（#88）
+- `SettingsService.ResolveCommandPath` に重複していた `McpSubscriptionService` 内の同名メソッドを統合（#88）
 
 ## [0.1.2] - 2026-06-21
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -19,8 +19,9 @@ public class SettingsServiceTests : IDisposable
         string? oldPath = Environment.GetEnvironmentVariable("PATH");
         try
         {
+            // PATH を空にして PATH 検索を無効化し、pnpmBinDir: string.Empty で pnpm プローブも無効化する
             Environment.SetEnvironmentVariable("PATH", string.Empty);
-            _settingsService = new SettingsService(_settingsDirectory);
+            _settingsService = new SettingsService(_settingsDirectory, pnpmBinDir: string.Empty);
         }
         finally
         {
@@ -70,18 +71,9 @@ public class SettingsServiceTests : IDisposable
 
         try
         {
-            // PATH が空でも pnpmBinDir から発見できる
-            string? oldPath = Environment.GetEnvironmentVariable("PATH");
-            try
-            {
-                Environment.SetEnvironmentVariable("PATH", string.Empty);
-                string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: tempDir);
-                result.Should().Be(Path.GetFullPath(fakeExe));
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("PATH", oldPath);
-            }
+            // pathEnv を直接渡すことで global PATH を操作せずに検証
+            string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: tempDir, pathEnv: string.Empty);
+            result.Should().Be(Path.GetFullPath(fakeExe));
         }
         finally
         {
@@ -104,17 +96,9 @@ public class SettingsServiceTests : IDisposable
 
         try
         {
-            string? oldPath = Environment.GetEnvironmentVariable("PATH");
-            try
-            {
-                Environment.SetEnvironmentVariable("PATH", pathDir);
-                string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: pnpmDir);
-                result.Should().Be(Path.GetFullPath(pathExe));
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("PATH", oldPath);
-            }
+            // pathEnv を直接渡すことで global PATH を操作せずに検証
+            string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: pnpmDir, pathEnv: pathDir);
+            result.Should().Be(Path.GetFullPath(pathExe));
         }
         finally
         {

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -44,11 +44,83 @@ public class SettingsServiceTests : IDisposable
         AppSettings settings = _settingsService.Settings;
 
         // Assert
+        // pnpmBinDir=null なので pnpm プローブなし → PATH も空 → デフォルト名のまま
         settings.SubscriberCommandPath.Should().Be("mcp-resource-subscriber");
         settings.SubscriberArguments.Should().BeEmpty();
         settings.GatewayUrl.Should().Be("http://localhost:3000");
         settings.ResourceUri.Should().Be("queue://review/queue");
         settings.NotificationTimeoutMs.Should().Be(60000);
+    }
+
+    [Fact]
+    public void ResolveCommandPath_ShouldReturnCommandName_WhenNotFound()
+    {
+        string result = SettingsService.ResolveCommandPath("nonexistent-tool-xyz", pnpmBinDir: null);
+        result.Should().Be("nonexistent-tool-xyz");
+    }
+
+    [Fact]
+    public void ResolveCommandPath_ShouldFindExecutable_InPnpmBinDir()
+    {
+        // Arrange: 一時ディレクトリに偽の実行ファイルを作成
+        string tempDir = Path.Combine(Path.GetTempPath(), $"pnpm_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        string fakeExe = Path.Combine(tempDir, "my-tool.cmd");
+        File.WriteAllText(fakeExe, "@echo off");
+
+        try
+        {
+            // PATH が空でも pnpmBinDir から発見できる
+            string? oldPath = Environment.GetEnvironmentVariable("PATH");
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", string.Empty);
+                string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: tempDir);
+                result.Should().Be(Path.GetFullPath(fakeExe));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("PATH", oldPath);
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveCommandPath_ShouldPreferPath_OverPnpmBinDir()
+    {
+        // Arrange: PATH 用と pnpm 用に別々の偽ファイルを作成
+        string pathDir = Path.Combine(Path.GetTempPath(), $"path_test_{Guid.NewGuid()}");
+        string pnpmDir = Path.Combine(Path.GetTempPath(), $"pnpm_test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(pathDir);
+        Directory.CreateDirectory(pnpmDir);
+        string pathExe = Path.Combine(pathDir, "my-tool.cmd");
+        string pnpmExe = Path.Combine(pnpmDir, "my-tool.cmd");
+        File.WriteAllText(pathExe, "@echo off");
+        File.WriteAllText(pnpmExe, "@echo off");
+
+        try
+        {
+            string? oldPath = Environment.GetEnvironmentVariable("PATH");
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", pathDir);
+                string result = SettingsService.ResolveCommandPath("my-tool", pnpmBinDir: pnpmDir);
+                result.Should().Be(Path.GetFullPath(pathExe));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("PATH", oldPath);
+            }
+        }
+        finally
+        {
+            Directory.Delete(pathDir, true);
+            Directory.Delete(pnpmDir, true);
+        }
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
@@ -93,7 +93,11 @@ public class TaskSchedulerServiceTests
         command.Should().Contain("Squirrel Notifier");
         command.Should().Contain("--tray");
         command.Should().Contain("AtLogOn");
+        command.Should().Contain("AllowStartIfOnBatteries");
+        command.Should().Contain("DontStopIfGoingOnBatteries");
+        command.Should().Contain("New-ScheduledTaskPrincipal");
         command.Should().Contain("Limited");
+        command.Should().Contain("$env:USERNAME");
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/TaskSchedulerServiceTests.cs
@@ -87,13 +87,13 @@ public class TaskSchedulerServiceTests
 
         // Assert
         capturedPsi.Should().NotBeNull();
-        capturedPsi!.FileName.Should().Be("schtasks.exe");
-        capturedPsi.Arguments.Should().Contain("/Create");
-        capturedPsi.Arguments.Should().Contain("Squirrel Notifier");
-        capturedPsi.Arguments.Should().Contain("--tray");
-        capturedPsi.Arguments.Should().Contain("ONLOGON");
-        capturedPsi.Arguments.Should().Contain("/RU");
-        capturedPsi.Arguments.Should().Contain("/IT");
+        capturedPsi!.FileName.Should().Be("powershell.exe");
+        string command = capturedPsi.ArgumentList[3];
+        command.Should().Contain("Register-ScheduledTask");
+        command.Should().Contain("Squirrel Notifier");
+        command.Should().Contain("--tray");
+        command.Should().Contain("AtLogOn");
+        command.Should().Contain("Limited");
     }
 
     [Fact]
@@ -132,8 +132,10 @@ public class TaskSchedulerServiceTests
         await service.UnregisterAsync();
 
         // Assert
-        capturedPsi!.Arguments.Should().Contain("/Delete");
-        capturedPsi.Arguments.Should().Contain("Squirrel Notifier");
+        capturedPsi!.FileName.Should().Be("powershell.exe");
+        string command = capturedPsi.ArgumentList[3];
+        command.Should().Contain("Unregister-ScheduledTask");
+        command.Should().Contain("Squirrel Notifier");
     }
 
     [Fact]
@@ -165,13 +167,13 @@ public class TaskSchedulerServiceTests
         Mock<IProcessInstance> createMock = CreateMockProcess(0);
 
         var mockRunner = new Mock<IProcessRunner>();
-        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Query"))))
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => PsCommand(p).Contains("Get-ScheduledTask"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Query"))
             .Returns(queryMock.Object);
-        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Delete"))))
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => PsCommand(p).Contains("Unregister-ScheduledTask"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Delete"))
             .Returns(deleteMock.Object);
-        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Create"))))
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => PsCommand(p).Contains("Register-ScheduledTask"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Create"))
             .Returns(createMock.Object);
 
@@ -194,10 +196,10 @@ public class TaskSchedulerServiceTests
         Mock<IProcessInstance> createMock = CreateMockProcess(0);
 
         var mockRunner = new Mock<IProcessRunner>();
-        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Query"))))
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => PsCommand(p).Contains("Get-ScheduledTask"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Query"))
             .Returns(queryMock.Object);
-        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => p.Arguments.Contains("/Create"))))
+        mockRunner.Setup(r => r.Start(It.Is<ProcessStartInfo>(p => PsCommand(p).Contains("Register-ScheduledTask"))))
             .Callback<ProcessStartInfo>(_ => callOrder.Add("Create"))
             .Returns(createMock.Object);
 
@@ -209,4 +211,7 @@ public class TaskSchedulerServiceTests
         // Assert
         callOrder.Should().Equal("Query", "Create");
     }
+
+    private static string PsCommand(ProcessStartInfo psi)
+        => psi.ArgumentList.Count >= 4 ? psi.ArgumentList[3] : string.Empty;
 }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -687,10 +687,41 @@ internal sealed partial class MainWindow : Window
         {
             if (AutoStartToggle.IsOn)
             {
+                string exePath = TaskSchedulerService.GetExePath();
+                ContentDialog confirmDialog = new ContentDialog
+                {
+                    Title = "自動起動を設定します",
+                    Content = $"以下の内容でタスクスケジューラへ登録します\n\n　タスク名: Squirrel Notifier\n　実行ファイル: {exePath}\n　引数: --tray\n　トリガー: ログオン時（現在のユーザー）",
+                    PrimaryButtonText = "はい",
+                    CloseButtonText = "いいえ",
+                    XamlRoot = Content.XamlRoot,
+                };
+                ContentDialogResult confirmed = await confirmDialog.ShowAsync(ContentDialogPlacement.Popup);
+                if (confirmed != ContentDialogResult.Primary)
+                {
+                    AutoStartToggle.IsOn = false;
+                    return;
+                }
+
                 await _taskSchedulerService.RegisterAsync().ConfigureAwait(true);
             }
             else
             {
+                ContentDialog confirmDialog = new ContentDialog
+                {
+                    Title = "自動起動を解除します",
+                    Content = "自動起動タスクを削除します。よろしいですか？",
+                    PrimaryButtonText = "はい",
+                    CloseButtonText = "いいえ",
+                    XamlRoot = Content.XamlRoot,
+                };
+                ContentDialogResult confirmed = await confirmDialog.ShowAsync(ContentDialogPlacement.Popup);
+                if (confirmed != ContentDialogResult.Primary)
+                {
+                    AutoStartToggle.IsOn = true;
+                    return;
+                }
+
                 await _taskSchedulerService.UnregisterAsync().ConfigureAwait(true);
             }
         }

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -195,45 +195,6 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         return result;
     }
 
-    private static string ResolveCommandPath(string command)
-    {
-        if (File.Exists(command))
-        {
-            return Path.GetFullPath(command);
-        }
-
-        if (OperatingSystem.IsWindows())
-        {
-            string? pathEnv = Environment.GetEnvironmentVariable("PATH");
-            if (!string.IsNullOrEmpty(pathEnv))
-            {
-                string[] paths = pathEnv.Split(';', StringSplitOptions.RemoveEmptyEntries);
-                string[] extensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
-
-                foreach (string path in paths)
-                {
-                    string fullPath = Path.Combine(path, command);
-
-                    foreach (string ext in extensions)
-                    {
-                        string extPath = fullPath + ext;
-                        if (File.Exists(extPath))
-                        {
-                            return Path.GetFullPath(extPath);
-                        }
-                    }
-
-                    if (File.Exists(fullPath))
-                    {
-                        return Path.GetFullPath(fullPath);
-                    }
-                }
-            }
-        }
-
-        return command;
-    }
-
     public async Task<bool> PreflightCheckAsync(CancellationToken token)
     {
         _activeProcessCts = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -244,7 +205,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             AppSettings settings = _settingsService.Settings;
             ProcessStartInfo psi = new ProcessStartInfo
             {
-                FileName = ResolveCommandPath(settings.SubscriberCommandPath),
+                FileName = SettingsService.ResolveCommandPath(settings.SubscriberCommandPath),
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
@@ -310,7 +271,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                 AppSettings settings = _settingsService.Settings;
                 ProcessStartInfo psi = new ProcessStartInfo
                 {
-                    FileName = ResolveCommandPath(settings.SubscriberCommandPath),
+                    FileName = SettingsService.ResolveCommandPath(settings.SubscriberCommandPath),
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -20,7 +20,7 @@ internal sealed class SettingsService
     public SettingsService()
         : this(
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SquirrelNotifier"),
-            GetPnpmGlobalBinDir())
+            pnpmBinDir: null)
     {
     }
 
@@ -39,7 +39,10 @@ internal sealed class SettingsService
 
         if (_settings.SubscriberCommandPath == "mcp-resource-subscriber")
         {
-            string resolved = ResolveCommandPath(_settings.SubscriberCommandPath, pnpmBinDir);
+            // Lazy pnpm probe: only runs when the default command name needs resolution.
+            // Tests pass pnpmBinDir: string.Empty to skip the probe entirely.
+            string? binDir = pnpmBinDir ?? GetPnpmGlobalBinDir();
+            string resolved = ResolveCommandPath(_settings.SubscriberCommandPath, binDir);
             if (resolved != "mcp-resource-subscriber")
             {
                 _settings.SubscriberCommandPath = resolved;
@@ -48,7 +51,7 @@ internal sealed class SettingsService
         }
     }
 
-    internal static string ResolveCommandPath(string command, string? pnpmBinDir = null)
+    internal static string ResolveCommandPath(string command, string? pnpmBinDir = null, string? pathEnv = null)
     {
         if (File.Exists(command))
         {
@@ -59,7 +62,7 @@ internal sealed class SettingsService
             ? [".exe", ".cmd", ".bat", ".ps1"]
             : [];
 
-        string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+        pathEnv ??= Environment.GetEnvironmentVariable("PATH");
         if (!string.IsNullOrEmpty(pathEnv))
         {
             char separator = OperatingSystem.IsWindows() ? ';' : ':';
@@ -85,7 +88,7 @@ internal sealed class SettingsService
         return command;
     }
 
-    // Runs `pnpm bin -g` to locate the global bin directory; returns null on any failure.
+    // Runs `pnpm bin -g` to locate the global bin directory; returns null on any failure or timeout.
     internal static string? GetPnpmGlobalBinDir()
     {
         try
@@ -104,9 +107,15 @@ internal sealed class SettingsService
                 return null;
             }
 
-            string output = proc.StandardOutput.ReadToEnd().Trim();
-            proc.WaitForExit(3000);
+            Task<string> readTask = proc.StandardOutput.ReadToEndAsync();
+            if (!readTask.Wait(3000))
+            {
+                proc.Kill();
+                return null;
+            }
 
+            proc.WaitForExit(1000);
+            string output = readTask.Result.Trim();
             return proc.ExitCode == 0 && Directory.Exists(output) ? output : null;
         }
         catch

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace SquirrelNotifier.WinUI3.Services;
@@ -17,11 +18,13 @@ internal sealed class SettingsService
     public event EventHandler? SettingsChanged;
 
     public SettingsService()
-        : this(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SquirrelNotifier"))
+        : this(
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SquirrelNotifier"),
+            GetPnpmGlobalBinDir())
     {
     }
 
-    internal SettingsService(string settingsDirectory)
+    internal SettingsService(string settingsDirectory, string? pnpmBinDir = null)
     {
         if (string.IsNullOrWhiteSpace(settingsDirectory))
         {
@@ -36,7 +39,7 @@ internal sealed class SettingsService
 
         if (_settings.SubscriberCommandPath == "mcp-resource-subscriber")
         {
-            string resolved = ResolveCommandPath(_settings.SubscriberCommandPath);
+            string resolved = ResolveCommandPath(_settings.SubscriberCommandPath, pnpmBinDir);
             if (resolved != "mcp-resource-subscriber")
             {
                 _settings.SubscriberCommandPath = resolved;
@@ -45,43 +48,91 @@ internal sealed class SettingsService
         }
     }
 
-    internal static string ResolveCommandPath(string command)
+    internal static string ResolveCommandPath(string command, string? pnpmBinDir = null)
     {
         if (File.Exists(command))
         {
             return Path.GetFullPath(command);
         }
 
-        if (OperatingSystem.IsWindows())
+        string[] extensions = OperatingSystem.IsWindows()
+            ? [".exe", ".cmd", ".bat", ".ps1"]
+            : [];
+
+        string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrEmpty(pathEnv))
         {
-            string? pathEnv = Environment.GetEnvironmentVariable("PATH");
-            if (!string.IsNullOrEmpty(pathEnv))
+            char separator = OperatingSystem.IsWindows() ? ';' : ':';
+            foreach (string dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
             {
-                string[] paths = pathEnv.Split(';', StringSplitOptions.RemoveEmptyEntries);
-                string[] extensions = new[] { ".exe", ".cmd", ".bat", ".ps1" };
-
-                foreach (string path in paths)
+                string? found = FindInDirectory(dir, command, extensions);
+                if (found is not null)
                 {
-                    string fullPath = Path.Combine(path, command);
-
-                    foreach (string ext in extensions)
-                    {
-                        string extPath = fullPath + ext;
-                        if (File.Exists(extPath))
-                        {
-                            return Path.GetFullPath(extPath);
-                        }
-                    }
-
-                    if (File.Exists(fullPath))
-                    {
-                        return Path.GetFullPath(fullPath);
-                    }
+                    return found;
                 }
             }
         }
 
+        if (!string.IsNullOrEmpty(pnpmBinDir))
+        {
+            string? found = FindInDirectory(pnpmBinDir, command, extensions);
+            if (found is not null)
+            {
+                return found;
+            }
+        }
+
         return command;
+    }
+
+    // Runs `pnpm bin -g` to locate the global bin directory; returns null on any failure.
+    internal static string? GetPnpmGlobalBinDir()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "pnpm",
+                Arguments = "bin -g",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+            };
+            using Process? proc = Process.Start(psi);
+            if (proc is null)
+            {
+                return null;
+            }
+
+            string output = proc.StandardOutput.ReadToEnd().Trim();
+            proc.WaitForExit(3000);
+
+            return proc.ExitCode == 0 && Directory.Exists(output) ? output : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? FindInDirectory(string dir, string command, string[] extensions)
+    {
+        string fullPath = Path.Combine(dir, command);
+        foreach (string ext in extensions)
+        {
+            string extPath = fullPath + ext;
+            if (File.Exists(extPath))
+            {
+                return Path.GetFullPath(extPath);
+            }
+        }
+
+        if (File.Exists(fullPath))
+        {
+            return Path.GetFullPath(fullPath);
+        }
+
+        return null;
     }
 
     private AppSettings LoadSettings()

--- a/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
@@ -43,9 +43,10 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
         string exePath = EscapePs(GetExePath());
         string command =
             $"$a = New-ScheduledTaskAction -Execute '{exePath}' -Argument '--tray'; " +
-            $"$t = New-ScheduledTaskTrigger -AtLogOn; " +
-            $"$s = New-ScheduledTaskSettingsSet -ExecutionTimeLimit 0; " +
-            $"Register-ScheduledTask -TaskName '{EscapePs(_taskName)}' -Action $a -Trigger $t -Settings $s -RunLevel Limited -Force";
+            $"$t = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME; " +
+            $"$s = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RunOnlyIfNetworkAvailable:$false -DontStopOnIdleEnd; " +
+            $"$p = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited; " +
+            $"Register-ScheduledTask -TaskName '{EscapePs(_taskName)}' -Action $a -Trigger $t -Settings $s -Principal $p -Force";
 
         ProcessStartInfo psi = BuildPsi(command);
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/TaskSchedulerService.cs
@@ -23,15 +23,8 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
 
     public async Task<TaskRegistrationStatus> GetStatusAsync()
     {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "schtasks.exe",
-            Arguments = $"/Query /TN \"{_taskName}\"",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-        };
+        string command = $"if (Get-ScheduledTask -TaskName '{EscapePs(_taskName)}' -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}";
+        ProcessStartInfo psi = BuildPsi(command);
 
         try
         {
@@ -47,17 +40,14 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
 
     public async Task RegisterAsync()
     {
-        string exePath = GetExePath();
-        string userName = Environment.UserName;
-        var psi = new ProcessStartInfo
-        {
-            FileName = "schtasks.exe",
-            Arguments = $"/Create /TN \"{_taskName}\" /TR \"\\\"{exePath}\\\" --tray\" /SC ONLOGON /RU \"{userName}\" /IT /RL LIMITED /F",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-        };
+        string exePath = EscapePs(GetExePath());
+        string command =
+            $"$a = New-ScheduledTaskAction -Execute '{exePath}' -Argument '--tray'; " +
+            $"$t = New-ScheduledTaskTrigger -AtLogOn; " +
+            $"$s = New-ScheduledTaskSettingsSet -ExecutionTimeLimit 0; " +
+            $"Register-ScheduledTask -TaskName '{EscapePs(_taskName)}' -Action $a -Trigger $t -Settings $s -RunLevel Limited -Force";
+
+        ProcessStartInfo psi = BuildPsi(command);
 
         using IProcessInstance proc = _processRunner.Start(psi);
         Task<string> errorTask = proc.StandardError.ReadToEndAsync();
@@ -72,15 +62,8 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
 
     public async Task UnregisterAsync()
     {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "schtasks.exe",
-            Arguments = $"/Delete /TN \"{_taskName}\" /F",
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-        };
+        string command = $"Unregister-ScheduledTask -TaskName '{EscapePs(_taskName)}' -Confirm:$false";
+        ProcessStartInfo psi = BuildPsi(command);
 
         using IProcessInstance proc = _processRunner.Start(psi);
         Task<string> errorTask = proc.StandardError.ReadToEndAsync();
@@ -104,6 +87,26 @@ internal sealed class TaskSchedulerService : ITaskSchedulerService
         await RegisterAsync().ConfigureAwait(false);
     }
 
-    private static string GetExePath()
+    internal static string GetExePath()
         => Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "SquirrelNotifier.WinUI3.exe");
+
+    private static ProcessStartInfo BuildPsi(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-NonInteractive");
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-Command");
+        psi.ArgumentList.Add(command);
+        return psi;
+    }
+
+    // PowerShell single-quoted string escaping: ' → ''
+    private static string EscapePs(string value) => value.Replace("'", "''", StringComparison.Ordinal);
 }


### PR DESCRIPTION
## Summary

- **#86**: `schtasks.exe /SC ONLOGON` が UAC 有効環境で Access denied になるバグを修正。`Register-ScheduledTask` / `Unregister-ScheduledTask` / `Get-ScheduledTask` PowerShell コマンドレット（CIM API 経由）に切り替え
- **#86**: 「自動起動」トグルのオン・オフ時に確認ダイアログを追加。「いいえ」でトグルを元の状態に戻す
- **#88**: `SettingsService.ResolveCommandPath` に `pnpm bin -g` によるグローバル bin ディレクトリのフォールバックを追加
- **#88**: `McpSubscriptionService` に重複していた `ResolveCommandPath` を削除し `SettingsService` 側に統合

## Test plan

- [ ] `dotnet test` 全 123 件パス（本 PR でテスト +3 件追加）
- [ ] Windows 11（UAC 有効・非昇格）で自動起動トグルをオンにしてタスクが登録されることを確認
- [ ] 確認ダイアログで「いいえ」を押すとトグルが戻ることを確認
- [ ] pnpm でインストールした `mcp-resource-subscriber` のパスが自動解決されることを確認

Closes #86
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)