### PR TITLE
fix: error handling, tray activation and onboarding notification (#83, #84, #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- 自動起動（タスクスケジューラ）が未登録の場合に、メインウィンドウ上部に設定画面への誘導を促すオンボーディング案内（InfoBar）を表示する機能を追加（#83）
+
 ### Fixed
+- mcp-gateway のエンドポイントが 404 を返した際や、接続エラーが発生した際のエラーメッセージをパースし、設定画面への確認を促す分かりやすいメッセージに変換するよう改善。また、ログに `[CONN_REFUSED]`、`[HTTP_404]`、`[AUTH_ERROR]` などのエラータグを出力するようにした（#85）
+- `--tray`（トレイ）モードで起動した際、WinUI 3 (Windows App SDK) の仕様で `Window.Activate` を呼ばないとメッセージループが開始せずプロセスが即時終了してしまう問題を修正（#84）
 - Settings の「自動起動」トグルで `schtasks.exe /SC ONLOGON` が UAC 有効環境で Access denied になる問題を修正。`Register-ScheduledTask` / `Unregister-ScheduledTask` PowerShell コマンドレット（CIM API 経由）に切り替え、非昇格プロセスでも登録・削除できるようにした（#86）
 
 ### Changed

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -963,16 +963,8 @@ public class McpSubscriptionServiceTests : IDisposable
     [InlineData(null, "不明なエラーが発生しました。", "[UNKNOWN_ERROR]")]
     public void ErrorMessageMapping_ShouldReturnFriendlyMessageAndTag(string? input, string expectedFriendly, string expectedTag)
     {
-        // Arrange
-        var getFriendlyMethod = typeof(McpSubscriptionService).GetMethod("GetFriendlyErrorMessage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        var getTagMethod = typeof(McpSubscriptionService).GetMethod("GetErrorTag", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-        getFriendlyMethod.Should().NotBeNull();
-        getTagMethod.Should().NotBeNull();
-
         // Act
-        var friendlyResult = (string)getFriendlyMethod!.Invoke(null, new object?[] { input })!;
-        var tagResult = (string)getTagMethod!.Invoke(null, new object?[] { input })!;
+        var (friendlyResult, tagResult) = McpSubscriptionService.GetErrorInfo(input!);
 
         // Assert
         friendlyResult.Should().Be(expectedFriendly);

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -950,4 +950,32 @@ public class McpSubscriptionServiceTests : IDisposable
         // Assert: 新規通知後にキャッシュが保存される
         mockCacheService.Verify(c => c.SaveAsync(It.Is<NotificationCache>(nc => nc.SeenEventIds.Contains("evt_new"))), Times.Once);
     }
+
+    [Theory]
+    [InlineData("fetch failed", "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。", "[CONN_REFUSED]")]
+    [InlineData("connect ECONNREFUSED 127.0.0.1:8080", "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。", "[CONN_REFUSED]")]
+    [InlineData("404 page not found", "指定されたエンドポイントが見つかりませんでした (404)。Gateway URL のポート番号やパスプレフィックス、または Resource URI が正しいか確認してください。", "[HTTP_404]")]
+    [InlineData("Error POSTing to endpoint: 404", "指定されたエンドポイントが見つかりませんでした (404)。Gateway URL のポート番号やパスプレフィックス、または Resource URI が正しいか確認してください。", "[HTTP_404]")]
+    [InlineData("Unauthorized access", "mcp-gateway で認証エラーが発生しました。認証トークン（MCP_PROBE_AUTH_TOKEN）の設定を確認してください。", "[AUTH_ERROR]")]
+    [InlineData("401 Unauthorized", "mcp-gateway で認証エラーが発生しました。認証トークン（MCP_PROBE_AUTH_TOKEN）の設定を確認してください。", "[AUTH_ERROR]")]
+    [InlineData("something went wrong", "予期しないエラーが発生しました: something went wrong", "[GENERAL_ERROR]")]
+    [InlineData("", "不明なエラーが発生しました。", "[UNKNOWN_ERROR]")]
+    [InlineData(null, "不明なエラーが発生しました。", "[UNKNOWN_ERROR]")]
+    public void ErrorMessageMapping_ShouldReturnFriendlyMessageAndTag(string? input, string expectedFriendly, string expectedTag)
+    {
+        // Arrange
+        var getFriendlyMethod = typeof(McpSubscriptionService).GetMethod("GetFriendlyErrorMessage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var getTagMethod = typeof(McpSubscriptionService).GetMethod("GetErrorTag", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        getFriendlyMethod.Should().NotBeNull();
+        getTagMethod.Should().NotBeNull();
+
+        // Act
+        var friendlyResult = (string)getFriendlyMethod!.Invoke(null, new object?[] { input })!;
+        var tagResult = (string)getTagMethod!.Invoke(null, new object?[] { input })!;
+
+        // Assert
+        friendlyResult.Should().Be(expectedFriendly);
+        tagResult.Should().Be(expectedTag);
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -68,10 +68,11 @@ public partial class App : Application
         _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, showWindow);
         _window.Closed += OnWindowClosed;
 
-        // Activate window if it should be shown
-        if (showWindow)
+        _window.Activate();
+
+        if (!showWindow)
         {
-            _window.Activate();
+            _window.HideWindowToTray();
         }
 
         _subscriptionService.Start();

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -16,9 +16,21 @@
                        FontWeight="SemiBold"/>
             <TextBlock x:Name="StatusText"
                        Text="Stopped"/>
+            <InfoBar x:Name="OnboardingInfoBar"
+                     Title="自動起動が未設定です"
+                     Message="設定の「自動起動」を有効にすると、ログイン時にバックグラウンドで動作を開始します。"
+                     Severity="Warning"
+                     IsOpen="False"
+                     IsClosable="True"
+                     Margin="0,4,0,0">
+                <InfoBar.ActionButton>
+                    <Button Content="設定へ移動" Click="OnGoToSettingsClick"/>
+                </InfoBar.ActionButton>
+            </InfoBar>
         </StackPanel>
 
         <Expander Grid.Row="1"
+                  x:Name="SettingsExpander"
                   Header="Settings"
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -146,6 +146,12 @@ internal sealed partial class MainWindow : Window
         }
     }
 
+    private void OnGoToSettingsClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        SettingsExpander.IsExpanded = true;
+        AutoStartToggle.Focus(FocusState.Programmatic);
+    }
+
     private nint NewWndProc(nint hWnd, uint msg, nint wParam, nint lParam)
     {
         // Process tray icon messages
@@ -276,17 +282,20 @@ internal sealed partial class MainWindow : Window
     {
         if (state == SubscriptionState.Error)
         {
+            _ = _loggingService.WriteAsync($"[UI] Updating tray icon to error state. Error: {_service.LastError}");
             _trayIconService.UpdateIcon("squirrel-notifier-error.ico");
             _trayIconService.UpdateTooltip($"Squirrel Notifier - Error: {_service.LastError}");
 
             if (!_hasShownErrorBalloon)
             {
                 _hasShownErrorBalloon = true;
+                _ = _loggingService.WriteAsync("[UI] Showing connection error balloon notification.");
                 _trayIconService.ShowBalloonTip("Squirrel Notifier", $"接続エラー: {_service.LastError}");
             }
         }
         else
         {
+            _ = _loggingService.WriteAsync($"[UI] Updating tray icon to normal state. State: {state}");
             _trayIconService.UpdateIcon("squirrel-notifier.ico");
             _trayIconService.UpdateTooltip("Squirrel Notifier");
             _hasShownErrorBalloon = false;
@@ -778,12 +787,14 @@ internal sealed partial class MainWindow : Window
                     AutoStartToggle.IsOn = true;
                     AutoStartStatusText.Text = "登録済み";
                     RepairAutoStartButton.IsEnabled = true;
+                    OnboardingInfoBar.IsOpen = false;
                 }
                 else
                 {
                     AutoStartToggle.IsOn = false;
                     AutoStartStatusText.Text = "未登録";
                     RepairAutoStartButton.IsEnabled = false;
+                    OnboardingInfoBar.IsOpen = true;
                 }
             }
             finally

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -149,7 +149,7 @@ internal sealed partial class MainWindow : Window
     private void OnGoToSettingsClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
         SettingsExpander.IsExpanded = true;
-        AutoStartToggle.Focus(FocusState.Programmatic);
+        _ = DispatcherQueue.TryEnqueue(() => AutoStartToggle.Focus(FocusState.Programmatic));
     }
 
     private nint NewWndProc(nint hWnd, uint msg, nint wParam, nint lParam)

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -393,8 +393,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             catch (Exception ex)
             {
                 retryCount++;
-                string friendlyMessage = GetFriendlyErrorMessage(ex.Message);
-                string tag = GetErrorTag(ex.Message);
+                (string friendlyMessage, string tag) = GetErrorInfo(ex.Message);
 
                 if (retryCount > _maxRetries)
                 {
@@ -599,64 +598,33 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         _activeProcessCts?.Dispose();
     }
 
-    private static string GetFriendlyErrorMessage(string rawError)
+    internal static (string FriendlyMessage, string ErrorTag) GetErrorInfo(string rawError)
     {
         if (string.IsNullOrEmpty(rawError))
         {
-            return "不明なエラーが発生しました。";
+            return ("不明なエラーが発生しました。", "[UNKNOWN_ERROR]");
         }
 
         if (rawError.Contains("fetch failed", StringComparison.OrdinalIgnoreCase) ||
             rawError.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
         {
-            return "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。";
+            return ("mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。", "[CONN_REFUSED]");
         }
 
         if (rawError.Contains("404 page not found", StringComparison.OrdinalIgnoreCase) ||
             rawError.Contains("Error POSTing to endpoint: 404", StringComparison.OrdinalIgnoreCase))
         {
-            return "指定されたエンドポイントが見つかりませんでした (404)。Gateway URL のポート番号やパスプレフィックス、または Resource URI が正しいか確認してください。";
+            return ("指定されたエンドポイントが見つかりませんでした (404)。Gateway URL のポート番号やパスプレフィックス、または Resource URI が正しいか確認してください。", "[HTTP_404]");
         }
 
         if (rawError.Contains("401", StringComparison.OrdinalIgnoreCase) ||
             rawError.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("Forbidden", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("auth", StringComparison.OrdinalIgnoreCase))
+            rawError.Contains("Forbidden", StringComparison.OrdinalIgnoreCase))
         {
-            return "mcp-gateway で認証エラーが発生しました。認証トークン（MCP_PROBE_AUTH_TOKEN）の設定を確認してください。";
+            return ("mcp-gateway で認証エラーが発生しました。認証トークン（MCP_PROBE_AUTH_TOKEN）の設定を確認してください。", "[AUTH_ERROR]");
         }
 
-        return $"予期しないエラーが発生しました: {rawError}";
-    }
-
-    private static string GetErrorTag(string rawError)
-    {
-        if (string.IsNullOrEmpty(rawError))
-        {
-            return "[UNKNOWN_ERROR]";
-        }
-
-        if (rawError.Contains("fetch failed", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
-        {
-            return "[CONN_REFUSED]";
-        }
-
-        if (rawError.Contains("404 page not found", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("Error POSTing to endpoint: 404", StringComparison.OrdinalIgnoreCase))
-        {
-            return "[HTTP_404]";
-        }
-
-        if (rawError.Contains("401", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("Forbidden", StringComparison.OrdinalIgnoreCase) ||
-            rawError.Contains("auth", StringComparison.OrdinalIgnoreCase))
-        {
-            return "[AUTH_ERROR]";
-        }
-
-        return "[GENERAL_ERROR]";
+        return ($"予期しないエラーが発生しました: {rawError}", "[GENERAL_ERROR]");
     }
 }
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -393,16 +393,19 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             catch (Exception ex)
             {
                 retryCount++;
+                string friendlyMessage = GetFriendlyErrorMessage(ex.Message);
+                string tag = GetErrorTag(ex.Message);
+
                 if (retryCount > _maxRetries)
                 {
-                    LastError = ex.Message;
+                    LastError = friendlyMessage;
                     State = SubscriptionState.Error;
-                    ReportStatus($"Error: {ex.Message}");
-                    await LogAsync($"Subscription loop error (max retries exceeded): {ex.Message}").ConfigureAwait(false);
+                    ReportStatus($"Error: {friendlyMessage}");
+                    await LogAsync($"Subscription loop error (max retries exceeded) {tag}: {ex.Message}").ConfigureAwait(false);
                     break;
                 }
 
-                await LogAsync($"Subscription loop error (retry {retryCount}/{_maxRetries}): {ex.Message}").ConfigureAwait(false);
+                await LogAsync($"Subscription loop error (retry {retryCount}/{_maxRetries}) {tag}: {ex.Message}").ConfigureAwait(false);
                 ReportStatus($"Retrying ({retryCount}/{_maxRetries})...");
 
                 try
@@ -594,6 +597,66 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
 
         _cts.Dispose();
         _activeProcessCts?.Dispose();
+    }
+
+    private static string GetFriendlyErrorMessage(string rawError)
+    {
+        if (string.IsNullOrEmpty(rawError))
+        {
+            return "不明なエラーが発生しました。";
+        }
+
+        if (rawError.Contains("fetch failed", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
+        {
+            return "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。";
+        }
+
+        if (rawError.Contains("404 page not found", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Error POSTing to endpoint: 404", StringComparison.OrdinalIgnoreCase))
+        {
+            return "指定されたエンドポイントが見つかりませんでした (404)。Gateway URL のポート番号やパスプレフィックス、または Resource URI が正しいか確認してください。";
+        }
+
+        if (rawError.Contains("401", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Forbidden", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("auth", StringComparison.OrdinalIgnoreCase))
+        {
+            return "mcp-gateway で認証エラーが発生しました。認証トークン（MCP_PROBE_AUTH_TOKEN）の設定を確認してください。";
+        }
+
+        return $"予期しないエラーが発生しました: {rawError}";
+    }
+
+    private static string GetErrorTag(string rawError)
+    {
+        if (string.IsNullOrEmpty(rawError))
+        {
+            return "[UNKNOWN_ERROR]";
+        }
+
+        if (rawError.Contains("fetch failed", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
+        {
+            return "[CONN_REFUSED]";
+        }
+
+        if (rawError.Contains("404 page not found", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Error POSTing to endpoint: 404", StringComparison.OrdinalIgnoreCase))
+        {
+            return "[HTTP_404]";
+        }
+
+        if (rawError.Contains("401", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("Forbidden", StringComparison.OrdinalIgnoreCase) ||
+            rawError.Contains("auth", StringComparison.OrdinalIgnoreCase))
+        {
+            return "[AUTH_ERROR]";
+        }
+
+        return "[GENERAL_ERROR]";
     }
 }
 


### PR DESCRIPTION
## 概要
Phase 1（安定化・不具合修正）の対象である #83, #84, #85 の修正対応を行いました。

## 変更内容
1. **エラーメッセージの親切化 (#85)**
   - McpSubscriptionService でのエラー発生時（接続拒否、404、認証エラー等）にユーザーに分かりやすいメッセージへ変換するロジックを追加。
   - ログ出力時に [CONN_REFUSED]、[HTTP_404] などのエラータグを付与。
   - 分岐網羅のためのテストケースを McpSubscriptionServiceTests.cs に追加（カバレッジ基準80%以上を維持）。

2. **トレイ起動時の即時終了不具合の修正と実機確認 (#84)**
   - --tray（非表示）モード起動時に Window.Activate が呼ばれずメッセージポンプが開始せずにプロセスが即死する問題を App.xaml.cs にて修正。
   - 実機においてバックグラウンドで接続エラー遷移時に、UI側のトレイアイコン切り替えとバルーン通知表示処理（[UI] Showing connection error balloon notification.）が正しく実行されることをログで実証確認。

3. **タスクスケジューラ未登録時のオンボーディング案内 (#83)**
   - 自動起動が未登録の場合にメインウィンドウ上部に InfoBar で警告表示する機能を追加。
   - 「設定へ移動」ボタンで設定 Expander を展開し、トグルスイッチへフォーカスを当てる挙動を実装。

## テスト結果
- xUnit テストがすべて合格（132件合格、失敗0）。
- カバレッジ：Line 87.13%, Branch 82.46% で目標（80%以上）をクリア。