### PR TITLE
feat: Settings - Gateway URL をコンテナから自動設定するボタンを追加 (#89)

### DIFF
--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
@@ -1,0 +1,63 @@
+// <copyright file="DockerPortParserTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class DockerPortParserTests
+{
+    [Theory]
+    [InlineData("0.0.0.0:8080->8080/tcp", "http://localhost:8080/mcp/thread-owl")]
+    [InlineData("0.0.0.0:3000->3000/tcp", "http://localhost:3000/mcp/thread-owl")]
+    [InlineData(":::8080->8080/tcp", "http://localhost:8080/mcp/thread-owl")]
+    public void ParseGatewayUrls_SinglePort_ReturnsCorrectUrl(string dockerPsOutput, string expectedUrl)
+    {
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayUrls(dockerPsOutput);
+
+        result.Should().ContainSingle().Which.Should().Be(expectedUrl);
+    }
+
+    [Fact]
+    public void ParseGatewayUrls_MultipleContainerLines_ReturnsAllUrls()
+    {
+        string dockerPsOutput = "0.0.0.0:8080->8080/tcp\n0.0.0.0:8081->8080/tcp";
+
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayUrls(dockerPsOutput);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain("http://localhost:8080/mcp/thread-owl");
+        result.Should().Contain("http://localhost:8081/mcp/thread-owl");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("no port mapping here")]
+    [InlineData("8080/tcp")]
+    public void ParseGatewayUrls_NoMatchingPorts_ReturnsEmpty(string dockerPsOutput)
+    {
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayUrls(dockerPsOutput);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseGatewayUrls_DefaultRoute_IsThreadOwlMcpRoute()
+    {
+        DockerPortParser.DefaultMcpRoute.Should().Be("/mcp/thread-owl");
+    }
+
+    [Fact]
+    public void ParseGatewayUrls_CustomRoute_AppendsCorrectly()
+    {
+        string dockerPsOutput = "0.0.0.0:8080->8080/tcp";
+
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayUrls(dockerPsOutput, "/mcp/custom-service");
+
+        result.Should().ContainSingle().Which.Should().Be("http://localhost:8080/mcp/custom-service");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
@@ -1,0 +1,30 @@
+// <copyright file="DockerPortParser.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Text.RegularExpressions;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+internal static class DockerPortParser
+{
+    // squirrel-notifier が購読する mcp-gateway の既定 route パス
+    internal const string DefaultMcpRoute = "/mcp/thread-owl";
+
+    private static readonly Regex _portMappingRegex = new(@":(\d+)->\d+/tcp", RegexOptions.Compiled);
+
+    internal static IReadOnlyList<string> ParseGatewayUrls(string dockerPsOutput, string mcpRoute = DefaultMcpRoute)
+    {
+        var candidates = new List<string>();
+        foreach (string line in dockerPsOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            Match match = _portMappingRegex.Match(line);
+            if (match.Success)
+            {
+                candidates.Add($"http://localhost:{match.Groups[1].Value}{mcpRoute}");
+            }
+        }
+
+        return candidates;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -47,7 +47,10 @@
                     <TextBox Grid.Row="1" Grid.Column="1" x:Name="ArgumentsBox" TextChanged="OnSettingChanged"/>
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Gateway URL:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" x:Name="GatewayUrlBox" TextChanged="OnSettingChanged"/>
+                    <Grid Grid.Row="2" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                        <TextBox Grid.Column="0" x:Name="GatewayUrlBox" TextChanged="OnSettingChanged"/>
+                        <Button Grid.Column="1" Content="コンテナから自動設定" Click="OnAutoDetectGatewayUrlClick"/>
+                    </Grid>
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="Resource URI:" VerticalAlignment="Center"/>
                     <TextBox Grid.Row="3" Grid.Column="1" x:Name="ResourceUriBox" TextChanged="OnSettingChanged"/>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -6,7 +6,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -403,31 +402,12 @@ internal sealed partial class MainWindow : Window
                 return;
             }
 
-            string[] lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (lines.Length == 0)
+            IReadOnlyList<string> candidates = DockerPortParser.ParseGatewayUrls(output);
+            if (candidates.Count == 0)
             {
                 await ShowAlertDialogAsync(
                     "コンテナが見つかりませんでした",
                     "コンテナ名に 'mcp-gateway' が含まれているか、コンテナが起動しているか確認してください。");
-                return;
-            }
-
-            var portRegex = new Regex(@":(\d+)->\d+/tcp");
-            var candidates = new List<string>();
-            foreach (string line in lines)
-            {
-                Match match = portRegex.Match(line);
-                if (match.Success)
-                {
-                    candidates.Add($"http://localhost:{match.Groups[1].Value}");
-                }
-            }
-
-            if (candidates.Count == 0)
-            {
-                await ShowAlertDialogAsync(
-                    "ポートマッピングが取得できませんでした",
-                    "コンテナが起動していないか、ポートが公開されていない可能性があります。");
                 return;
             }
 

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -370,6 +371,96 @@ internal sealed partial class MainWindow : Window
         }
 
         SaveCurrentSettings();
+    }
+
+    private async void OnAutoDetectGatewayUrlClick(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = "docker",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            process.StartInfo.ArgumentList.Add("ps");
+            process.StartInfo.ArgumentList.Add("--filter");
+            process.StartInfo.ArgumentList.Add("name=mcp-gateway");
+            process.StartInfo.ArgumentList.Add("--format");
+            process.StartInfo.ArgumentList.Add("{{.Ports}}");
+            process.Start();
+            string output = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            string[] lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (lines.Length == 0)
+            {
+                await ShowAlertDialogAsync(
+                    "コンテナが見つかりませんでした",
+                    "コンテナ名に 'mcp-gateway' が含まれているか、コンテナが起動しているか確認してください。");
+                return;
+            }
+
+            var portRegex = new Regex(@":(\d+)->\d+/tcp");
+            var candidates = new List<string>();
+            foreach (string line in lines)
+            {
+                Match match = portRegex.Match(line);
+                if (match.Success)
+                {
+                    candidates.Add($"http://localhost:{match.Groups[1].Value}");
+                }
+            }
+
+            if (candidates.Count == 0)
+            {
+                await ShowAlertDialogAsync(
+                    "ポートマッピングが取得できませんでした",
+                    "コンテナが起動していないか、ポートが公開されていない可能性があります。");
+                return;
+            }
+
+            if (candidates.Count == 1)
+            {
+                GatewayUrlBox.Text = candidates[0];
+                return;
+            }
+
+            var listView = new ListView { ItemsSource = candidates, SelectedIndex = 0, MaxHeight = 160 };
+            var selectDialog = new ContentDialog
+            {
+                Title = "Gateway URL を選択",
+                Content = listView,
+                PrimaryButtonText = "選択",
+                CloseButtonText = "キャンセル",
+                DefaultButton = ContentDialogButton.Primary,
+            };
+            ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
+            if (result == ContentDialogResult.Primary && listView.SelectedItem is string selectedUrl)
+            {
+                GatewayUrlBox.Text = selectedUrl;
+            }
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            await ShowAlertDialogAsync(
+                "Docker が見つかりませんでした",
+                "Docker がインストールされていないか PATH に含まれていません。Gateway URL を手動で入力してください。");
+        }
+    }
+
+    private async Task ShowAlertDialogAsync(string title, string message)
+    {
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = "OK",
+        };
+        await dialog.ShowAsync(ContentDialogPlacement.Popup);
     }
 
     private void OnTimeoutChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -392,8 +392,16 @@ internal sealed partial class MainWindow : Window
             process.StartInfo.ArgumentList.Add("--format");
             process.StartInfo.ArgumentList.Add("{{.Ports}}");
             process.Start();
-            string output = await process.StandardOutput.ReadToEndAsync();
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
+            string output = await stdoutTask;
+            string stderr = await stderrTask;
+            if (process.ExitCode != 0 && string.IsNullOrWhiteSpace(output))
+            {
+                await ShowAlertDialogAsync("Docker エラー", $"Docker コマンドが失敗しました。\n{stderr.Trim()}");
+                return;
+            }
 
             string[] lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             if (lines.Length == 0)


### PR DESCRIPTION
## Summary

- Settings の Gateway URL フィールド横に「コンテナから自動設定」ボタンを追加
- `docker ps --filter name=mcp-gateway --format "{{.Ports}}"` を実行し、ポートマッピングから `http://localhost:PORT` を自動構築して入力欄に設定する
- 複数のコンテナが見つかった場合は選択ダイアログを表示
- Docker 未インストール時・コンテナ未起動時はアラートダイアログでフォールバックを案内

## Test plan

- [ ] mcp-gateway コンテナ起動中にボタンを押すと Gateway URL が自動入力される
- [ ] Docker 未インストール環境でボタンを押してもクラッシュせず、エラーダイアログが表示される
- [ ] コンテナ未起動状態でボタンを押すと「コンテナが見つかりませんでした」ダイアログが表示される
- [ ] ボタンを押さず手動入力が引き続き機能する

closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)