### PR TITLE
chore: v0.1.3 リリース準備（CHANGELOG 昇格・csproj バージョン更新）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-27
+
 ### Added
 - 自動起動（タスクスケジューラ）が未登録の場合に、メインウィンドウ上部に設定画面への誘導を促すオンボーディング案内（InfoBar）を表示する機能を追加（#83）
 
@@ -272,7 +274,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - レート制限対応
 - リトライ機能
 
-[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/scottlz0310/squirrel-notifier/releases/tag/v0.1.0

--- a/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
+++ b/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
@@ -5,9 +5,9 @@
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.1.0</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
+    <Version>0.1.3</Version>
+    <AssemblyVersion>0.1.3.0</AssemblyVersion>
+    <FileVersion>0.1.3.0</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\squirrel-notifier.ico</ApplicationIcon>


### PR DESCRIPTION
## 概要

v0.1.3 のリリース準備。CHANGELOG の `[Unreleased]` セクションを `[0.1.3]` に昇格し、csproj のバージョン番号を更新する。

## 変更内容

- `CHANGELOG.md`: `[Unreleased]` → `[0.1.3] - 2026-06-27` へ昇格、新しい空の `[Unreleased]` セクション追加、比較リンク更新
- `SquirrelNotifier.WinUI3.csproj`: `Version`・`AssemblyVersion`・`FileVersion` を `0.1.0` → `0.1.3` に更新（v0.1.1・v0.1.2 では更新が漏れていた）

## マージ後の手順

1. `git tag v0.1.3` → `git push origin v0.1.3`
2. feature/89・feature/90 を新しい main に rebase（force push）
3. PR #100・#101 の diff からこのコミットを除外

## 関連

- Closes #98（v0.1.3 リリース準備）