### PR TITLE
feat: Gateway URL 自動設定に MCP route 選択 UI を追加 (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Gateway URL の「コンテナから自動設定」で、検出したポートに加えて MCP route パス（既定 `/mcp/thread-owl`）を選択・入力できるダイアログを追加。`docker ps` から取得した `http://localhost:PORT` に route を結合して設定するため、gateway root（`/`）に繋いで `resources/list` が 404 になる問題を回避できる。Gateway URL 入力欄にも route を含むプレースホルダーを表示（#102）
+
 ## [0.1.3] - 2026-06-27
 
 ### Added

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
@@ -92,7 +92,8 @@ public class DockerPortParserTests
     [InlineData("http://localhost:8080", "", "http://localhost:8080")] // 空 route は base のみ
     [InlineData("http://localhost:8080", "   ", "http://localhost:8080")] // 空白のみ route は base のみ
     [InlineData("http://localhost:8080", "/", "http://localhost:8080")] // ルートのみ route は base のみ
-    public void CombineRoute_NormalizesAndCombines(string baseUrl, string route, string expected)
+    [InlineData("http://localhost:8080", null, "http://localhost:8080")] // null route は base のみ
+    public void CombineRoute_NormalizesAndCombines(string baseUrl, string? route, string expected)
     {
         DockerPortParser.CombineRoute(baseUrl, route).Should().Be(expected);
     }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/DockerPortParserTests.cs
@@ -60,4 +60,40 @@ public class DockerPortParserTests
 
         result.Should().ContainSingle().Which.Should().Be("http://localhost:8080/mcp/custom-service");
     }
+
+    [Theory]
+    [InlineData("0.0.0.0:8080->8080/tcp", "http://localhost:8080")]
+    [InlineData(":::3000->3000/tcp", "http://localhost:3000")]
+    public void ParseGatewayBaseUrls_SinglePort_ReturnsBaseWithoutRoute(string dockerPsOutput, string expected)
+    {
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayBaseUrls(dockerPsOutput);
+
+        result.Should().ContainSingle().Which.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseGatewayBaseUrls_MultipleContainerLines_ReturnsAllBaseUrls()
+    {
+        string dockerPsOutput = "0.0.0.0:8080->8080/tcp\n0.0.0.0:8081->8080/tcp";
+
+        IReadOnlyList<string> result = DockerPortParser.ParseGatewayBaseUrls(dockerPsOutput);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain("http://localhost:8080");
+        result.Should().Contain("http://localhost:8081");
+    }
+
+    [Theory]
+    [InlineData("http://localhost:8080", "/mcp/thread-owl", "http://localhost:8080/mcp/thread-owl")]
+    [InlineData("http://localhost:8080", "mcp/thread-owl", "http://localhost:8080/mcp/thread-owl")] // 先頭スラッシュ補完
+    [InlineData("http://localhost:8080", "/mcp/thread-owl/", "http://localhost:8080/mcp/thread-owl")] // 末尾スラッシュ除去
+    [InlineData("http://localhost:8080/", "/mcp/thread-owl", "http://localhost:8080/mcp/thread-owl")] // base 末尾スラッシュ除去
+    [InlineData("http://localhost:8080", "  /mcp/thread-owl  ", "http://localhost:8080/mcp/thread-owl")] // 前後空白除去
+    [InlineData("http://localhost:8080", "", "http://localhost:8080")] // 空 route は base のみ
+    [InlineData("http://localhost:8080", "   ", "http://localhost:8080")] // 空白のみ route は base のみ
+    [InlineData("http://localhost:8080", "/", "http://localhost:8080")] // ルートのみ route は base のみ
+    public void CombineRoute_NormalizesAndCombines(string baseUrl, string route, string expected)
+    {
+        DockerPortParser.CombineRoute(baseUrl, route).Should().Be(expected);
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Integration/GatewayConnectionTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Integration/GatewayConnectionTests.cs
@@ -15,12 +15,10 @@ namespace SquirrelNotifier.WinUI3.Tests.Integration;
 // MCP endpoint に到達する（route が 404 にならない）ことを検証する。
 public class GatewayConnectionTests
 {
-    private const string GatewayUrlEnvVar = "MCP_GATEWAY_URL";
-
     [Fact]
     public async Task ResourcesList_AtConfiguredGatewayUrl_DoesNotReturn404()
     {
-        string? gatewayUrl = Environment.GetEnvironmentVariable(GatewayUrlEnvVar);
+        string? gatewayUrl = Environment.GetEnvironmentVariable("MCP_GATEWAY_URL");
         if (string.IsNullOrWhiteSpace(gatewayUrl))
         {
             // 環境変数が未設定の場合はスキップ（CI 既定）。

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Integration/GatewayConnectionTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Integration/GatewayConnectionTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="GatewayConnectionTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Integration;
+
+// 現行 compose 経由の結合テスト。
+// 既定（環境変数 MCP_GATEWAY_URL 未設定）ではスキップし、CI を壊さない。
+// 実環境で route を含む Gateway URL を指定して実行すると、構築した URL が
+// MCP endpoint に到達する（route が 404 にならない）ことを検証する。
+public class GatewayConnectionTests
+{
+    private const string GatewayUrlEnvVar = "MCP_GATEWAY_URL";
+
+    [Fact]
+    public async Task ResourcesList_AtConfiguredGatewayUrl_DoesNotReturn404()
+    {
+        string? gatewayUrl = Environment.GetEnvironmentVariable(GatewayUrlEnvVar);
+        if (string.IsNullOrWhiteSpace(gatewayUrl))
+        {
+            // 環境変数が未設定の場合はスキップ（CI 既定）。
+            return;
+        }
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        using var request = new HttpRequestMessage(HttpMethod.Post, gatewayUrl);
+        _ = request.Headers.TryAddWithoutValidation("Accept", "application/json, text/event-stream");
+        request.Content = new StringContent(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"resources/list\",\"params\":{}}",
+            Encoding.UTF8,
+            "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // route が誤っている場合、gateway root は 404 を返す（Issue #102）。
+        // 正しい route なら 404 以外（200 や JSON-RPC エラー応答を含む）になる。
+        response.StatusCode.Should().NotBe(
+            HttpStatusCode.NotFound,
+            $"'{gatewayUrl}' は MCP endpoint に到達する必要があります（route が正しいこと）");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
@@ -13,7 +13,11 @@ internal static class DockerPortParser
 
     private static readonly Regex _portMappingRegex = new(@":(\d+)->\d+/tcp", RegexOptions.Compiled);
 
-    internal static IReadOnlyList<string> ParseGatewayUrls(string dockerPsOutput, string mcpRoute = DefaultMcpRoute)
+    /// <summary>
+    /// docker ps のポートマッピングから route を含まない base URL（http://localhost:PORT）の一覧を返す。
+    /// route は呼び出し側で <see cref="CombineRoute"/> を用いて付与する。
+    /// </summary>
+    internal static IReadOnlyList<string> ParseGatewayBaseUrls(string dockerPsOutput)
     {
         var candidates = new List<string>();
         foreach (string line in dockerPsOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -21,10 +25,46 @@ internal static class DockerPortParser
             Match match = _portMappingRegex.Match(line);
             if (match.Success)
             {
-                candidates.Add($"http://localhost:{match.Groups[1].Value}{mcpRoute}");
+                candidates.Add($"http://localhost:{match.Groups[1].Value}");
             }
         }
 
         return candidates;
+    }
+
+    /// <summary>
+    /// base URL に MCP route パスを正規化して結合する。
+    /// route が空の場合は base をそのまま返す。先頭スラッシュの補完・余分なスラッシュの除去を行う。
+    /// </summary>
+    internal static string CombineRoute(string baseUrl, string route)
+    {
+        string trimmedBase = baseUrl.TrimEnd('/');
+        string trimmedRoute = (route ?? string.Empty).Trim();
+        if (trimmedRoute.Length == 0)
+        {
+            return trimmedBase;
+        }
+
+        if (!trimmedRoute.StartsWith('/'))
+        {
+            trimmedRoute = "/" + trimmedRoute;
+        }
+
+        trimmedRoute = trimmedRoute.TrimEnd('/');
+        return trimmedRoute.Length == 0 ? trimmedBase : trimmedBase + trimmedRoute;
+    }
+
+    /// <summary>
+    /// docker ps のポートマッピングから route を付与した Gateway URL の一覧を返す。
+    /// </summary>
+    internal static IReadOnlyList<string> ParseGatewayUrls(string dockerPsOutput, string mcpRoute = DefaultMcpRoute)
+    {
+        var result = new List<string>();
+        foreach (string baseUrl in ParseGatewayBaseUrls(dockerPsOutput))
+        {
+            result.Add(CombineRoute(baseUrl, mcpRoute));
+        }
+
+        return result;
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
@@ -32,7 +32,7 @@ internal static class DockerPortParser
 
     // base URL に MCP route パスを正規化して結合する。
     // route が空の場合は base をそのまま返す。先頭スラッシュの補完・余分なスラッシュの除去を行う。
-    internal static string CombineRoute(string baseUrl, string route)
+    internal static string CombineRoute(string baseUrl, string? route)
     {
         string trimmedBase = baseUrl.TrimEnd('/');
         string trimmedRoute = (route ?? string.Empty).Trim();

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/DockerPortParser.cs
@@ -13,10 +13,8 @@ internal static class DockerPortParser
 
     private static readonly Regex _portMappingRegex = new(@":(\d+)->\d+/tcp", RegexOptions.Compiled);
 
-    /// <summary>
-    /// docker ps のポートマッピングから route を含まない base URL（http://localhost:PORT）の一覧を返す。
-    /// route は呼び出し側で <see cref="CombineRoute"/> を用いて付与する。
-    /// </summary>
+    // docker ps のポートマッピングから route を含まない base URL（http://localhost:PORT）の一覧を返す。
+    // route は呼び出し側で CombineRoute を用いて付与する。
     internal static IReadOnlyList<string> ParseGatewayBaseUrls(string dockerPsOutput)
     {
         var candidates = new List<string>();
@@ -32,10 +30,8 @@ internal static class DockerPortParser
         return candidates;
     }
 
-    /// <summary>
-    /// base URL に MCP route パスを正規化して結合する。
-    /// route が空の場合は base をそのまま返す。先頭スラッシュの補完・余分なスラッシュの除去を行う。
-    /// </summary>
+    // base URL に MCP route パスを正規化して結合する。
+    // route が空の場合は base をそのまま返す。先頭スラッシュの補完・余分なスラッシュの除去を行う。
     internal static string CombineRoute(string baseUrl, string route)
     {
         string trimmedBase = baseUrl.TrimEnd('/');
@@ -54,9 +50,7 @@ internal static class DockerPortParser
         return trimmedRoute.Length == 0 ? trimmedBase : trimmedBase + trimmedRoute;
     }
 
-    /// <summary>
-    /// docker ps のポートマッピングから route を付与した Gateway URL の一覧を返す。
-    /// </summary>
+    // docker ps のポートマッピングから route を付与した Gateway URL の一覧を返す。
     internal static IReadOnlyList<string> ParseGatewayUrls(string dockerPsOutput, string mcpRoute = DefaultMcpRoute)
     {
         var result = new List<string>();

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -48,7 +48,8 @@
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Gateway URL:" VerticalAlignment="Center"/>
                     <Grid Grid.Row="2" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="4">
-                        <TextBox Grid.Column="0" x:Name="GatewayUrlBox" TextChanged="OnSettingChanged"/>
+                        <TextBox Grid.Column="0" x:Name="GatewayUrlBox" TextChanged="OnSettingChanged"
+                                 PlaceholderText="http://localhost:8080/mcp/thread-owl"/>
                         <Button Grid.Column="1" Content="コンテナから自動設定" Click="OnAutoDetectGatewayUrlClick"/>
                     </Grid>
 

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -402,8 +402,8 @@ internal sealed partial class MainWindow : Window
                 return;
             }
 
-            IReadOnlyList<string> candidates = DockerPortParser.ParseGatewayUrls(output);
-            if (candidates.Count == 0)
+            IReadOnlyList<string> baseUrls = DockerPortParser.ParseGatewayBaseUrls(output);
+            if (baseUrls.Count == 0)
             {
                 await ShowAlertDialogAsync(
                     "コンテナが見つかりませんでした",
@@ -411,25 +411,37 @@ internal sealed partial class MainWindow : Window
                 return;
             }
 
-            if (candidates.Count == 1)
+            // mcp-gateway は route（例: /mcp/thread-owl）配下に MCP endpoint を割り当てるため、
+            // 検出した base URL（host:port）に加えて route パスを選択・入力できるようにする。
+            var portCombo = new ComboBox
             {
-                GatewayUrlBox.Text = candidates[0];
-                return;
-            }
+                ItemsSource = baseUrls,
+                SelectedIndex = 0,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+            var routeBox = new TextBox
+            {
+                Text = DockerPortParser.DefaultMcpRoute,
+                PlaceholderText = DockerPortParser.DefaultMcpRoute,
+            };
+            var panel = new StackPanel { Spacing = 8 };
+            panel.Children.Add(new TextBlock { Text = "ポート（コンテナ）:" });
+            panel.Children.Add(portCombo);
+            panel.Children.Add(new TextBlock { Text = "MCP route パス:" });
+            panel.Children.Add(routeBox);
 
-            var listView = new ListView { ItemsSource = candidates, SelectedIndex = 0, MaxHeight = 160 };
             var selectDialog = new ContentDialog
             {
-                Title = "Gateway URL を選択",
-                Content = listView,
-                PrimaryButtonText = "選択",
+                Title = "Gateway URL を設定",
+                Content = panel,
+                PrimaryButtonText = "設定",
                 CloseButtonText = "キャンセル",
                 DefaultButton = ContentDialogButton.Primary,
             };
             ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
-            if (result == ContentDialogResult.Primary && listView.SelectedItem is string selectedUrl)
+            if (result == ContentDialogResult.Primary && portCombo.SelectedItem is string selectedBase)
             {
-                GatewayUrlBox.Text = selectedUrl;
+                GatewayUrlBox.Text = DockerPortParser.CombineRoute(selectedBase, routeBox.Text);
             }
         }
         catch (System.ComponentModel.Win32Exception)

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -460,6 +460,7 @@ internal sealed partial class MainWindow : Window
             Title = title,
             Content = message,
             CloseButtonText = "OK",
+            XamlRoot = Content.XamlRoot,
         };
         await dialog.ShowAsync(ContentDialogPlacement.Popup);
     }
@@ -480,6 +481,7 @@ internal sealed partial class MainWindow : Window
             PrimaryButtonText = "選択",
             CloseButtonText = "キャンセル",
             DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = Content.XamlRoot,
         };
         ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
         if (result == ContentDialogResult.Primary && listView.SelectedItem is string selectedUri)

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -437,6 +437,7 @@ internal sealed partial class MainWindow : Window
                 PrimaryButtonText = "設定",
                 CloseButtonText = "キャンセル",
                 DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = Content.XamlRoot,
             };
             ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
             if (result == ContentDialogResult.Primary && portCombo.SelectedItem is string selectedBase)


### PR DESCRIPTION
- 「コンテナから自動設定」で検出したポートに加え、MCP route パス
  （既定 /mcp/thread-owl）を選択・入力できるダイアログを追加。
  gateway root に繋いで resources/list が 404 になる問題を回避
- DockerPortParser: ParseGatewayBaseUrls / CombineRoute を追加し
  route の正規化（先頭スラッシュ補完・余分なスラッシュ除去・空 route 許容）
  を一元化。ParseGatewayUrls は後方互換のため維持
- GatewayUrl 入力欄に route を含むプレースホルダーを表示
- DockerPortParser の新メソッドの unit テストと、env 指定時のみ実行する
  gated 結合テスト（MCP_GATEWAY_URL）を追加

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017V2mK6qpknNJMU6Lnf4FVn