### PR TITLE
feat: ランチャー 2 スロット化・{reason} プレースホルダー・複数 URI 並行購読 (#91 #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ランチャー設定を reviewer-side / reviewed-side の 2 スロット化。Settings に「起動ロール」（reviewer / reviewed）の RadioButton と、各スロットの Path・Arguments 入力欄を追加。`ReviewEvent.Source` が `queue://review/re-review-requests` の場合は常に reviewer スロットを使用し、`queue://review/queue` の場合は LauncherRole 設定で切り替える（#91）
+- `LauncherArgumentBuilder` に `{reason}` プレースホルダーを追加。`reviewEvent.Reason`（`opened` / `synchronized` / `re-review-requested` 等）を引数テンプレートに埋め込めるようになった。値は既存の `_safeNameRegex` で検証する（#91）
+- デフォルトのランチャー設定を `review-raven` から `claude -p "/thread-owl-pr-reviewer ..."` / `claude -p "/thread-owl-review-cycle ..."` に更新（#91）
+- 旧単一スロット設定（`LauncherCommandPath`）をユーザーがカスタマイズしていた場合、`SettingsService` コンストラクタ起動時に reviewer スロットへ自動移行（#91）
 - Settings の「Resource URI」欄に「MCP から取得」ボタンを追加。`ModelContextProtocol.Core` v1.4.0（公式 C# MCP SDK）を使用し、MCP Streamable HTTP transport（initialize handshake → Mcp-Session-Id セッション管理 → resources/list）を通じて mcp-gateway から Resource URI を動的に取得できるようになった。`MCP_PROBE_AUTH_TOKEN` 環境変数が設定されている場合は Bearer トークンを全リクエストに付与する（#103）
 - Gateway URL の「コンテナから自動設定」で、検出したポートに加えて MCP route パス（既定 `/mcp/thread-owl`）を選択・入力できるダイアログを追加。`docker ps` から取得した `http://localhost:PORT` に route を結合して設定するため、gateway root（`/`）に繋いで `resources/list` が 404 になる問題を回避できる。Gateway URL 入力欄にも route を含むプレースホルダーを表示（#102）
+- Settings の「Resource URI」欄を複数行 TextBox（`ResourceUrisBox`）に変更し、1 行 1 URI で複数の URI を設定できるようになった。`AppSettings.ResourceUris`（`List<string>`）に保存し、旧単一フィールド `ResourceUri` からの自動移行も対応（#92）
+- 複数 Resource URI に対して並行購読ループを実行。`McpSubscriptionService` が `Task.WhenAll` を使って各 URI の購読ループを独立したタスクとして並行実行し、`_activeProcesses`（`ConcurrentDictionary`）で全プロセスを追跡する。`StopAsync()` および `DisposeAsync()` が全プロセスをキルして確実に停止する（#92）
 
 ## [0.1.3] - 2026-06-27
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/LauncherArgumentBuilderTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/LauncherArgumentBuilderTests.cs
@@ -42,6 +42,53 @@ public class LauncherArgumentBuilderTests
     }
 
     [Theory]
+    [InlineData("opened")]
+    [InlineData("synchronized")]
+    [InlineData("re-review-requested")]
+    public void BuildArguments_ShouldSubstituteReasonPlaceholder(string reason)
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-reason",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Reason = reason,
+        };
+        string template = "-p \"/skill {owner}/{repo}#{prNumber} を {reason} モード\"";
+
+        // Act
+        List<string> result = LauncherArgumentBuilder.BuildArguments(template, reviewEvent);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result[0].Should().Be("-p");
+        result[1].Should().Contain(reason);
+    }
+
+    [Fact]
+    public void BuildArguments_ShouldThrowForInvalidReason()
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-event-reason-invalid",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Reason = "bad;reason",
+        };
+        string template = "--reason {reason}";
+
+        // Act
+        Action act = () => LauncherArgumentBuilder.BuildArguments(template, reviewEvent);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
     [InlineData("invalid;owner/repo")]
     [InlineData("owner/repo&bad")]
     [InlineData("owner/repo|cmd")]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -205,7 +205,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldPassArgumentsAndSecretsCorrectly()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", "queue://res", 30000, "review-raven", "", 300000);
+        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", "super-secret-token");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -361,7 +361,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldSkipTokenAndArgumentsWhenEmpty()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", "queue://res", 30000, "review-raven", "", 300000);
+        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", null);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -553,7 +553,7 @@ public class McpSubscriptionServiceTests : IDisposable
         await File.WriteAllTextAsync(testCmd, "@echo off\r\nif \"%1\"==\"--help\" (\r\n    exit /b 0\r\n)\r\nexit /b 1\r\n", Encoding.ASCII);
 
         var settingsService = new SettingsService(tempDir);
-        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", "queue://res", 30000, "review-raven", "", 300000);
+        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
 
         var runner = new ProcessRunner();
         await using var service = new McpSubscriptionService(settingsService, _notificationService, _loggingService, runner);
@@ -949,6 +949,110 @@ public class McpSubscriptionServiceTests : IDisposable
 
         // Assert: 新規通知後にキャッシュが保存される
         mockCacheService.Verify(c => c.SaveAsync(It.Is<NotificationCache>(nc => nc.SeenEventIds.Contains("evt_new"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task Start_WithMultipleResourceUris_ShouldLaunchProcessForEachUri()
+    {
+        // Arrange: 2つの URI を設定
+        _settingsService.UpdateSettings(
+            "my-cmd", "", "http://gateway:80",
+            new[] { "queue://uri-one", "queue://uri-two" },
+            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+
+        var preflightProcess = CreateMockProcess(0, "help", "");
+        var launchedUris = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var bothStartedTcs = new TaskCompletionSource();
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns<ProcessStartInfo>(psi =>
+            {
+                if (psi.ArgumentList.Contains("--help"))
+                {
+                    return preflightProcess;
+                }
+
+                int uriIndex = new List<string>(psi.ArgumentList).IndexOf("--uri");
+                if (uriIndex >= 0 && uriIndex + 1 < psi.ArgumentList.Count)
+                {
+                    launchedUris.Add(psi.ArgumentList[uriIndex + 1]);
+                    if (launchedUris.Count >= 2)
+                    {
+                        bothStartedTcs.TrySetResult();
+                    }
+                }
+
+                var mock = new Mock<IProcessInstance>();
+                mock.SetupGet(p => p.ExitCode).Returns(0);
+                mock.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+                mock.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+                mock.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
+                    .Returns<CancellationToken>(ct => Task.Delay(Timeout.Infinite, ct));
+                return mock.Object;
+            });
+
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
+
+        // Act
+        service.Start();
+        await bothStartedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.StopAsync();
+
+        // Assert: 両方の URI に対してプロセスが起動された
+        launchedUris.Should().Contain("queue://uri-one");
+        launchedUris.Should().Contain("queue://uri-two");
+    }
+
+    [Fact]
+    public async Task StopAsync_WithMultipleResourceUris_ShouldStopAllLoopsPromptly()
+    {
+        // Arrange: 2つの URI を設定し、両ループがバックオフ待機中に StopAsync を呼ぶ
+        _settingsService.UpdateSettings(
+            "my-cmd", "", "http://gateway:80",
+            new[] { "queue://uri-one", "queue://uri-two" },
+            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+
+        var preflightProcess = CreateMockProcess(0, "help", "");
+        int retryingCount = 0;
+        var bothRetryingTcs = new TaskCompletionSource();
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns<ProcessStartInfo>(psi =>
+            {
+                if (psi.ArgumentList.Contains("--help"))
+                {
+                    return preflightProcess;
+                }
+
+                return CreateMockProcess(1, "", "transient error");
+            });
+
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object, maxRetries: 5);
+        service.StatusTextChanged += (_, text) =>
+        {
+            if (text.StartsWith("Retrying"))
+            {
+                int count = Interlocked.Increment(ref retryingCount);
+                if (count >= 2)
+                {
+                    bothRetryingTcs.TrySetResult();
+                }
+            }
+        };
+
+        service.Start();
+        await bothRetryingTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Act: 両ループがバックオフ待機中に StopAsync を呼ぶ
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await service.StopAsync();
+        sw.Stop();
+
+        // Assert: 1000ms のバックオフ遅延より十分早く完了する
+        sw.ElapsedMilliseconds.Should().BeLessThan(800);
+        service.State.Should().Be(SubscriptionState.Stopped);
     }
 
     [Theory]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -1105,6 +1105,62 @@ public class McpSubscriptionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task NotifyReviewEvent_WhenExceptionThrown_ShouldPersistUndoSoRestartDoesNotDeduplicate()
+    {
+        // Arrange: 通知失敗 → UndoMarkAsSeen → PersistCacheAsync の順で、
+        // 再起動後も event が seen として残らないことを検証する
+        var savedCaches = new System.Collections.Generic.List<NotificationCache>();
+        var mockCacheService = new Mock<ICacheService>();
+        mockCacheService.Setup(c => c.LoadAsync()).ReturnsAsync(new NotificationCache());
+        mockCacheService.Setup(c => c.SaveAsync(It.IsAny<NotificationCache>()))
+            .Callback<NotificationCache>(nc => savedCaches.Add(new NotificationCache
+            {
+                SeenEventIds = new List<string>(nc.SeenEventIds),
+                RecentEvents = new List<CachedReviewEvent>(nc.RecentEvents),
+            }))
+            .Returns(Task.CompletedTask);
+
+        string evtA = @"{""eventId"":""evt_fail"",""repository"":""owner/repo"",""prNumber"":1,""prUrl"":""https://github.com/owner/repo/pull/1"",""reason"":""review_requested"",""source"":""thread-owl"",""message"":""msg""}";
+        string evtAJson = JsonSerializer.Serialize(new SubscriptionResult { Route = "subscription", NotificationReceived = true, FinalText = evtA });
+
+        var preflightProcess = CreateMockProcess(0, "help", "");
+        var testCts = new CancellationTokenSource();
+        int callCount = 0;
+
+        _mockNotificationService.Setup(n => n.NotifyReviewEvent(It.IsAny<ReviewEvent>()))
+            .Throws(new InvalidOperationException("notify failed"));
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns<ProcessStartInfo>(psi =>
+            {
+                if (psi.ArgumentList.Contains("--help"))
+                {
+                    return preflightProcess;
+                }
+
+                if (++callCount >= 2)
+                {
+                    testCts.Cancel();
+                }
+
+                return CreateMockProcess(0, evtAJson, "");
+            });
+
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object, cacheService: mockCacheService.Object);
+        var runMethod = typeof(McpSubscriptionService).GetMethod("RunSubscriptionLoopAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Act
+        var task = (Task)runMethod!.Invoke(service, new object[] { testCts.Token })!;
+        await task;
+
+        // Assert: 最後に保存された cache には evt_fail が含まれていない（undo が永続化された）
+        savedCaches.Should().NotBeEmpty();
+        NotificationCache lastCache = savedCaches[^1];
+        lastCache.SeenEventIds.Should().NotContain("evt_fail");
+    }
+
+    [Fact]
     public async Task PersistCacheAsync_ConcurrentSaves_ShouldPreserveLatestSnapshot()
     {
         // Arrange: 並行保存で最新 snapshot が保存されることを検証

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -679,26 +679,21 @@ public class McpSubscriptionServiceTests : IDisposable
         // Arrange
         var mockRunner = new Mock<IProcessRunner>();
         var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
-        var hasBeenSeenMethod = typeof(McpSubscriptionService).GetMethod("HasBeenSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var markAsSeenMethod = typeof(McpSubscriptionService).GetMethod("MarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        hasBeenSeenMethod.Should().NotBeNull();
-        markAsSeenMethod.Should().NotBeNull();
+        var tryMarkAsSeenMethod = typeof(McpSubscriptionService).GetMethod("TryMarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        tryMarkAsSeenMethod.Should().NotBeNull();
 
         // Act & Assert
-        // First check: not seen
-        var result1 = (bool)hasBeenSeenMethod!.Invoke(service, new object[] { "evt_1" })!;
-        result1.Should().BeFalse();
+        // First call: not seen yet → returns true (claimed)
+        var result1 = (bool)tryMarkAsSeenMethod!.Invoke(service, new object[] { "evt_1", null! })!;
+        result1.Should().BeTrue();
 
-        // Mark as seen
-        markAsSeenMethod!.Invoke(service, new object[] { "evt_1", null! });
+        // Second call: already seen → returns false
+        var result2 = (bool)tryMarkAsSeenMethod.Invoke(service, new object[] { "evt_1", null! })!;
+        result2.Should().BeFalse();
 
-        // Second check: seen
-        var result2 = (bool)hasBeenSeenMethod.Invoke(service, new object[] { "evt_1" })!;
-        result2.Should().BeTrue();
-
-        // Different ID: not seen
-        var result3 = (bool)hasBeenSeenMethod.Invoke(service, new object[] { "evt_2" })!;
-        result3.Should().BeFalse();
+        // Different ID: not seen → returns true
+        var result3 = (bool)tryMarkAsSeenMethod.Invoke(service, new object[] { "evt_2", null! })!;
+        result3.Should().BeTrue();
     }
 
     [Fact]
@@ -835,20 +830,18 @@ public class McpSubscriptionServiceTests : IDisposable
         // Arrange
         var mockRunner = new Mock<IProcessRunner>();
         var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
-        var hasBeenSeenMethod = typeof(McpSubscriptionService).GetMethod("HasBeenSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var markAsSeenMethod = typeof(McpSubscriptionService).GetMethod("MarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        hasBeenSeenMethod.Should().NotBeNull();
-        markAsSeenMethod.Should().NotBeNull();
+        var tryMarkAsSeenMethod = typeof(McpSubscriptionService).GetMethod("TryMarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        tryMarkAsSeenMethod.Should().NotBeNull();
 
         // Add 101 items
         for (int i = 0; i < 101; i++)
         {
-            markAsSeenMethod!.Invoke(service, new object[] { $"evt_{i}", null! });
+            tryMarkAsSeenMethod!.Invoke(service, new object[] { $"evt_{i}", null! });
         }
 
-        // The first item should be evicted now, so it should not be detected as seen
-        var result = (bool)hasBeenSeenMethod!.Invoke(service, new object[] { "evt_0" })!;
-        result.Should().BeFalse();
+        // The first item should be evicted now, so TryMarkAsSeen returns true (not in cache)
+        var result = (bool)tryMarkAsSeenMethod!.Invoke(service, new object[] { "evt_0", null! })!;
+        result.Should().BeTrue();
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -1048,6 +1048,102 @@ public class McpSubscriptionServiceTests : IDisposable
         service.State.Should().Be(SubscriptionState.Stopped);
     }
 
+    [Fact]
+    public async Task NotifyReviewEvent_WhenExceptionThrown_ShouldRedeliverOnNextSubscription()
+    {
+        // Arrange: 通知サービスが例外を投げる場合、seen cache から削除されて再配信で通知される
+        string eventPayload = @"{""eventId"":""evt_redeliver"",""repository"":""owner/repo"",""prNumber"":10,""prUrl"":""https://github.com/owner/repo/pull/10"",""reason"":""review_requested"",""source"":""thread-owl"",""message"":""Review requested""}";
+        string eventJson = JsonSerializer.Serialize(new SubscriptionResult
+        {
+            Route = "subscription",
+            NotificationReceived = true,
+            FinalText = eventPayload,
+        });
+
+        var preflightProcess = CreateMockProcess(0, "help", "");
+        int subscriptionCallCount = 0;
+        var testCts = new CancellationTokenSource();
+        int notifyCallCount = 0;
+
+        _mockNotificationService.Setup(n => n.NotifyReviewEvent(It.IsAny<ReviewEvent>()))
+            .Callback<ReviewEvent>(_ =>
+            {
+                notifyCallCount++;
+                if (notifyCallCount == 1)
+                {
+                    throw new InvalidOperationException("Simulated notification failure");
+                }
+            });
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns<ProcessStartInfo>(psi =>
+            {
+                if (psi.ArgumentList.Contains("--help"))
+                {
+                    return preflightProcess;
+                }
+
+                subscriptionCallCount++;
+                if (subscriptionCallCount >= 3)
+                {
+                    testCts.Cancel();
+                }
+
+                return CreateMockProcess(0, eventJson, "");
+            });
+
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object);
+        var runMethod = typeof(McpSubscriptionService).GetMethod("RunSubscriptionLoopAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Act
+        var task = (Task)runMethod!.Invoke(service, new object[] { testCts.Token })!;
+        await task;
+
+        // Assert: 1回目は失敗・ロールバック、2回目の再配信で通知が届く
+        notifyCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task PersistCacheAsync_ConcurrentSaves_ShouldPreserveLatestSnapshot()
+    {
+        // Arrange: 並行保存で最新 snapshot が保存されることを検証
+        var saveOrder = new System.Collections.Concurrent.ConcurrentQueue<List<string>>();
+        var mockCacheService = new Mock<ICacheService>();
+        mockCacheService.Setup(c => c.LoadAsync()).ReturnsAsync(new NotificationCache());
+        mockCacheService.Setup(c => c.SaveAsync(It.IsAny<NotificationCache>()))
+            .Callback<NotificationCache>(nc => saveOrder.Enqueue(new List<string>(nc.SeenEventIds)))
+            .Returns(Task.CompletedTask);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object, cacheService: mockCacheService.Object);
+
+        var tryMarkMethod = typeof(McpSubscriptionService).GetMethod("TryMarkAsSeen", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var persistMethod = typeof(McpSubscriptionService).GetMethod("PersistCacheAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // RestoreCacheAsync を先に呼んで初期化する
+        var restoreMethod = typeof(McpSubscriptionService).GetMethod("RestoreCacheAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        await (Task)restoreMethod!.Invoke(service, null)!;
+
+        // evt_A と evt_B を登録してから並行保存する
+        tryMarkMethod!.Invoke(service, new object[] { "evt_A", null! });
+        tryMarkMethod!.Invoke(service, new object[] { "evt_B", null! });
+
+        var task1 = (Task)persistMethod!.Invoke(service, null)!;
+        var task2 = (Task)persistMethod!.Invoke(service, null)!;
+        await Task.WhenAll(task1, task2);
+
+        // Assert: 最終的に保存された snapshot は両方の event ID を含む
+        saveOrder.Should().NotBeEmpty();
+        List<string>? last = null;
+        while (saveOrder.TryDequeue(out var item))
+        {
+            last = item;
+        }
+
+        last.Should().Contain("evt_A").And.Contain("evt_B");
+    }
+
     [Theory]
     [InlineData("fetch failed", "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。", "[CONN_REFUSED]")]
     [InlineData("connect ECONNREFUSED 127.0.0.1:8080", "mcp-gateway への接続に失敗しました。mcp-gateway コンテナが起動しているか、または Gateway URL の設定が正しいか確認してください。", "[CONN_REFUSED]")]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewEventParserTests.cs
@@ -129,4 +129,38 @@ public class ReviewEventParserTests
         second.Source.Should().Be("thread-owl");
         second.Message.Should().Be("re-review requested");
     }
+
+    [Fact]
+    public void Parse_WithSourceUri_ShouldOverrideSourceInCandidateFormat()
+    {
+        // Arrange: ReviewCandidate 形式（requestedBy なし）
+        string json = @"[{
+            ""owner"": ""scottlz0310"",
+            ""repo"": ""squirrel-notifier"",
+            ""prNumber"": 42,
+            ""queuedAt"": ""2026-06-28T10:00:00Z"",
+            ""reason"": ""re-review-requested""
+        }]";
+
+        // Act
+        List<ReviewEvent> result = ReviewEventParser.Parse(json, "queue://review/re-review-requests");
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Source.Should().Be("queue://review/re-review-requests");
+    }
+
+    [Fact]
+    public void Parse_WithSourceUri_ShouldOverrideSourceInReviewEventFormat()
+    {
+        // Arrange: ReviewEvent 直接形式（source フィールドあり）
+        string json = "{\"eventId\":\"evt_1\",\"repository\":\"org/repo\",\"prNumber\":42,\"prUrl\":\"https://github.com/org/repo/pull/42\",\"reason\":\"re-review-requested\",\"source\":\"thread-owl\",\"message\":\"msg\"}";
+
+        // Act
+        List<ReviewEvent> result = ReviewEventParser.Parse(json, "queue://review/re-review-requests");
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Source.Should().Be("queue://review/re-review-requests");
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -59,6 +59,22 @@ public class ReviewLauncherServiceTests : IDisposable
         return mockProcess;
     }
 
+    private void ConfigureSettings(
+        string reviewerCmd = "reviewer-cmd",
+        string reviewerArgs = "--reviewer-arg",
+        string reviewedCmd = "reviewed-cmd",
+        string reviewedArgs = "--reviewed-arg",
+        string role = "reviewer",
+        int timeoutMs = 10000)
+    {
+        _settingsService.UpdateSettings(
+            "my-review-cmd", "--repo {owner}/{repo}",
+            "http://localhost:3000", new[] { "queue://res" }, 30000,
+            reviewerCmd, reviewerArgs,
+            reviewedCmd, reviewedArgs,
+            role, timeoutMs);
+    }
+
     [Fact]
     public async Task LaunchAsync_ShouldRunSuccessfullyAndReturnExitCodeZero()
     {
@@ -68,10 +84,11 @@ public class ReviewLauncherServiceTests : IDisposable
             EventId = "test-event-1",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
-            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Source = "queue://review/queue",
         };
 
-        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+        ConfigureSettings(reviewerCmd: "launcher-cmd", reviewerArgs: "--launcher-arg");
 
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Success Output", "");
         ProcessStartInfo? capturedPsi = null;
@@ -107,10 +124,11 @@ public class ReviewLauncherServiceTests : IDisposable
             EventId = "test-event-2",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
-            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Source = "queue://review/queue",
         };
 
-        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+        ConfigureSettings();
 
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Success Output", "", delayMs: 1000);
 
@@ -143,10 +161,11 @@ public class ReviewLauncherServiceTests : IDisposable
             EventId = "test-event-3",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
-            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Source = "queue://review/queue",
         };
 
-        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 10000);
+        ConfigureSettings();
 
         // Delay mock process to simulate execution time
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Pending...", "", delayMs: 5000);
@@ -181,11 +200,11 @@ public class ReviewLauncherServiceTests : IDisposable
             EventId = "test-event-4",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
-            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52"
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Source = "queue://review/queue",
         };
 
-        // Timeout is set to 200ms
-        _settingsService.UpdateSettings("my-review-cmd", "--repo {owner}/{repo}", "http://localhost:3000", "queue://res", 30000, "launcher-cmd", "--launcher-arg", 200);
+        ConfigureSettings(timeoutMs: 200);
 
         // Process takes 5000ms
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Slow...", "", delayMs: 5000);
@@ -203,5 +222,45 @@ public class ReviewLauncherServiceTests : IDisposable
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Contain("timed out");
         mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("queue://review/re-review-requests", "reviewer", "reviewer-cmd")]
+    [InlineData("queue://review/queue", "reviewer", "reviewer-cmd")]
+    [InlineData("queue://review/queue", "reviewed", "reviewed-cmd")]
+    public async Task LaunchAsync_ShouldSelectCorrectSlotBySourceAndRole(
+        string source, string role, string expectedCmd)
+    {
+        // Arrange
+        var reviewEvent = new ReviewEvent
+        {
+            EventId = "test-slot",
+            Repository = "scottlz0310/squirrel-notifier",
+            PrNumber = 52,
+            PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+            Source = source,
+        };
+
+        ConfigureSettings(
+            reviewerCmd: "reviewer-cmd", reviewerArgs: "--reviewer-arg",
+            reviewedCmd: "reviewed-cmd", reviewedArgs: "--reviewed-arg",
+            role: role);
+
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
+        ProcessStartInfo? capturedPsi = null;
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act
+        await service.LaunchAsync(reviewEvent, CancellationToken.None);
+
+        // Assert
+        capturedPsi.Should().NotBeNull();
+        capturedPsi!.FileName.Should().Contain(expectedCmd);
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -107,36 +107,76 @@ public class SettingsServiceTests : IDisposable
         }
     }
 
+    private static readonly IReadOnlyList<string> _defaultUris = new[] { "queue://custom" };
+
+    private void UpdateSettingsDefault(
+        string cmd = "custom-cmd",
+        string args = "--arg",
+        string url = "https://example.com/gw",
+        IReadOnlyList<string>? uris = null,
+        int timeout = 120000,
+        string reviewerCmd = "reviewer-cmd",
+        string reviewerArgs = "--reviewer-arg",
+        string reviewedCmd = "reviewed-cmd",
+        string reviewedArgs = "--reviewed-arg",
+        string role = "reviewer",
+        int launcherTimeout = 150000)
+    {
+        _settingsService.UpdateSettings(cmd, args, url, uris ?? _defaultUris, timeout, reviewerCmd, reviewerArgs, reviewedCmd, reviewedArgs, role, launcherTimeout);
+    }
+
     [Fact]
     public void UpdateSettings_ShouldUpdateSettings()
     {
         // Act
-        _settingsService.UpdateSettings("custom-cmd", "--arg", "https://example.com/gw", "queue://custom", 120000, "launcher-cmd", "--launcher-arg", 150000);
+        UpdateSettingsDefault(uris: new[] { "queue://custom", "queue://custom2" });
 
         // Assert
         _settingsService.Settings.SubscriberCommandPath.Should().Be("custom-cmd");
         _settingsService.Settings.SubscriberArguments.Should().Be("--arg");
         _settingsService.Settings.GatewayUrl.Should().Be("https://example.com/gw");
         _settingsService.Settings.ResourceUri.Should().Be("queue://custom");
+        _settingsService.Settings.ResourceUris.Should().BeEquivalentTo(new[] { "queue://custom", "queue://custom2" });
         _settingsService.Settings.NotificationTimeoutMs.Should().Be(120000);
-        _settingsService.Settings.LauncherCommandPath.Should().Be("launcher-cmd");
-        _settingsService.Settings.LauncherArguments.Should().Be("--launcher-arg");
+        _settingsService.Settings.ReviewerLauncherCommandPath.Should().Be("reviewer-cmd");
+        _settingsService.Settings.ReviewerLauncherArguments.Should().Be("--reviewer-arg");
+        _settingsService.Settings.ReviewedLauncherCommandPath.Should().Be("reviewed-cmd");
+        _settingsService.Settings.ReviewedLauncherArguments.Should().Be("--reviewed-arg");
+        _settingsService.Settings.LauncherRole.Should().Be("reviewer");
         _settingsService.Settings.LauncherTimeoutMs.Should().Be(150000);
     }
 
-    [Theory]
-    [InlineData("", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", 60000)] // Empty command path
-    [InlineData("cmd", "--arg", "invalid-url", "queue://custom", 60000, "launcher-cmd", 60000)] // Invalid URL
-    [InlineData("cmd", "--arg", "ftp://localhost:3000", "queue://custom", 60000, "launcher-cmd", 60000)] // Non-http/https URL
-    [InlineData("cmd", "--arg", "http://localhost:3000", "", 60000, "launcher-cmd", 60000)] // Empty resource URI
-    [InlineData("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "", 60000)] // Empty launcher path
-    public void UpdateSettings_ShouldThrowArgumentExceptionForInvalidInputs(
-        string cmd, string args, string url, string uri, int timeout, string launcherCmd, int launcherTimeout)
-    {
-        // Act & Assert
-        Action act = () => _settingsService.UpdateSettings(cmd, args, url, uri, timeout, launcherCmd, "--launcher-arg", launcherTimeout);
-        act.Should().Throw<ArgumentException>();
-    }
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyCommandPath()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(cmd: "")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForInvalidGatewayUrl()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(url: "invalid-url")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForNonHttpGatewayUrl()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(url: "ftp://localhost:3000")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyResourceUris()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(uris: Array.Empty<string>())).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForBlankResourceUri()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(uris: new[] { "  " })).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyReviewerCommandPath()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(reviewerCmd: "")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyReviewedCommandPath()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(reviewedCmd: "")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForInvalidRole()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(role: "invalid")).Should().Throw<ArgumentException>();
 
     [Theory]
     [InlineData(0)]
@@ -144,12 +184,8 @@ public class SettingsServiceTests : IDisposable
     [InlineData(300001)]
     public void UpdateSettings_ShouldThrowArgumentOutOfRangeExceptionForInvalidTimeout(int invalidTimeout)
     {
-        // Act & Assert
-        Action act1 = () => _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", invalidTimeout, "launcher-cmd", "--launcher-arg", 60000);
-        act1.Should().Throw<ArgumentOutOfRangeException>();
-
-        Action act2 = () => _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", "--launcher-arg", invalidTimeout);
-        act2.Should().Throw<ArgumentOutOfRangeException>();
+        FluentActions.Invoking(() => UpdateSettingsDefault(timeout: invalidTimeout)).Should().Throw<ArgumentOutOfRangeException>();
+        FluentActions.Invoking(() => UpdateSettingsDefault(launcherTimeout: invalidTimeout)).Should().Throw<ArgumentOutOfRangeException>();
     }
 
     [Fact]
@@ -203,7 +239,7 @@ public class SettingsServiceTests : IDisposable
         _settingsService.SettingsChanged += (_, _) => eventRaised = true;
 
         // Act
-        _settingsService.UpdateSettings("cmd", "--arg", "http://localhost:3000", "queue://custom", 60000, "launcher-cmd", "--launcher-arg", 60000);
+        UpdateSettingsDefault();
 
         // Assert
         eventRaised.Should().BeTrue();

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -284,7 +284,8 @@ public class SettingsServiceTests : IDisposable
             // Act
             var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
 
-            // Assert: カスタム arguments が reviewer スロットに移行される
+            // Assert: path/args を組として reviewer スロットに移行される
+            service.Settings.ReviewerLauncherCommandPath.Should().Be("review-raven");
             service.Settings.ReviewerLauncherArguments.Should().Be("custom-arg --repo {owner}/{repo}");
             service.Settings.LauncherSlotsMigrated.Should().BeTrue();
         }
@@ -314,8 +315,40 @@ public class SettingsServiceTests : IDisposable
             // Act
             var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
 
-            // Assert: カスタム path が reviewer スロットに移行される
+            // Assert: path/args を組として reviewer スロットに移行される
             service.Settings.ReviewerLauncherCommandPath.Should().Be("my-custom-review-tool");
+            service.Settings.ReviewerLauncherArguments.Should().Be("review --interactive --repo {owner}/{repo} --pr {prNumber}");
+            service.Settings.LauncherSlotsMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void LauncherSlotsMigration_ShouldMigrateBothCustomPathAndArgs()
+    {
+        // Arrange: LauncherCommandPath と LauncherArguments の両方をカスタマイズ
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "LauncherCommandPath": "my-custom-tool",
+                "LauncherArguments": "my-custom-arg --repo {owner}/{repo}",
+                "LauncherSlotsMigrated": false
+            }
+            """);
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: path/args を組として reviewer スロットに移行される
+            service.Settings.ReviewerLauncherCommandPath.Should().Be("my-custom-tool");
+            service.Settings.ReviewerLauncherArguments.Should().Be("my-custom-arg --repo {owner}/{repo}");
             service.Settings.LauncherSlotsMigrated.Should().BeTrue();
         }
         finally

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -263,4 +263,94 @@ public class SettingsServiceTests : IDisposable
         var anotherService = new SettingsService(_settingsDirectory);
         anotherService.Settings.LastSkippedVersion.Should().Be("v3.1.0");
     }
+
+    [Fact]
+    public void LauncherSlotsMigration_ShouldMigrateCustomArgsOnlySettings()
+    {
+        // Arrange: LauncherCommandPath は既定値のまま、LauncherArguments のみカスタマイズされた設定ファイルを作成
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "LauncherCommandPath": "review-raven",
+                "LauncherArguments": "custom-arg --repo {owner}/{repo}",
+                "LauncherSlotsMigrated": false
+            }
+            """);
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: カスタム arguments が reviewer スロットに移行される
+            service.Settings.ReviewerLauncherArguments.Should().Be("custom-arg --repo {owner}/{repo}");
+            service.Settings.LauncherSlotsMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void LauncherSlotsMigration_ShouldMigrateCustomPathSettings()
+    {
+        // Arrange: LauncherCommandPath のみカスタマイズされた設定ファイルを作成
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "LauncherCommandPath": "my-custom-review-tool",
+                "LauncherArguments": "review --interactive --repo {owner}/{repo} --pr {prNumber}",
+                "LauncherSlotsMigrated": false
+            }
+            """);
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: カスタム path が reviewer スロットに移行される
+            service.Settings.ReviewerLauncherCommandPath.Should().Be("my-custom-review-tool");
+            service.Settings.LauncherSlotsMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void LauncherSlotsMigration_ShouldSkipWhenAlreadyMigrated()
+    {
+        // Arrange: 既に移行済みの設定
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "LauncherCommandPath": "review-raven",
+                "LauncherArguments": "custom-arg",
+                "ReviewerLauncherCommandPath": "my-migrated-tool",
+                "LauncherSlotsMigrated": true
+            }
+            """);
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: 移行済みなので reviewer スロットは上書きされない
+            service.Settings.ReviewerLauncherCommandPath.Should().Be("my-migrated-tool");
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/LauncherArgumentBuilder.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/LauncherArgumentBuilder.cs
@@ -53,6 +53,11 @@ internal static class LauncherArgumentBuilder
             throw new ArgumentException("Invalid repository name.", nameof(reviewEvent));
         }
 
+        if (!string.IsNullOrEmpty(reviewEvent.Reason) && !_safeNameRegex.IsMatch(reviewEvent.Reason))
+        {
+            throw new ArgumentException("Invalid reason value.", nameof(reviewEvent));
+        }
+
         // Validate PR Url
         if (!UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
         {
@@ -66,7 +71,8 @@ internal static class LauncherArgumentBuilder
                 .Replace("{owner}", owner, StringComparison.Ordinal)
                 .Replace("{repo}", repo, StringComparison.Ordinal)
                 .Replace("{prNumber}", reviewEvent.PrNumber.ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal)
-                .Replace("{prUrl}", reviewEvent.PrUrl, StringComparison.Ordinal);
+                .Replace("{prUrl}", reviewEvent.PrUrl, StringComparison.Ordinal)
+                .Replace("{reason}", reviewEvent.Reason, StringComparison.Ordinal);
             result.Add(replaced);
         }
 

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -34,8 +34,8 @@
                   Header="Settings"
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
-            <ScrollViewer MaxHeight="180">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+            <ScrollViewer MaxHeight="240">
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -53,32 +53,53 @@
                         <Button Grid.Column="1" Content="コンテナから自動設定" Click="OnAutoDetectGatewayUrlClick"/>
                     </Grid>
 
-                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Resource URI:" VerticalAlignment="Center"/>
-                    <Grid Grid.Row="3" Grid.Column="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="4">
-                        <TextBox Grid.Column="0" x:Name="ResourceUriBox" TextChanged="OnSettingChanged"/>
-                        <Button Grid.Column="1" Content="URI を選択" Click="OnSelectResourceUriClick"/>
-                        <Button Grid.Column="2" Content="MCP から取得" Click="OnFetchResourceUriFromMcpClick"/>
-                    </Grid>
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Resource URIs:" VerticalAlignment="Top" Margin="0,4,0,0"/>
+                    <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4">
+                        <TextBox x:Name="ResourceUrisBox"
+                                 AcceptsReturn="True"
+                                 Height="60"
+                                 TextWrapping="Wrap"
+                                 PlaceholderText="1行に1つのURIを入力"
+                                 TextChanged="OnSettingChanged"/>
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <Button Content="URI を追加" Click="OnSelectResourceUriClick"/>
+                            <Button Content="MCP から取得" Click="OnFetchResourceUriFromMcpClick"/>
+                        </StackPanel>
+                    </StackPanel>
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Timeout (ms):" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="4" Grid.Column="1" x:Name="TimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Launcher Path:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" x:Name="LauncherPathBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="起動ロール:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="16">
+                        <RadioButton x:Name="ReviewerRoleRadio" Content="reviewer（レビュアー）"
+                                     GroupName="LauncherRole" Checked="OnLauncherRoleChanged"/>
+                        <RadioButton x:Name="ReviewedRoleRadio" Content="reviewed（実装者）"
+                                     GroupName="LauncherRole" Checked="OnLauncherRoleChanged"/>
+                    </StackPanel>
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Launcher Args:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="LauncherArgumentsBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Reviewer Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="ReviewerPathBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
-                    <NumberBox Grid.Row="7" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Reviewer Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="7" Grid.Column="1" x:Name="ReviewerArgumentsBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="8" Grid.Column="1" x:Name="AutoStartToggle"
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Reviewed Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="8" Grid.Column="1" x:Name="ReviewedPathBox" TextChanged="OnSettingChanged"/>
+
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="9" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
+
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
+                    <NumberBox Grid.Row="10" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="11" Grid.Column="1" x:Name="AutoStartToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnAutoStartToggled"/>
 
-                    <TextBlock Grid.Row="9" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="9" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
                         <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
                     </StackPanel>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -111,10 +111,16 @@ internal sealed partial class MainWindow : Window
         CommandPathBox.Text = settings.SubscriberCommandPath;
         ArgumentsBox.Text = settings.SubscriberArguments;
         GatewayUrlBox.Text = settings.GatewayUrl;
-        ResourceUriBox.Text = settings.ResourceUri;
+        ResourceUrisBox.Text = settings.ResourceUris.Count > 0
+            ? string.Join("\n", settings.ResourceUris)
+            : settings.ResourceUri;
         TimeoutBox.Value = settings.NotificationTimeoutMs;
-        LauncherPathBox.Text = settings.LauncherCommandPath;
-        LauncherArgumentsBox.Text = settings.LauncherArguments;
+        ReviewerPathBox.Text = settings.ReviewerLauncherCommandPath;
+        ReviewerArgumentsBox.Text = settings.ReviewerLauncherArguments;
+        ReviewedPathBox.Text = settings.ReviewedLauncherCommandPath;
+        ReviewedArgumentsBox.Text = settings.ReviewedLauncherArguments;
+        ReviewerRoleRadio.IsChecked = settings.LauncherRole != "reviewed";
+        ReviewedRoleRadio.IsChecked = settings.LauncherRole == "reviewed";
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
 
         _isInitializing = false;
@@ -473,20 +479,31 @@ internal sealed partial class MainWindow : Window
 
     private async void OnSelectResourceUriClick(object sender, RoutedEventArgs e)
     {
-        var listView = new ListView { ItemsSource = _knownResourceUris, SelectedIndex = 0, MaxHeight = 160 };
+        var listView = new ListView { ItemsSource = _knownResourceUris, SelectionMode = ListViewSelectionMode.Multiple, MaxHeight = 160 };
         var selectDialog = new ContentDialog
         {
-            Title = "Resource URI を選択",
+            Title = "Resource URI を追加",
             Content = listView,
-            PrimaryButtonText = "選択",
+            PrimaryButtonText = "追加",
             CloseButtonText = "キャンセル",
             DefaultButton = ContentDialogButton.Primary,
             XamlRoot = Content.XamlRoot,
         };
         ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
-        if (result == ContentDialogResult.Primary && listView.SelectedItem is string selectedUri)
+        if (result == ContentDialogResult.Primary && listView.SelectedItems.Count > 0)
         {
-            ResourceUriBox.Text = selectedUri;
+            HashSet<string> existing = ResourceUrisBox.Text
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToHashSet();
+            foreach (object item in listView.SelectedItems)
+            {
+                if (item is string uri)
+                {
+                    existing.Add(uri);
+                }
+            }
+
+            ResourceUrisBox.Text = string.Join("\n", existing);
         }
     }
 
@@ -512,26 +529,31 @@ internal sealed partial class MainWindow : Window
                 return;
             }
 
-            if (uris.Count == 1)
-            {
-                ResourceUriBox.Text = uris[0];
-                return;
-            }
-
-            var listView = new ListView { ItemsSource = uris, SelectedIndex = 0, MaxHeight = 160 };
+            var listView = new ListView { ItemsSource = uris, SelectionMode = ListViewSelectionMode.Multiple, MaxHeight = 160 };
             var selectDialog = new ContentDialog
             {
-                Title = "Resource URI を選択",
+                Title = "追加する Resource URI を選択",
                 Content = listView,
-                PrimaryButtonText = "選択",
+                PrimaryButtonText = "追加",
                 CloseButtonText = "キャンセル",
                 DefaultButton = ContentDialogButton.Primary,
                 XamlRoot = Content.XamlRoot,
             };
             ContentDialogResult result = await selectDialog.ShowAsync(ContentDialogPlacement.Popup);
-            if (result == ContentDialogResult.Primary && listView.SelectedItem is string selectedUri)
+            if (result == ContentDialogResult.Primary && listView.SelectedItems.Count > 0)
             {
-                ResourceUriBox.Text = selectedUri;
+                HashSet<string> existing = ResourceUrisBox.Text
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToHashSet();
+                foreach (object item in listView.SelectedItems)
+                {
+                    if (item is string selectedUri)
+                    {
+                        existing.Add(selectedUri);
+                    }
+                }
+
+                ResourceUrisBox.Text = string.Join("\n", existing);
             }
         }
         catch (Exception ex)
@@ -550,6 +572,16 @@ internal sealed partial class MainWindow : Window
         SaveCurrentSettings();
     }
 
+    private void OnLauncherRoleChanged(object sender, RoutedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        SaveCurrentSettings();
+    }
+
     private void SaveCurrentSettings()
     {
         try
@@ -557,21 +589,36 @@ internal sealed partial class MainWindow : Window
             string commandPath = CommandPathBox.Text;
             string arguments = ArgumentsBox.Text;
             string gatewayUrl = GatewayUrlBox.Text;
-            string resourceUri = ResourceUriBox.Text;
+            List<string> resourceUris = ResourceUrisBox.Text
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct()
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+            if (resourceUris.Count == 0)
+            {
+                return;
+            }
+
             int timeoutMs = double.IsNaN(TimeoutBox.Value) ? 60000 : (int)TimeoutBox.Value;
 
-            string launcherPath = LauncherPathBox.Text;
-            string launcherArguments = LauncherArgumentsBox.Text;
+            string reviewerPath = ReviewerPathBox.Text;
+            string reviewerArguments = ReviewerArgumentsBox.Text;
+            string reviewedPath = ReviewedPathBox.Text;
+            string reviewedArguments = ReviewedArgumentsBox.Text;
+            string launcherRole = ReviewedRoleRadio.IsChecked == true ? "reviewed" : "reviewer";
             int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 300000 : (int)LauncherTimeoutBox.Value;
 
             _settingsService.UpdateSettings(
                 commandPath,
                 arguments,
                 gatewayUrl,
-                resourceUri,
+                resourceUris,
                 timeoutMs,
-                launcherPath,
-                launcherArguments,
+                reviewerPath,
+                reviewerArguments,
+                reviewedPath,
+                reviewedArguments,
+                launcherRole,
                 launcherTimeoutMs);
         }
         catch

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -408,6 +408,8 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                                     }
                                     catch (Exception notifyEx)
                                     {
+                                        // 通知失敗時は claim を解除して再配信で再試行できるようにする
+                                        UndoMarkAsSeen(reviewEvent.EventId);
                                         await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
                                     }
                                 }
@@ -569,6 +571,32 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         }
     }
 
+    private void UndoMarkAsSeen(string eventId)
+    {
+        if (string.IsNullOrEmpty(eventId))
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _seenEventIds.Remove(eventId);
+            Queue<string> newQueue = new(_eventIdQueue.Where(id => id != eventId));
+            _eventIdQueue.Clear();
+            foreach (string id in newQueue)
+            {
+                _eventIdQueue.Enqueue(id);
+            }
+
+            Queue<CachedReviewEvent> newEvents = new(_recentEvents.Where(e => e.EventId != eventId));
+            _recentEvents.Clear();
+            foreach (CachedReviewEvent e in newEvents)
+            {
+                _recentEvents.Enqueue(e);
+            }
+        }
+    }
+
     private async Task PersistCacheAsync()
     {
         if (_cacheService == null)
@@ -576,19 +604,19 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             return;
         }
 
-        NotificationCache cache;
-        lock (_lock)
-        {
-            cache = new NotificationCache
-            {
-                SeenEventIds = new List<string>(_eventIdQueue),
-                RecentEvents = new List<CachedReviewEvent>(_recentEvents),
-            };
-        }
-
         await _cacheSemaphore.WaitAsync().ConfigureAwait(false);
         try
         {
+            NotificationCache cache;
+            lock (_lock)
+            {
+                cache = new NotificationCache
+                {
+                    SeenEventIds = new List<string>(_eventIdQueue),
+                    RecentEvents = new List<CachedReviewEvent>(_recentEvents),
+                };
+            }
+
             await _cacheService.SaveAsync(cache).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using SquirrelNotifier.WinUI3.Models;
@@ -23,9 +24,11 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
     private readonly Queue<string> _eventIdQueue = new();
     private readonly Queue<CachedReviewEvent> _recentEvents = new();
     private readonly object _lock = new();
+    private readonly ConcurrentDictionary<string, IProcessInstance> _activeProcesses = new();
 
     private Task? _loopTask;
     private CancellationTokenSource? _activeProcessCts;
+    private CancellationTokenSource? _stopCts;
     private IProcessInstance? _activeProcess;
     private SubscriptionState _state = SubscriptionState.Stopped;
     private string _lastError = string.Empty;
@@ -78,20 +81,37 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
 
         LastError = string.Empty;
         State = SubscriptionState.Starting;
-        _loopTask = Task.Run(() => RunSubscriptionLoopAsync(_cts.Token));
+        _stopCts?.Dispose();
+        _stopCts = new CancellationTokenSource();
+        _loopTask = Task.Run(() => RunSubscriptionLoopAsync(_stopCts.Token));
     }
 
     public async Task StopAsync()
     {
         State = SubscriptionState.Stopping;
 
-        // Cancel process first to stop immediately
+        // Cancel the subscription loop (including backoff delays)
+        _stopCts?.Cancel();
+
+        // Cancel all active processes immediately
         _activeProcessCts?.Cancel();
         if (_activeProcess != null)
         {
             try
             {
                 _activeProcess.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        foreach (IProcessInstance process in _activeProcesses.Values)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
             }
             catch
             {
@@ -258,13 +278,33 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         State = SubscriptionState.Running;
         ReportStatus("Subscribed.");
 
+        AppSettings settings = _settingsService.Settings;
+        List<string> uris = settings.ResourceUris.Count > 0
+            ? settings.ResourceUris
+            : new List<string> { settings.ResourceUri };
+
+        if (uris.Count == 1)
+        {
+            await RunSingleUriLoopAsync(uris[0], token).ConfigureAwait(false);
+        }
+        else
+        {
+            await LogAsync($"Starting parallel subscription for {uris.Count} URIs.").ConfigureAwait(false);
+            Task[] tasks = uris.Select(uri => RunSingleUriLoopAsync(uri, token)).ToArray();
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunSingleUriLoopAsync(string resourceUri, CancellationToken token)
+    {
         int retryCount = 0;
         int retryDelayMs = 1000;
 
         while (!token.IsCancellationRequested)
         {
-            _activeProcessCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            CancellationToken processToken = _activeProcessCts.Token;
+            using var loopCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            CancellationToken processToken = loopCts.Token;
+            string processKey = $"{resourceUri}:{Environment.TickCount64}";
 
             try
             {
@@ -299,28 +339,31 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                 psi.ArgumentList.Add(settings.GatewayUrl);
 
                 psi.ArgumentList.Add("--uri");
-                psi.ArgumentList.Add(settings.ResourceUri);
+                psi.ArgumentList.Add(resourceUri);
 
                 psi.ArgumentList.Add("--timeout-ms");
                 psi.ArgumentList.Add(settings.NotificationTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
                 psi.ArgumentList.Add("--json");
 
-                await LogAsync($"Launching subscriber for resource: {settings.ResourceUri}").ConfigureAwait(false);
+                await LogAsync($"Launching subscriber for resource: {resourceUri}").ConfigureAwait(false);
 
-                using (_activeProcess = _processRunner.Start(psi))
+                IProcessInstance process = _processRunner.Start(psi);
+                _activeProcesses[processKey] = process;
+
+                try
                 {
-                    Task<string> stdoutTask = _activeProcess.StandardOutput.ReadToEndAsync(processToken);
-                    Task<string> stderrTask = _activeProcess.StandardError.ReadToEndAsync(processToken);
+                    Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(processToken);
+                    Task<string> stderrTask = process.StandardError.ReadToEndAsync(processToken);
 
-                    await _activeProcess.WaitForExitAsync(processToken).ConfigureAwait(false);
+                    await process.WaitForExitAsync(processToken).ConfigureAwait(false);
 
                     string stdout = await stdoutTask.ConfigureAwait(false);
                     string stderr = await stderrTask.ConfigureAwait(false);
 
-                    if (_activeProcess.ExitCode != 0)
+                    if (process.ExitCode != 0)
                     {
-                        throw new InvalidOperationException($"Subscriber process exited with non-zero code {_activeProcess.ExitCode}. Stderr: {stderr.Trim()}");
+                        throw new InvalidOperationException($"Subscriber process exited with non-zero code {process.ExitCode}. Stderr: {stderr.Trim()}");
                     }
 
                     if (string.IsNullOrWhiteSpace(stdout))
@@ -377,17 +420,21 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     }
                     else
                     {
-                        // Some other state, e.g. normal exit but not a notification
                         await LogAsync($"Subscriber finished execution. Route={result.Route}").ConfigureAwait(false);
                     }
+                }
+                finally
+                {
+                    _activeProcesses.TryRemove(processKey, out _);
+                    process.Dispose();
                 }
 
                 retryCount = 0;
                 retryDelayMs = 1000;
             }
-            catch (OperationCanceledException) when (token.IsCancellationRequested || _activeProcessCts?.IsCancellationRequested == true)
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
-                // Loop or process cancellation (StopAsync/DisposeAsync) — do not retry
+                // Loop cancellation (StopAsync/DisposeAsync) — do not retry
                 break;
             }
             catch (Exception ex)
@@ -400,16 +447,16 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     LastError = friendlyMessage;
                     State = SubscriptionState.Error;
                     ReportStatus($"Error: {friendlyMessage}");
-                    await LogAsync($"Subscription loop error (max retries exceeded) {tag}: {ex.Message}").ConfigureAwait(false);
+                    await LogAsync($"[{resourceUri}] Subscription loop error (max retries exceeded) {tag}: {ex.Message}").ConfigureAwait(false);
                     break;
                 }
 
-                await LogAsync($"Subscription loop error (retry {retryCount}/{_maxRetries}) {tag}: {ex.Message}").ConfigureAwait(false);
+                await LogAsync($"[{resourceUri}] Subscription loop error (retry {retryCount}/{_maxRetries}) {tag}: {ex.Message}").ConfigureAwait(false);
                 ReportStatus($"Retrying ({retryCount}/{_maxRetries})...");
 
                 try
                 {
-                    await Task.Delay(retryDelayMs, processToken).ConfigureAwait(false);
+                    await Task.Delay(retryDelayMs, token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -417,12 +464,6 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                 }
 
                 retryDelayMs = Math.Min(retryDelayMs * 2, 32000);
-            }
-            finally
-            {
-                _activeProcess = null;
-                _activeProcessCts?.Dispose();
-                _activeProcessCts = null;
             }
         }
     }
@@ -567,7 +608,9 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _cts.Cancel();
+        _stopCts?.Cancel();
         _activeProcessCts?.Cancel();
+
         if (_activeProcess != null)
         {
             try
@@ -582,6 +625,22 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             _activeProcess.Dispose();
         }
 
+        foreach (IProcessInstance process in _activeProcesses.Values)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            process.Dispose();
+        }
+
+        _activeProcesses.Clear();
+
         if (_loopTask != null)
         {
             try
@@ -595,6 +654,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         }
 
         _cts.Dispose();
+        _stopCts?.Dispose();
         _activeProcessCts?.Dispose();
     }
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -25,6 +25,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
     private readonly Queue<CachedReviewEvent> _recentEvents = new();
     private readonly object _lock = new();
     private readonly ConcurrentDictionary<string, IProcessInstance> _activeProcesses = new();
+    private readonly SemaphoreSlim _cacheSemaphore = new(1, 1);
 
     private Task? _loopTask;
     private CancellationTokenSource? _activeProcessCts;
@@ -389,7 +390,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     {
                         await LogAsync($"Notification payload received: {result.FinalText}").ConfigureAwait(false);
 
-                        List<ReviewEvent> reviewEvents = ReviewEventParser.Parse(result.FinalText);
+                        List<ReviewEvent> reviewEvents = ReviewEventParser.Parse(result.FinalText, resourceUri);
                         if (reviewEvents.Count == 0)
                         {
                             await LogAsync($"Warning: Malformed or unsupported review event payload received: {result.FinalText}").ConfigureAwait(false);
@@ -398,22 +399,21 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                         {
                             foreach (ReviewEvent reviewEvent in reviewEvents)
                             {
-                                if (HasBeenSeen(reviewEvent.EventId))
-                                {
-                                    await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
-                                }
-                                else
+                                if (TryMarkAsSeen(reviewEvent.EventId, reviewEvent))
                                 {
                                     try
                                     {
                                         _notificationService.NotifyReviewEvent(reviewEvent);
-                                        MarkAsSeen(reviewEvent.EventId, reviewEvent);
                                         await PersistCacheAsync().ConfigureAwait(false);
                                     }
                                     catch (Exception notifyEx)
                                     {
                                         await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
                                     }
+                                }
+                                else
+                                {
+                                    await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
                                 }
                             }
                         }
@@ -478,7 +478,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         await _loggingService.WriteAsync(message).ConfigureAwait(false);
     }
 
-    private bool HasBeenSeen(string eventId)
+    private bool TryMarkAsSeen(string eventId, ReviewEvent? reviewEvent = null)
     {
         if (string.IsNullOrEmpty(eventId))
         {
@@ -487,28 +487,17 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
 
         lock (_lock)
         {
-            return _seenEventIds.Contains(eventId);
-        }
-    }
-
-    private void MarkAsSeen(string eventId, ReviewEvent? reviewEvent = null)
-    {
-        if (string.IsNullOrEmpty(eventId))
-        {
-            return;
-        }
-
-        lock (_lock)
-        {
-            if (_seenEventIds.Add(eventId))
+            if (!_seenEventIds.Add(eventId))
             {
-                _eventIdQueue.Enqueue(eventId);
+                return false;
+            }
 
-                while (_eventIdQueue.Count > 100)
-                {
-                    string oldId = _eventIdQueue.Dequeue();
-                    _seenEventIds.Remove(oldId);
-                }
+            _eventIdQueue.Enqueue(eventId);
+
+            while (_eventIdQueue.Count > 100)
+            {
+                string oldId = _eventIdQueue.Dequeue();
+                _seenEventIds.Remove(oldId);
             }
 
             if (reviewEvent != null)
@@ -529,6 +518,8 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     _recentEvents.Dequeue();
                 }
             }
+
+            return true;
         }
     }
 
@@ -595,6 +586,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
             };
         }
 
+        await _cacheSemaphore.WaitAsync().ConfigureAwait(false);
         try
         {
             await _cacheService.SaveAsync(cache).ConfigureAwait(false);
@@ -602,6 +594,10 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         catch (Exception ex)
         {
             await LogAsync($"[WARN] Cache save failed: {ex.Message}").ConfigureAwait(false);
+        }
+        finally
+        {
+            _cacheSemaphore.Release();
         }
     }
 
@@ -656,6 +652,7 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
         _cts.Dispose();
         _stopCts?.Dispose();
         _activeProcessCts?.Dispose();
+        _cacheSemaphore.Dispose();
     }
 
     internal static (string FriendlyMessage, string ErrorTag) GetErrorInfo(string rawError)

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -408,8 +408,9 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                                     }
                                     catch (Exception notifyEx)
                                     {
-                                        // 通知失敗時は claim を解除して再配信で再試行できるようにする
+                                        // 通知失敗時は claim を解除し、ディスクにも反映して再起動後の duplicate 扱いを防ぐ
                                         UndoMarkAsSeen(reviewEvent.EventId);
+                                        await PersistCacheAsync().ConfigureAwait(false);
                                         await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
                                     }
                                 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewEventParser.cs
@@ -12,7 +12,7 @@ namespace SquirrelNotifier.WinUI3.Services;
 
 internal static class ReviewEventParser
 {
-    public static List<ReviewEvent> Parse(string? json)
+    public static List<ReviewEvent> Parse(string? json, string? sourceUri = null)
     {
         List<ReviewEvent> events = new List<ReviewEvent>();
         if (string.IsNullOrWhiteSpace(json))
@@ -37,7 +37,7 @@ internal static class ReviewEventParser
                     {
                         try
                         {
-                            ReviewEvent reviewEvent = ConvertToEvent(candidate);
+                            ReviewEvent reviewEvent = ConvertToEvent(candidate, sourceUri);
                             events.Add(reviewEvent);
                         }
                         catch (Exception ex)
@@ -56,6 +56,11 @@ internal static class ReviewEventParser
                     reviewEvent.Validate();
                     if (UrlValidator.IsSafeGitHubUrl(reviewEvent.PrUrl, reviewEvent.Repository, reviewEvent.PrNumber))
                     {
+                        if (!string.IsNullOrEmpty(sourceUri))
+                        {
+                            reviewEvent.Source = sourceUri;
+                        }
+
                         events.Add(reviewEvent);
                         return events;
                     }
@@ -67,7 +72,7 @@ internal static class ReviewEventParser
                 {
                     try
                     {
-                        ReviewEvent converted = ConvertToEvent(candidate);
+                        ReviewEvent converted = ConvertToEvent(candidate, sourceUri);
                         events.Add(converted);
                     }
                     catch (Exception ex)
@@ -85,7 +90,7 @@ internal static class ReviewEventParser
         return events;
     }
 
-    private static ReviewEvent ConvertToEvent(ReviewCandidate candidate)
+    private static ReviewEvent ConvertToEvent(ReviewCandidate candidate, string? sourceUri = null)
     {
         if (string.IsNullOrEmpty(candidate.Owner) || string.IsNullOrEmpty(candidate.Repo))
         {
@@ -103,7 +108,8 @@ internal static class ReviewEventParser
 
         string eventId = $"evt_{safeOwner}_{safeRepo}_{candidate.PrNumber}_{safeReason}_{safeQueuedAt}";
 
-        string source = !string.IsNullOrEmpty(candidate.RequestedBy) ? candidate.RequestedBy : "thread-owl";
+        string source = !string.IsNullOrEmpty(sourceUri) ? sourceUri
+            : !string.IsNullOrEmpty(candidate.RequestedBy) ? candidate.RequestedBy : "thread-owl";
         string message = !string.IsNullOrEmpty(candidate.RequestedBy)
             ? $"{candidate.Reason} by {candidate.RequestedBy}"
             : candidate.Reason;

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -65,8 +65,12 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber}").ConfigureAwait(false);
 
         AppSettings settings = _settingsService.Settings;
-        string commandPath = settings.LauncherCommandPath;
-        string argumentsTemplate = settings.LauncherArguments;
+
+        // re-review-requests URI は常に reviewer スロット、queue URI は LauncherRole で切り替え
+        bool useReviewer = reviewEvent.Source.Contains("re-review-requests", StringComparison.OrdinalIgnoreCase)
+            || settings.LauncherRole == "reviewer";
+        string commandPath = useReviewer ? settings.ReviewerLauncherCommandPath : settings.ReviewedLauncherCommandPath;
+        string argumentsTemplate = useReviewer ? settings.ReviewerLauncherArguments : settings.ReviewedLauncherArguments;
         int timeoutMs = settings.LauncherTimeoutMs;
 
         _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -37,6 +37,24 @@ internal sealed class SettingsService
 
         _settings = LoadSettings();
 
+        // 旧単一 ResourceUri を ResourceUris リストに移行する
+        if (_settings.ResourceUris.Count == 0)
+        {
+            _settings.ResourceUris.Add(_settings.ResourceUri);
+            SaveSettings();
+        }
+
+        // 旧単一スロット設定をユーザーがカスタマイズしていた場合、reviewer スロットに移行する
+        const string legacyDefaultLauncherPath = "review-raven";
+        if (_settings.LauncherCommandPath != legacyDefaultLauncherPath
+            && _settings.ReviewerLauncherCommandPath == "claude")
+        {
+            _settings.ReviewerLauncherCommandPath = _settings.LauncherCommandPath;
+            _settings.ReviewerLauncherArguments = _settings.LauncherArguments;
+            _settings.LauncherCommandPath = legacyDefaultLauncherPath;
+            SaveSettings();
+        }
+
         if (_settings.SubscriberCommandPath == "mcp-resource-subscriber")
         {
             // Lazy pnpm probe: only runs when the default command name needs resolution.
@@ -193,10 +211,13 @@ internal sealed class SettingsService
         string commandPath,
         string arguments,
         string gatewayUrl,
-        string resourceUri,
+        IReadOnlyList<string> resourceUris,
         int timeoutMs,
-        string launcherCommandPath,
-        string launcherArguments,
+        string reviewerLauncherCommandPath,
+        string reviewerLauncherArguments,
+        string reviewedLauncherCommandPath,
+        string reviewedLauncherArguments,
+        string launcherRole,
         int launcherTimeoutMs)
     {
         if (string.IsNullOrWhiteSpace(commandPath))
@@ -209,9 +230,10 @@ internal sealed class SettingsService
             throw new ArgumentException("Gateway URL must be a valid http/https absolute URL", nameof(gatewayUrl));
         }
 
-        if (string.IsNullOrWhiteSpace(resourceUri))
+        ArgumentNullException.ThrowIfNull(resourceUris);
+        if (resourceUris.Count == 0 || resourceUris.Any(string.IsNullOrWhiteSpace))
         {
-            throw new ArgumentException("Resource URI cannot be empty", nameof(resourceUri));
+            throw new ArgumentException("Resource URIs must contain at least one non-empty URI", nameof(resourceUris));
         }
 
         if (timeoutMs <= 0 || timeoutMs > 300000)
@@ -219,9 +241,19 @@ internal sealed class SettingsService
             throw new ArgumentOutOfRangeException(nameof(timeoutMs), "Timeout must be between 1 and 300000 ms");
         }
 
-        if (string.IsNullOrWhiteSpace(launcherCommandPath))
+        if (string.IsNullOrWhiteSpace(reviewerLauncherCommandPath))
         {
-            throw new ArgumentException("Launcher command path cannot be empty", nameof(launcherCommandPath));
+            throw new ArgumentException("Reviewer launcher command path cannot be empty", nameof(reviewerLauncherCommandPath));
+        }
+
+        if (string.IsNullOrWhiteSpace(reviewedLauncherCommandPath))
+        {
+            throw new ArgumentException("Reviewed launcher command path cannot be empty", nameof(reviewedLauncherCommandPath));
+        }
+
+        if (launcherRole != "reviewer" && launcherRole != "reviewed")
+        {
+            throw new ArgumentException("Launcher role must be 'reviewer' or 'reviewed'", nameof(launcherRole));
         }
 
         if (launcherTimeoutMs <= 0 || launcherTimeoutMs > 300000)
@@ -232,10 +264,14 @@ internal sealed class SettingsService
         _settings.SubscriberCommandPath = commandPath;
         _settings.SubscriberArguments = arguments;
         _settings.GatewayUrl = gatewayUrl;
-        _settings.ResourceUri = resourceUri;
+        _settings.ResourceUris = new List<string>(resourceUris);
+        _settings.ResourceUri = resourceUris[0];
         _settings.NotificationTimeoutMs = timeoutMs;
-        _settings.LauncherCommandPath = launcherCommandPath;
-        _settings.LauncherArguments = launcherArguments;
+        _settings.ReviewerLauncherCommandPath = reviewerLauncherCommandPath;
+        _settings.ReviewerLauncherArguments = reviewerLauncherArguments;
+        _settings.ReviewedLauncherCommandPath = reviewedLauncherCommandPath;
+        _settings.ReviewedLauncherArguments = reviewedLauncherArguments;
+        _settings.LauncherRole = launcherRole;
         _settings.LauncherTimeoutMs = launcherTimeoutMs;
         SaveSettings();
     }
@@ -249,13 +285,30 @@ internal sealed class AppSettings
 
     public string GatewayUrl { get; set; } = "http://localhost:3000";
 
+    // 旧フィールド（後方互換; 新設定は ResourceUris を使用）
     public string ResourceUri { get; set; } = "queue://review/queue";
+
+    public List<string> ResourceUris { get; set; } = new();
 
     public int NotificationTimeoutMs { get; set; } = 60000;
 
+    // 旧フィールド（後方互換のため残す; UI からは削除済み）
     public string LauncherCommandPath { get; set; } = "review-raven";
 
     public string LauncherArguments { get; set; } = "review --interactive --repo {owner}/{repo} --pr {prNumber}";
+
+    // reviewer-side スロット
+    public string ReviewerLauncherCommandPath { get; set; } = "claude";
+
+    public string ReviewerLauncherArguments { get; set; } = "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+
+    // reviewed-side スロット
+    public string ReviewedLauncherCommandPath { get; set; } = "claude";
+
+    public string ReviewedLauncherArguments { get; set; } = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
+
+    // queue://review/queue に対して使うロール ("reviewer" | "reviewed")
+    public string LauncherRole { get; set; } = "reviewer";
 
     public int LauncherTimeoutMs { get; set; } = 300000;
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -54,16 +54,9 @@ internal sealed class SettingsService
 
             if (pathCustomized || argsCustomized)
             {
-                if (pathCustomized)
-                {
-                    _settings.ReviewerLauncherCommandPath = _settings.LauncherCommandPath;
-                    _settings.LauncherCommandPath = legacyDefaultLauncherPath;
-                }
-
-                if (argsCustomized)
-                {
-                    _settings.ReviewerLauncherArguments = _settings.LauncherArguments;
-                }
+                // どちらかがカスタマイズされていれば path/args を組として reviewer スロットへ移行する
+                _settings.ReviewerLauncherCommandPath = _settings.LauncherCommandPath;
+                _settings.ReviewerLauncherArguments = _settings.LauncherArguments;
             }
 
             _settings.LauncherSlotsMigrated = true;

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -44,14 +44,29 @@ internal sealed class SettingsService
             SaveSettings();
         }
 
-        // 旧単一スロット設定をユーザーがカスタマイズしていた場合、reviewer スロットに移行する
-        const string legacyDefaultLauncherPath = "review-raven";
-        if (_settings.LauncherCommandPath != legacyDefaultLauncherPath
-            && _settings.ReviewerLauncherCommandPath == "claude")
+        // 旧単一スロット設定（path または arguments がカスタマイズ済み）を reviewer スロットに移行する
+        if (!_settings.LauncherSlotsMigrated)
         {
-            _settings.ReviewerLauncherCommandPath = _settings.LauncherCommandPath;
-            _settings.ReviewerLauncherArguments = _settings.LauncherArguments;
-            _settings.LauncherCommandPath = legacyDefaultLauncherPath;
+            const string legacyDefaultLauncherPath = "review-raven";
+            const string legacyDefaultLauncherArgs = "review --interactive --repo {owner}/{repo} --pr {prNumber}";
+            bool pathCustomized = _settings.LauncherCommandPath != legacyDefaultLauncherPath;
+            bool argsCustomized = _settings.LauncherArguments != legacyDefaultLauncherArgs;
+
+            if (pathCustomized || argsCustomized)
+            {
+                if (pathCustomized)
+                {
+                    _settings.ReviewerLauncherCommandPath = _settings.LauncherCommandPath;
+                    _settings.LauncherCommandPath = legacyDefaultLauncherPath;
+                }
+
+                if (argsCustomized)
+                {
+                    _settings.ReviewerLauncherArguments = _settings.LauncherArguments;
+                }
+            }
+
+            _settings.LauncherSlotsMigrated = true;
             SaveSettings();
         }
 
@@ -309,6 +324,8 @@ internal sealed class AppSettings
 
     // queue://review/queue に対して使うロール ("reviewer" | "reviewed")
     public string LauncherRole { get; set; } = "reviewer";
+
+    public bool LauncherSlotsMigrated { get; set; }
 
     public int LauncherTimeoutMs { get; set; } = 300000;
 


### PR DESCRIPTION
## Summary

Epic #87 のサブタスク #91 と #92 を実装。

### #91 ランチャー 2 スロット化・claude CLI 対応

- `AppSettings` に **reviewer-side / reviewed-side の 2 スロット** を追加
  - `ReviewerLauncherCommandPath/Arguments`、`ReviewedLauncherCommandPath/Arguments`、`LauncherRole`
- デフォルト設定を `review-raven` から `claude -p "/thread-owl-pr-reviewer ..."` / `claude -p "/thread-owl-review-cycle ..."` に変更
- `ReviewLauncherService`: `ReviewEvent.Source` が `re-review-requests` を含む場合は常に reviewer スロットを使用し、それ以外は `LauncherRole` 設定で切り替え
- `LauncherArgumentBuilder` に `{reason}` プレースホルダーを追加（`_safeNameRegex` で検証）
- `SettingsService` コンストラクタで旧単一スロット設定を reviewer スロットへ自動移行
- Settings UI に RadioButton（reviewer/reviewed）と各スロットの Path/Arguments 欄を追加

### #92 複数 URI 並行購読対応

- `AppSettings.ResourceUris`（`List<string>`）追加、旧 `ResourceUri` からの自動移行
- Settings UI の Resource URI 欄を複数行 TextBox（`ResourceUrisBox`、1 行 1 URI）に変更
- `UpdateSettings` シグネチャを `IReadOnlyList<string> resourceUris` に変更（空リスト・空白エントリは `ArgumentException`）
- `McpSubscriptionService` に `_stopCts` フィールドを追加し、`StopAsync()` で Cancel してバックオフ遅延を即座にキャンセルできるよう修正
- 複数 URI を `Task.WhenAll` で並行購読、`_activeProcesses`（`ConcurrentDictionary`）で全プロセスを追跡。`StopAsync()`/`DisposeAsync()` で全プロセスをキル

## 含まれない変更

- #93（PR 作成トリガーによる購読の自動開始）: thread-owl/mcp-gateway 側の入力契約が未確定のため実装を保留。#93 は open のまま残す。
- Epic #87 は #93 が残っているためクローズしない。

## Test plan

- [x] `McpSubscriptionServiceTests` 45 件パス（`StopAsync_ShouldCancelBackoffDelayPromptly`、`Start_WithMultipleResourceUris_ShouldLaunchProcessForEachUri`、`StopAsync_WithMultipleResourceUris_ShouldStopAllLoopsPromptly` 含む）
- [x] `ReviewLauncherServiceTests` 全件パス（スロット選択 3 ケース含む）
- [x] `SettingsServiceTests` 全件パス（`UpdateSettings_ShouldThrowForEmptyResourceUris`、`UpdateSettings_ShouldThrowForBlankResourceUri` 含む）
- [x] `LauncherArgumentBuilderTests` 全件パス（`{reason}` プレースホルダーテスト含む）
- [x] 全 182 件パス（pre-push hook のカバレッジチェック通過）

Closes #91
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)