### PR TITLE
fix: Resource URI 複数行 TextBox の改行文字を \r/\n 両対応に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Settings の Resource URI 複数行 TextBox で、`Enter` 入力による改行が `\r`（WinUI3 TextBox の既定の改行文字）であるため `Split('\n')` では分割されず、複数 URI を手入力すると1要素に `\r` が混入したまま保存されていた不具合を修正。`\r` と `\n` の両方で分割するように変更（#111 の手動検証で発見）
+
 ### Added
 - ランチャー設定を reviewer-side / reviewed-side の 2 スロット化。Settings に「起動ロール」（reviewer / reviewed）の RadioButton と、各スロットの Path・Arguments 入力欄を追加。`ReviewEvent.Source` が `queue://review/re-review-requests` の場合は常に reviewer スロットを使用し、`queue://review/queue` の場合は LauncherRole 設定で切り替える（#91）
 - `LauncherArgumentBuilder` に `{reason}` プレースホルダーを追加。`reviewEvent.Reason`（`opened` / `synchronized` / `re-review-requested` 等）を引数テンプレートに埋め込めるようになった。値は既存の `_safeNameRegex` で検証する（#91）

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -477,6 +477,8 @@ internal sealed partial class MainWindow : Window
         "queue://review/re-review-requests",
     ];
 
+    private static readonly char[] _resourceUriLineSeparators = ['\r', '\n'];
+
     private async void OnSelectResourceUriClick(object sender, RoutedEventArgs e)
     {
         var listView = new ListView { ItemsSource = _knownResourceUris, SelectionMode = ListViewSelectionMode.Multiple, MaxHeight = 160 };
@@ -493,7 +495,7 @@ internal sealed partial class MainWindow : Window
         if (result == ContentDialogResult.Primary && listView.SelectedItems.Count > 0)
         {
             HashSet<string> existing = ResourceUrisBox.Text
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Split(_resourceUriLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToHashSet();
             foreach (object item in listView.SelectedItems)
             {
@@ -543,7 +545,7 @@ internal sealed partial class MainWindow : Window
             if (result == ContentDialogResult.Primary && listView.SelectedItems.Count > 0)
             {
                 HashSet<string> existing = ResourceUrisBox.Text
-                    .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Split(_resourceUriLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .ToHashSet();
                 foreach (object item in listView.SelectedItems)
                 {
@@ -590,7 +592,7 @@ internal sealed partial class MainWindow : Window
             string arguments = ArgumentsBox.Text;
             string gatewayUrl = GatewayUrlBox.Text;
             List<string> resourceUris = ResourceUrisBox.Text
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Split(_resourceUriLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Distinct()
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .ToList();


### PR DESCRIPTION
## Summary
- Settings の Resource URI 複数行 TextBox（`ResourceUrisBox`）の保存・追加処理3箇所（`SaveCurrentSettings` / `OnAddResourceUriClick` / `OnFetchResourceUriFromMcpClick`）が `Split('\n')` のみだったため、WinUI3 TextBox の Enter 入力で挿入される `\r` を分割できず、複数 URI を手入力すると1要素に両方の URI が `\r` 連結された状態で保存されていた
- `\r` と `\n` の両方を分割文字に含める `static readonly char[]` フィールドに変更

## 発見経緯
Issue #111（全手動レビューサイクル検証）で実際に Settings 画面から `queue://review/queue` と `queue://review/re-review-requests` の2行を入力・保存したところ、`settings.json` に `"queue://review/queue\rqueue://review/re-review-requests"` という1要素の壊れた文字列が保存され、`McpSubscriptionService` が単一 URI として誤動作する不具合を実機で確認した。

## Test plan
- [x] `dotnet build winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64` 成功
- [x] `dotnet test winui3/SquirrelNotifier.WinUI3.sln` 191件全件成功（カバレッジ 90.12%/85.49%/95.52%）
- [x] `dotnet format winui3/SquirrelNotifier.WinUI3.sln --verify-no-changes` 差分なし
- [x] 実機検証: 修正版ビルドで `settings.json` の壊れた `ResourceUris` を手動修正後、Settings 画面から複数 URI を再入力・保存 → ログで `Starting parallel subscription for 2 URIs.` と各 URI が個別に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)