### PR TITLE
fix: 購読 timeout 満了での恒久停止とランチャー出力の文字化けを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `queue://review/*` の購読ループで、待機時間内にイベントが無い正常な満了（`route=timeout` / `errorCode=NOTIFICATION_TIMEOUT`）を購読失敗として扱い、リトライを消費して最大リトライ超過で購読が恒久停止していた不具合を修正。`NOTIFICATION_TIMEOUT` はリトライを消費せずそのまま再購読へ進むようにした。subscriber が timeout 時に非ゼロ終了することがあるため、終了コードより先に stdout の JSON で idle timeout を判定する（#111 の手動検証で発見）
+- レビュー起動結果ダイアログの標準出力・標準エラーが文字化けする不具合を修正。GUI プロセスにはコンソールが無く、リダイレクトした子プロセス出力の既定エンコーディングが UTF-8 に解決されないため、`ReviewLauncherService` と `McpSubscriptionService` の `ProcessStartInfo` に `StandardOutputEncoding` / `StandardErrorEncoding = UTF-8` を明示した（#111 の手動検証で発見）
 - Settings の Resource URI 複数行 TextBox で、`Enter` 入力による改行が `\r`（WinUI3 TextBox の既定の改行文字）であるため `Split('\n')` では分割されず、複数 URI を手入力すると1要素に `\r` が混入したまま保存されていた不具合を修正。`\r` と `\n` の両方で分割するように変更（#111 の手動検証で発見）
 
 ### Added

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -120,6 +120,58 @@ public class McpSubscriptionServiceTests : IDisposable
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task Start_ShouldResubscribeWithoutConsumingRetryOnNotificationTimeout(int exitCode)
+    {
+        // Arrange: NOTIFICATION_TIMEOUT は待機満了の正常応答。subscriber は非ゼロ終了することがある
+        string timeoutJson = JsonSerializer.Serialize(new SubscriptionResult
+        {
+            Route = "timeout",
+            ErrorCode = "NOTIFICATION_TIMEOUT",
+            Subscribed = true,
+            NotificationReceived = false,
+        });
+
+        var preflightProcess = CreateMockProcess(0, "help", "");
+
+        var mockRunner = new Mock<IProcessRunner>();
+        int subscriptionStartCount = 0;
+
+        var testCts = new CancellationTokenSource();
+
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Returns<ProcessStartInfo>(psi =>
+            {
+                if (psi.ArgumentList.Contains("--help"))
+                {
+                    return preflightProcess;
+                }
+
+                subscriptionStartCount++;
+                if (subscriptionStartCount >= 2)
+                {
+                    testCts.Cancel();
+                }
+
+                return CreateMockProcess(exitCode, timeoutJson, "auth token source: cache");
+            });
+
+        // maxRetries: 0 → エラー扱いなら 1 回目のプロセス終了で即 max retries exceeded になる
+        var service = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, mockRunner.Object, maxRetries: 0);
+        var runMethod = typeof(McpSubscriptionService).GetMethod("RunSubscriptionLoopAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Act
+        var task = (Task)runMethod!.Invoke(service, new object[] { testCts.Token })!;
+        await task;
+
+        // Assert: リトライを消費せず 2 回目の購読プロセスが起動している
+        subscriptionStartCount.Should().BeGreaterThanOrEqualTo(2);
+        service.State.Should().NotBe(SubscriptionState.Error);
+        service.LastError.Should().BeEmpty();
+    }
+
+    [Theory]
     [InlineData("failed", "ERR_01", "Gateway failed")]
     [InlineData("timeout", null, "Timeout occurred")]
     public async Task Start_ShouldTransitionToErrorOnFailureJson(string route, string? errorCode, string message)

--- a/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/McpSubscriptionService.cs
@@ -231,6 +231,8 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+                StandardErrorEncoding = System.Text.Encoding.UTF8,
             };
             psi.ArgumentList.Add("--help");
 
@@ -317,6 +319,8 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
+                    StandardOutputEncoding = System.Text.Encoding.UTF8,
+                    StandardErrorEncoding = System.Text.Encoding.UTF8,
                 };
 
                 // Add token env
@@ -362,68 +366,91 @@ internal sealed class McpSubscriptionService : IAsyncDisposable
                     string stdout = await stdoutTask.ConfigureAwait(false);
                     string stderr = await stderrTask.ConfigureAwait(false);
 
-                    if (process.ExitCode != 0)
+                    // NOTIFICATION_TIMEOUT は待機時間内にイベントが無かっただけの正常な満了。
+                    // subscriber は timeout でも非ゼロ終了するため、終了コードより先に stdout で判定し、
+                    // リトライを消費せずに再購読へ進む。
+                    SubscriptionResult? result = null;
+                    JsonException? parseError = null;
+                    if (!string.IsNullOrWhiteSpace(stdout))
+                    {
+                        try
+                        {
+                            result = JsonSerializer.Deserialize<SubscriptionResult>(stdout);
+                        }
+                        catch (JsonException ex)
+                        {
+                            parseError = ex;
+                        }
+                    }
+
+                    bool isIdleTimeout = result?.Route == "timeout" && result.ErrorCode == "NOTIFICATION_TIMEOUT";
+
+                    if (isIdleTimeout)
+                    {
+                        await LogAsync($"[{resourceUri}] No notification within timeout window; re-subscribing.").ConfigureAwait(false);
+                    }
+                    else if (process.ExitCode != 0)
                     {
                         throw new InvalidOperationException($"Subscriber process exited with non-zero code {process.ExitCode}. Stderr: {stderr.Trim()}");
                     }
-
-                    if (string.IsNullOrWhiteSpace(stdout))
+                    else if (parseError != null)
                     {
-                        throw new JsonException("Subscriber process output was empty.");
+                        throw parseError;
                     }
-
-                    // Parse JSON
-                    SubscriptionResult? result = JsonSerializer.Deserialize<SubscriptionResult>(stdout);
-                    if (result == null)
+                    else if (result == null)
                     {
-                        throw new JsonException("Failed to deserialize subscriber output JSON.");
-                    }
-
-                    result.Validate();
-
-                    if (result.Route == "failed" || result.Route == "timeout" || result.ErrorCode != null)
-                    {
-                        throw new InvalidOperationException($"Subscription failure: Route={result.Route}, ErrorCode={result.ErrorCode}, Message={result.FinalText}");
-                    }
-
-                    if (result.Route == "subscription" && result.NotificationReceived == true)
-                    {
-                        await LogAsync($"Notification payload received: {result.FinalText}").ConfigureAwait(false);
-
-                        List<ReviewEvent> reviewEvents = ReviewEventParser.Parse(result.FinalText, resourceUri);
-                        if (reviewEvents.Count == 0)
-                        {
-                            await LogAsync($"Warning: Malformed or unsupported review event payload received: {result.FinalText}").ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            foreach (ReviewEvent reviewEvent in reviewEvents)
-                            {
-                                if (TryMarkAsSeen(reviewEvent.EventId, reviewEvent))
-                                {
-                                    try
-                                    {
-                                        _notificationService.NotifyReviewEvent(reviewEvent);
-                                        await PersistCacheAsync().ConfigureAwait(false);
-                                    }
-                                    catch (Exception notifyEx)
-                                    {
-                                        // 通知失敗時は claim を解除し、ディスクにも反映して再起動後の duplicate 扱いを防ぐ
-                                        UndoMarkAsSeen(reviewEvent.EventId);
-                                        await PersistCacheAsync().ConfigureAwait(false);
-                                        await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
-                                    }
-                                }
-                                else
-                                {
-                                    await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
-                                }
-                            }
-                        }
+                        throw new JsonException(string.IsNullOrWhiteSpace(stdout)
+                            ? "Subscriber process output was empty."
+                            : "Failed to deserialize subscriber output JSON.");
                     }
                     else
                     {
-                        await LogAsync($"Subscriber finished execution. Route={result.Route}").ConfigureAwait(false);
+                        result.Validate();
+
+                        if (result.Route == "failed" || result.Route == "timeout" || result.ErrorCode != null)
+                        {
+                            throw new InvalidOperationException($"Subscription failure: Route={result.Route}, ErrorCode={result.ErrorCode}, Message={result.FinalText}");
+                        }
+
+                        if (result.Route == "subscription" && result.NotificationReceived == true)
+                        {
+                            await LogAsync($"Notification payload received: {result.FinalText}").ConfigureAwait(false);
+
+                            List<ReviewEvent> reviewEvents = ReviewEventParser.Parse(result.FinalText, resourceUri);
+                            if (reviewEvents.Count == 0)
+                            {
+                                await LogAsync($"Warning: Malformed or unsupported review event payload received: {result.FinalText}").ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                foreach (ReviewEvent reviewEvent in reviewEvents)
+                                {
+                                    if (TryMarkAsSeen(reviewEvent.EventId, reviewEvent))
+                                    {
+                                        try
+                                        {
+                                            _notificationService.NotifyReviewEvent(reviewEvent);
+                                            await PersistCacheAsync().ConfigureAwait(false);
+                                        }
+                                        catch (Exception notifyEx)
+                                        {
+                                            // 通知失敗時は claim を解除し、ディスクにも反映して再起動後の duplicate 扱いを防ぐ
+                                            UndoMarkAsSeen(reviewEvent.EventId);
+                                            await PersistCacheAsync().ConfigureAwait(false);
+                                            await LogAsync($"Error: Failed to show Windows notification: {notifyEx.Message}").ConfigureAwait(false);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        await LogAsync($"Duplicate event ignored: {reviewEvent.EventId}").ConfigureAwait(false);
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            await LogAsync($"Subscriber finished execution. Route={result.Route}").ConfigureAwait(false);
+                        }
                     }
                 }
                 finally

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -92,6 +92,8 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+                StandardErrorEncoding = System.Text.Encoding.UTF8,
             };
 
             // Build and add safe arguments


### PR DESCRIPTION
## 概要

#111 の全手動レビューサイクル検証（実機・閉域 smoke test）で発見した 2 件の不具合を修正します。いずれも #93（PR 作成トリガーによる自動購読開始）の常時稼働運用では致命的になるため、先行して修正します。

## 修正内容

### 1. `NOTIFICATION_TIMEOUT` での購読恒久停止（重大）

`queue://review/*` の購読ループで、待機時間内にイベントが無かっただけの**正常な満了**（`route=timeout` / `errorCode=NOTIFICATION_TIMEOUT`）を購読失敗として扱っていました。このためリトライを消費し、最大リトライ超過で購読が**恒久停止**していました（イベントが来ない限り必ず数分で停止する）。

- `NOTIFICATION_TIMEOUT` はリトライを消費せず、そのまま再購読へ進むように修正
- `mcp-resource-subscriber` は timeout 時に**非ゼロ終了することがある**ため、終了コードより先に stdout の JSON で idle timeout を判定するよう順序を変更

**実機確認**: 修正後、イベントが無い状態で約 62 秒周期の再購読が持続することを確認（旧実装では 5 分で停止していた）。

### 2. ランチャー結果ダイアログの標準出力が文字化け

GUI プロセスにはコンソールが無く、リダイレクトした子プロセス出力の既定エンコーディングが UTF-8 に解決されないため、「レビューを起動」結果ダイアログの標準出力・標準エラーが文字化けしていました（`綢ャ綢薙H…` のような表示）。

- `ReviewLauncherService` と `McpSubscriptionService` の `ProcessStartInfo` に `StandardOutputEncoding` / `StandardErrorEncoding = UTF-8` を明示

**実機確認**: 修正後、`claude` CLI の日本語出力が正しく表示されることを確認。

## テスト

- 回帰テストとして、`NOTIFICATION_TIMEOUT` でリトライを消費せず再購読することを検証するパラメータ化テストを追加（subscriber の終了コード 0 / 1 の両方）
- 既存 191 件 + 追加 2 件、計 **193 件全通過**（回帰なし）

## 関連

- #111（全手動レビューサイクル検証）
- #93（PR 作成トリガーによる自動購読開始 — 本修正はその前提整備）

🤖 Generated with [Claude Code](https://claude.com/claude-code)