### PR TITLE
fix: single-instance ガードを追加し二重起動での queue 二重購読を防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- single-instance ガードが無く、アプリを 2 回起動すると 2 インスタンスが同時に常駐して同一 Resource URI を並行購読してしまう不具合を修正。Windows App SDK の `AppInstance.FindOrRegisterForKey` + `RedirectActivationToAsync` による instance redirection を導入し、2 個目の起動はアクティブ化イベントを既存インスタンスへリダイレクトして自身は起動せず終了する。既存インスタンス側はリダイレクトを受け取るとウィンドウを前面化する（#116）
 - `queue://review/*` の購読ループで、待機時間内にイベントが無い正常な満了（`route=timeout` / `errorCode=NOTIFICATION_TIMEOUT`）を購読失敗として扱い、リトライを消費して最大リトライ超過で購読が恒久停止していた不具合を修正。`NOTIFICATION_TIMEOUT` はリトライを消費せずそのまま再購読へ進むようにした。subscriber が timeout 時に非ゼロ終了することがあるため、終了コードより先に stdout の JSON で idle timeout を判定する（#111 の手動検証で発見）
 - レビュー起動結果ダイアログの標準出力・標準エラーが文字化けする不具合を修正。GUI プロセスにはコンソールが無く、リダイレクトした子プロセス出力の既定エンコーディングが UTF-8 に解決されないため、`ReviewLauncherService` と `McpSubscriptionService` の `ProcessStartInfo` に `StandardOutputEncoding` / `StandardErrorEncoding = UTF-8` を明示した（#111 の手動検証で発見）
 - Settings の Resource URI 複数行 TextBox で、`Enter` 入力による改行が `\r`（WinUI3 TextBox の既定の改行文字）であるため `Split('\n')` では分割されず、複数 URI を手入力すると1要素に `\r` が混入したまま保存されていた不具合を修正。`\r` と `\n` の両方で分割するように変更（#111 の手動検証で発見）

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -75,14 +75,27 @@ public partial class App : Application
             _window.HideWindowToTray();
         }
 
+        Program.Reactivated += OnReactivated;
+
         _subscriptionService.Start();
     }
 
     private void OnWindowClosed(object sender, WindowEventArgs args)
     {
+        Program.Reactivated -= OnReactivated;
         _notificationService.OpenAppRequested -= OnOpenAppRequested;
         _subscriptionService.DisposeAsync().AsTask().ConfigureAwait(false);
         _autoUpdateService.Dispose();
+    }
+
+    private void OnReactivated(object? sender, Microsoft.Windows.AppLifecycle.AppActivationArguments e)
+    {
+        // 二重起動を検知した別プロセスからリダイレクトされた場合、既存インスタンスのウィンドウを前面化する
+        _ = _loggingService.WriteAsync("[INFO] 二重起動を検知。既存インスタンスのウィンドウを前面化します。");
+        if (_window != null)
+        {
+            _window.DispatcherQueue.TryEnqueue(() => _window.ShowWindowFromTray());
+        }
     }
 
     private void OnOpenAppRequested(object? sender, EventArgs e)

--- a/winui3/SquirrelNotifier.WinUI3/Program.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Program.cs
@@ -3,9 +3,11 @@
 // </copyright>
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
+using SquirrelNotifier.WinUI3.Services;
 
 namespace SquirrelNotifier.WinUI3;
 
@@ -15,7 +17,37 @@ internal static class Program
     // アプリの二重起動判定に使う固定キー。値そのものに意味はなく、他アプリと衝突しなければよい。
     private const string _singleInstanceKey = "SquirrelNotifier-SingleInstance-4F1B8C2E";
 
-    internal static event EventHandler<AppActivationArguments>? Reactivated;
+    private static readonly object _reactivationLock = new();
+    private static EventHandler<AppActivationArguments>? _reactivated;
+    private static AppActivationArguments? _pendingActivation;
+
+    internal static event EventHandler<AppActivationArguments>? Reactivated
+    {
+        add
+        {
+            AppActivationArguments? pending;
+            lock (_reactivationLock)
+            {
+                _reactivated += value;
+                pending = _pendingActivation;
+                _pendingActivation = null;
+            }
+
+            // 購読開始前に届いていたリダイレクトを取りこぼさず再送する
+            if (pending != null)
+            {
+                value?.Invoke(null, pending);
+            }
+        }
+
+        remove
+        {
+            lock (_reactivationLock)
+            {
+                _reactivated -= value;
+            }
+        }
+    }
 
     [STAThread]
     private static void Main(string[] args)
@@ -42,12 +74,55 @@ internal static class Program
 
         if (mainInstance.IsCurrent)
         {
-            mainInstance.Activated += (sender, args) => Reactivated?.Invoke(sender, args);
+            mainInstance.Activated += OnActivatedByRedirection;
             return false;
         }
 
         // 既に起動済みのインスタンスへアクティブ化イベントをリダイレクトし、自身は起動せず終了する
-        mainInstance.RedirectActivationToAsync(activationArgs).AsTask().GetAwaiter().GetResult();
+        RedirectActivationTo(activationArgs, mainInstance);
         return true;
+    }
+
+    private static void OnActivatedByRedirection(object? sender, AppActivationArguments args)
+    {
+        lock (_reactivationLock)
+        {
+            if (_reactivated == null)
+            {
+                // まだ購読者がいない（起動シーケンス完了前）場合は保持し、購読開始時に再送する
+                _pendingActivation = args;
+                return;
+            }
+        }
+
+        _reactivated?.Invoke(sender, args);
+    }
+
+    // STA スレッドで RedirectActivationToAsync を直接ブロック待機すると、公式ガイダンス
+    // (Redirecting but not blocking) の通りリダイレクトが失敗しうるため、実際の呼び出しは
+    // 別スレッドで実行し、STA スレッドは COM を伴わない Semaphore でのみ完了を待つ。
+    // https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing#redirecting-but-not-blocking
+    private static void RedirectActivationTo(AppActivationArguments activationArgs, AppInstance mainInstance)
+    {
+        using var redirectCompleted = new Semaphore(0, 1);
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                mainInstance.RedirectActivationToAsync(activationArgs).AsTask().Wait();
+            }
+            catch (Exception ex)
+            {
+                // リダイレクト失敗時も未処理例外で 2 個目のプロセスをクラッシュさせず終了させる
+                _ = new LoggingService().WriteAsync($"[WARN] 既存インスタンスへのリダイレクトに失敗しました: {ex.Message}");
+            }
+            finally
+            {
+                redirectCompleted.Release();
+            }
+        });
+
+        redirectCompleted.WaitOne();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Program.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Program.cs
@@ -1,0 +1,53 @@
+// <copyright file="Program.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
+
+namespace SquirrelNotifier.WinUI3;
+
+[ExcludeFromCodeCoverage]
+internal static class Program
+{
+    // アプリの二重起動判定に使う固定キー。値そのものに意味はなく、他アプリと衝突しなければよい。
+    private const string _singleInstanceKey = "SquirrelNotifier-SingleInstance-4F1B8C2E";
+
+    internal static event EventHandler<AppActivationArguments>? Reactivated;
+
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+
+        if (DecideRedirection())
+        {
+            return;
+        }
+
+        Application.Start(p =>
+        {
+            var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+            SynchronizationContext.SetSynchronizationContext(context);
+            _ = new App();
+        });
+    }
+
+    private static bool DecideRedirection()
+    {
+        AppActivationArguments activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
+        AppInstance mainInstance = AppInstance.FindOrRegisterForKey(_singleInstanceKey);
+
+        if (mainInstance.IsCurrent)
+        {
+            mainInstance.Activated += (sender, args) => Reactivated?.Invoke(sender, args);
+            return false;
+        }
+
+        // 既に起動済みのインスタンスへアクティブ化イベントをリダイレクトし、自身は起動せず終了する
+        mainInstance.RedirectActivationToAsync(activationArgs).AsTask().GetAwaiter().GetResult();
+        return true;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
+++ b/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
@@ -25,6 +25,8 @@
     <AnalysisMode>All</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <!-- single-instance 判定を Program.cs のカスタム Main で行うため、XAML 生成の既定 Main を無効化する -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
     <WarningsNotAsErrors>CA1515</WarningsNotAsErrors>
     <NoWarn>$(NoWarn);CA1001;CA1003;CA1014;CA1031;CA1063;CA1303;CA1816;CA1822;CA1823;CA1848;CA1849;CA1869;CA2007;CA2016;CA2216;CA5392;SA0001;SA1101;SA1312;SA1600;SA1601;SA1633;SA1200;SA1201;SA1202;SA1203;SA1204;SA1214;SA1402;SA1649;SA1309</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Windows App SDK の `AppInstance.FindOrRegisterForKey` + `RedirectActivationToAsync` による instance redirection を導入し、squirrel-notifier の二重起動を防止
- 2 個目の起動はアクティブ化イベントを既存インスタンスへリダイレクトして自身は `Application.Start` せず終了する（`Program.cs` に自前の `Main` を実装、WinUI3 生成の既定 Main は `DISABLE_XAML_GENERATED_MAIN` で無効化）
- 既存インスタンス側は `Program.Reactivated` イベントを受け取ると `ShowWindowFromTray()`（通知クリック時と同じ経路）でウィンドウを前面化する

Closes #116

## Test plan
- [x] `dotnet build`（Debug / Release, x64）成功
- [x] 既存テストスイート 193 件全て成功（回帰なし、カバレッジ低下なし）
- [x] 実機で `--tray` オプションを付けて 2 回連続起動を複数回実施し、常に 1 プロセスのみが残ること・ログに「二重起動を検知」が 1 回だけ記録され購読開始ログも 1 系統のみであることを確認
- [x] tray 常駐中に通常起動（2 個目）した際、既存ウィンドウが前面化されることをスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)