### PR TITLE
[codex] MSIの同一バージョン更新で重複登録を防ぐ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,23 @@ jobs:
       - name: Build solution
         run: dotnet build ${{ env.SOLUTION_PATH }} --configuration Release --no-restore /p:Platform=x64 /p:IncludeWindowsSdkBuildTools=false
 
+      - name: Verify MSI MajorUpgrade
+        shell: pwsh
+        run: |
+          $payloadDir = (New-Item -ItemType Directory -Path "./installer-test-payload" -Force).FullName
+          New-Item -ItemType File -Path (Join-Path $payloadDir "SquirrelNotifier.WinUI3.exe") -Force | Out-Null
+          $outputDir = (New-Item -ItemType Directory -Path "./installer-test-output" -Force).FullName
+          dotnet build winui3/SquirrelNotifier.Installer/SquirrelNotifier.Installer.wixproj `
+            --configuration Release `
+            /p:Platform=x64 `
+            /p:HarvestPath="$payloadDir" `
+            /p:PackageVersion=1.2.3 `
+            /p:OutputPath="$outputDir"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $msi = Get-ChildItem -Path $outputDir -Filter "*.msi" -Recurse | Select-Object -First 1
+          if (-not $msi) { throw "検証用 MSI が見つかりません: $outputDir" }
+          ./scripts/test-msi-major-upgrade.ps1 -MsiPath $msi.FullName
+
       - name: Run tests with coverage
         run: |
           foreach ($type in @("line", "branch", "method")) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           /p:OutputPath="$msiOutDir"
         $msi = Get-ChildItem -Path $msiOutDir -Filter "*.msi" -Recurse | Select-Object -First 1
         if (-not $msi) { throw "MSI ファイルが見つかりませんでした: $msiOutDir" }
+        ./scripts/test-msi-major-upgrade.ps1 -MsiPath $msi.FullName
         $msiName = "SquirrelNotifier-Setup-$version-$platform.msi"
         Copy-Item -Path $msi.FullName -Destination "./$msiName"
         echo "MSI_NAME=$msiName" >> $env:GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- MSI を同一バージョンで再ビルドした場合でも、旧 ProductCode の製品を MajorUpgrade で置き換えるように修正。生成 MSI の Upgrade table を CI とリリース時に検証する回帰チェックも追加（#117）
 - single-instance ガードが無く、アプリを 2 回起動すると 2 インスタンスが同時に常駐して同一 Resource URI を並行購読してしまう不具合を修正。Windows App SDK の `AppInstance.FindOrRegisterForKey` + `RedirectActivationToAsync` による instance redirection を導入し、2 個目の起動はアクティブ化イベントを既存インスタンスへリダイレクトして自身は起動せず終了する。既存インスタンス側はリダイレクトを受け取るとウィンドウを前面化する（#116）
 - `queue://review/*` の購読ループで、待機時間内にイベントが無い正常な満了（`route=timeout` / `errorCode=NOTIFICATION_TIMEOUT`）を購読失敗として扱い、リトライを消費して最大リトライ超過で購読が恒久停止していた不具合を修正。`NOTIFICATION_TIMEOUT` はリトライを消費せずそのまま再購読へ進むようにした。subscriber が timeout 時に非ゼロ終了することがあるため、終了コードより先に stdout の JSON で idle timeout を判定する（#111 の手動検証で発見）
 - レビュー起動結果ダイアログの標準出力・標準エラーが文字化けする不具合を修正。GUI プロセスにはコンソールが無く、リダイレクトした子プロセス出力の既定エンコーディングが UTF-8 に解決されないため、`ReviewLauncherService` と `McpSubscriptionService` の `ProcessStartInfo` に `StandardOutputEncoding` / `StandardErrorEncoding = UTF-8` を明示した（#111 の手動検証で発見）

--- a/scripts/test-msi-major-upgrade.ps1
+++ b/scripts/test-msi-major-upgrade.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+    MSI が同一バージョンの MajorUpgrade を検出できることを検証します。
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
+    [string]$MsiPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-ComMethod {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Target,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [object[]]$Arguments = @()
+    )
+
+    return $Target.GetType().InvokeMember(
+        $Name,
+        [System.Reflection.BindingFlags]::InvokeMethod,
+        $null,
+        $Target,
+        $Arguments)
+}
+
+function Get-ComProperty {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Target,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [object[]]$Arguments = @()
+    )
+
+    return $Target.GetType().InvokeMember(
+        $Name,
+        [System.Reflection.BindingFlags]::GetProperty,
+        $null,
+        $Target,
+        $Arguments)
+}
+
+function Get-MsiRows {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Database,
+
+        [Parameter(Mandatory)]
+        [string]$Query
+    )
+
+    $view = Invoke-ComMethod -Target $Database -Name 'OpenView' -Arguments @($Query)
+    try {
+        Invoke-ComMethod -Target $view -Name 'Execute' | Out-Null
+        while ($record = Invoke-ComMethod -Target $view -Name 'Fetch') {
+            try {
+                $fieldCount = Get-ComProperty -Target $record -Name 'FieldCount'
+                $row = for ($index = 1; $index -le $fieldCount; $index++) {
+                    Get-ComProperty -Target $record -Name 'StringData' -Arguments @($index)
+                }
+                ,$row
+            }
+            finally {
+                [System.Runtime.InteropServices.Marshal]::ReleaseComObject($record) | Out-Null
+            }
+        }
+    }
+    finally {
+        Invoke-ComMethod -Target $view -Name 'Close' | Out-Null
+        [System.Runtime.InteropServices.Marshal]::ReleaseComObject($view) | Out-Null
+    }
+}
+
+$resolvedMsiPath = (Resolve-Path -LiteralPath $MsiPath).Path
+$installer = New-Object -ComObject WindowsInstaller.Installer
+$database = $null
+try {
+    $database = Invoke-ComMethod -Target $installer -Name 'OpenDatabase' -Arguments @($resolvedMsiPath, 0)
+
+    $properties = @{}
+    foreach ($row in Get-MsiRows -Database $database -Query 'SELECT * FROM `Property`') {
+        $properties[$row[0]] = $row[1]
+    }
+
+    $productVersion = $properties['ProductVersion']
+    if ([string]::IsNullOrWhiteSpace($productVersion)) {
+        throw "MSI の ProductVersion を取得できません: $resolvedMsiPath"
+    }
+
+    $upgradeRow = Get-MsiRows -Database $database -Query 'SELECT * FROM `Upgrade`' |
+        Where-Object { $_[6] -eq 'WIX_UPGRADE_DETECTED' } |
+        Select-Object -First 1
+
+    if ($null -eq $upgradeRow) {
+        throw "MSI に WIX_UPGRADE_DETECTED の Upgrade table 行がありません: $resolvedMsiPath"
+    }
+
+    $versionMax = $upgradeRow[2]
+    $attributes = [int]$upgradeRow[4]
+    $versionMaxInclusive = 0x200
+
+    if ($versionMax -ne $productVersion -or ($attributes -band $versionMaxInclusive) -eq 0) {
+        throw "同一バージョンの MajorUpgrade が有効ではありません: ProductVersion=$productVersion, VersionMax=$versionMax, Attributes=$attributes"
+    }
+
+    Write-Host "MSI MajorUpgrade 検証に成功しました: ProductVersion=$productVersion, Attributes=$attributes"
+}
+finally {
+    if ($null -ne $database) {
+        [System.Runtime.InteropServices.Marshal]::ReleaseComObject($database) | Out-Null
+    }
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject($installer) | Out-Null
+}

--- a/winui3/SquirrelNotifier.Installer/Package.wxs
+++ b/winui3/SquirrelNotifier.Installer/Package.wxs
@@ -18,7 +18,9 @@
 
     <SummaryInformation Description="Squirrel Notifier - MCP リソース更新通知アプリ" />
 
-    <MajorUpgrade DowngradeErrorMessage="新しいバージョンの Squirrel Notifier がすでにインストールされています。" />
+    <!-- 同一バージョンの再ビルドでも、旧 ProductCode の製品を置き換える。 -->
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  DowngradeErrorMessage="新しいバージョンの Squirrel Notifier がすでにインストールされています。" />
     <MediaTemplate EmbedCab="yes" />
 
     <!-- インストール先: %LocalAppData%\Programs\SquirrelNotifier\ -->

--- a/winui3/SquirrelNotifier.Installer/SquirrelNotifier.Installer.wixproj
+++ b/winui3/SquirrelNotifier.Installer/SquirrelNotifier.Installer.wixproj
@@ -12,8 +12,8 @@
     <DefineConstants>PackageVersion=$(PackageVersion);HarvestPath=$(HarvestPath)</DefineConstants>
     <!-- WiX 7 OSMF EULA 同意 -->
     <AcceptEula>wix7</AcceptEula>
-    <!-- perUser + Files 要素の組み合わせで発生する ICE バリデーションエラーを抑制 -->
-    <SuppressIces>ICE03;ICE38;ICE64;ICE91</SuppressIces>
+    <!-- perUser + Files 要素と、意図的な同一バージョン置換で発生する ICE を抑制 -->
+    <SuppressIces>ICE03;ICE38;ICE61;ICE64;ICE91</SuppressIces>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要

- WiX `MajorUpgrade` で同一バージョンの再ビルドを置換対象に含めるようにしました
- 生成 MSI の `Upgrade` table が同一 `ProductVersion` を含むことを検証する PowerShell スクリプトを追加しました
- PR CI とリリース用 MSI 生成時の両方で回帰検証を実行します

## 原因と影響

ProductCode はビルドごとに生成される一方、従来の `MajorUpgrade` は同一 `ProductVersion` を検出範囲に含めていませんでした。そのため同一バージョンの再ビルドをインストールすると、既存製品を置き換えず別製品として登録されていました。

`AllowSameVersionUpgrades="yes"` により、固定 UpgradeCode に紐づく同一バージョンの旧製品も置き換え対象になります。

## 検証

- `dotnet build winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64`
- `dotnet test winui3/SquirrelNotifier.WinUI3.sln -c Release --no-build -p:Platform=x64` (193 tests passed)
- `dotnet format winui3/SquirrelNotifier.WinUI3.sln --verify-no-changes`
- 検証用 MSI を生成し、`ProductVersion=1.2.3` / `Upgrade.Attributes=513` を確認
- pre-commit / pre-push hooks passed

Closes #117
