### PR TITLE
chore: v0.2.0 へバージョンバンプ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-05
+
 ### Fixed
 - mcp-resource-subscriber が `AUTH_LOGIN_REQUIRED`、`invalid_token` などの再認証を要するエラーを返した場合、汎用の接続エラーではなく「認証が必要です」と通知するように修正（#113）。レビュー対応として、認証必須バルーンの文言重複を解消し、非ゼロ終了時の例外メッセージに stdout / JSON パース失敗情報を含めて原因特定しやすくし、401 判定時のメッセージに `MCP_PROBE_AUTH_TOKEN` 設定不備の可能性も併記するように調整。さらに、serverUrl のポート番号や resourceUri のパスセグメントとして単独の `401` が現れるケースでも誤って認証エラーと分類されないよう、`GetErrorInfo` を構造化された `result.ErrorCode` 優先で判定する設計に変更。`RESOURCE_NOT_FOUND` 等の意味が確定した非認証コードのみホワイトリストで legacy マッチングをスキップし、`INTERNAL_ERROR` / `SUBSCRIPTION_FAILED` のような詳細不明な汎用コードでは stderr の認証エラー詳細を見逃さないよう legacy マッチングにフォールバックする。さらに、`SUBSCRIPTION_FAILED` は実際には詳細を握りつぶし JSON stdout に resourceUri 等の URL・URI のみを返す出力契約であるため、legacy マッチングの判定対象を stdout 全文ではなく stderr / result.FinalText のみの診断テキストに限定し、URI パスセグメントとしての `401` による誤判定も回避する（#120）
 - MSI を同一バージョンで再ビルドした場合でも、旧 ProductCode の製品を MajorUpgrade で置き換えるように修正。生成 MSI の Upgrade table を CI とリリース時に検証する回帰チェックも追加（#117）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 開発用ツールセットの Python プロジェクト名を `squirrel-notifier-devtools` に変更
 - トレイ通知のイベント発生時、レビュー URL 開くボタンを（今回のスコープ外のため）一旦削除
 
-[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.0...v0.1.1

--- a/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
+++ b/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
@@ -5,9 +5,9 @@
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.1.3</Version>
-    <AssemblyVersion>0.1.3.0</AssemblyVersion>
-    <FileVersion>0.1.3.0</FileVersion>
+    <Version>0.2.0</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\squirrel-notifier.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary
- `SquirrelNotifier.WinUI3.csproj` の `Version` / `AssemblyVersion` / `FileVersion` を `0.1.3` → `0.2.0` に更新
- `CHANGELOG.md` の `[Unreleased]` を `[0.2.0] - 2026-07-05` として確定

新機能追加（レートリミット事前通知予約、PR URL enqueue によるレビューサイクル手動開始、ランチャー 2 スロット化、MCP Resource URI 動的取得、複数 URI 並行購読 等）が中心のため minor バンプとしています。

## Test plan
- [x] pre-commit（dotnet-build / dotnet-format / quality-and-security）通過
- [x] pre-push（dotnet-test with coverage）通過
- [ ] マージ後、`v0.2.0` タグを push して release workflow の実行を確認
