### PR TITLE
fix: 通知ボタン押下時にアプリが反応しない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正。実行中プロセスで通知アクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があるため、購読順序を入れ替えた。また、アプリ未起動時に通知ボタンから新プロセスが起動された場合は `NotificationInvoked` が発火しないため、`OnLaunched` で activation kind が `AppNotification` の場合に起動引数（`openUrl` / `launchReview` / `openApp`）を処理し、ウィンドウを表示するようにした（#130）
+- レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正。実行中プロセスで通知アクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があるため、購読順序を入れ替えた。また、アプリ未起動時に通知ボタンから新プロセスが起動された場合は `NotificationInvoked` が発火しないため、`OnLaunched` で activation kind が `AppNotification` の場合に起動引数（`openUrl` / `launchReview` / `openApp`）を処理し、ウィンドウを表示するようにした（#130）。レビュー対応として、`NotificationService.Initialize()` を `Register()` より前に呼ぶよう順序を変えたことで、self-contained モードで `Insights.Resource.dll` が見つからない環境では `Initialize()` 側でも同じ `COMException` が発生しうるため、`Register()` と同条件で捕捉して警告ログに落とし、起動クラッシュを防ぐようにした
 
 ## [0.2.0] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正。実行中プロセスで通知アクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があるため、購読順序を入れ替えた。また、アプリ未起動時に通知ボタンから新プロセスが起動された場合は `NotificationInvoked` が発火しないため、`OnLaunched` で activation kind が `AppNotification` の場合に起動引数（`openUrl` / `launchReview` / `openApp`）を処理し、ウィンドウを表示するようにした（#130）
+
 ## [0.2.0] - 2026-07-05
 
 ### Fixed

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -38,22 +38,20 @@ public partial class App : Application
             _ = _loggingService.WriteAsync($"[WARN] CacheService の初期化に失敗。キャッシュなしで起動します: {ex.Message}");
         }
 
-        bool notificationRegistered = false;
+        // 実行中プロセスで通知アクティベーションを受け取るには、NotificationInvoked の
+        // 購読を Register() より前に行う必要がある（#130）。
+        // https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/notifications/app-notifications/app-notifications-quickstart
+        _notificationService.Initialize();
+        _notificationService.OpenAppRequested += OnOpenAppRequested;
+
         try
         {
             AppNotificationManager.Default.Register();
-            notificationRegistered = true;
         }
         catch (System.Runtime.InteropServices.COMException ex) when (ex.Message.Contains("Insights.Resource.dll", StringComparison.Ordinal))
         {
             // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題
             _ = _loggingService.WriteAsync($"[WARN] AppNotificationManager.Register() 失敗（{ex.HResult:X8}）: {ex.Message}");
-        }
-
-        if (notificationRegistered)
-        {
-            _notificationService.Initialize();
-            _notificationService.OpenAppRequested += OnOpenAppRequested;
         }
 
         _subscriptionService = new McpSubscriptionService(_settingsService, _notificationService, _loggingService, cacheService: _cacheService);
@@ -65,9 +63,15 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        Microsoft.Windows.AppLifecycle.AppActivationArguments activationArgs =
+            Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
+        bool isNotificationActivation =
+            activationArgs.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.AppNotification;
+
         // Check for command-line arguments
         string[] commandLineArgs = Environment.GetCommandLineArgs();
-        bool showWindow = !commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t");
+        bool showWindow = isNotificationActivation
+            || (!commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t"));
 
         _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, _enqueueReviewService, _rateLimitReminderService, showWindow);
         _window.Closed += OnWindowClosed;
@@ -82,6 +86,14 @@ public partial class App : Application
         Program.Reactivated += OnReactivated;
 
         _subscriptionService.Start();
+
+        // アプリ未起動時に通知ボタンから起動された場合、NotificationInvoked は発火しない
+        // ため、起動引数（openUrl / launchReview / openApp）をここで処理する（#130）
+        if (isNotificationActivation
+            && activationArgs.Data is Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs notificationArgs)
+        {
+            _notificationService.HandleActivation(notificationArgs);
+        }
     }
 
     private void OnWindowClosed(object sender, WindowEventArgs args)

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -41,7 +41,17 @@ public partial class App : Application
         // 実行中プロセスで通知アクティベーションを受け取るには、NotificationInvoked の
         // 購読を Register() より前に行う必要がある（#130）。
         // https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/notifications/app-notifications/app-notifications-quickstart
-        _notificationService.Initialize();
+        try
+        {
+            _notificationService.Initialize();
+        }
+        catch (System.Runtime.InteropServices.COMException ex) when (ex.Message.Contains("Insights.Resource.dll", StringComparison.Ordinal))
+        {
+            // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題。
+            // Register() と同条件で発生しうるため、ここで捕捉せず起動クラッシュさせない。
+            _ = _loggingService.WriteAsync($"[WARN] NotificationService.Initialize() 失敗（{ex.HResult:X8}）: {ex.Message}");
+        }
+
         _notificationService.OpenAppRequested += OnOpenAppRequested;
 
         try

--- a/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
@@ -106,6 +106,14 @@ internal sealed class NotificationService : INotificationService
 
     private void OnNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
     {
+        HandleActivation(args);
+    }
+
+    // アプリ未起動時に通知ボタンから新プロセスが起動された場合は NotificationInvoked が
+    // 発火しないため、起動時アクティベーション引数（AppActivationArguments.Data）にも
+    // 同じ処理を適用できるように公開している。
+    public void HandleActivation(AppNotificationActivatedEventArgs args)
+    {
         if (args.Arguments.TryGetValue("action", out string? action))
         {
             if (action == "openUrl" && args.Arguments.TryGetValue("url", out string? url))


### PR DESCRIPTION
Closes #130

## 概要

レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正します。

## 変更内容

### 1. `NotificationInvoked` の購読を `Register()` より前に移動（第一容疑の修正）

Windows App SDK の[公式ドキュメント](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/notifications/app-notifications/app-notifications-quickstart)のとおり、実行中プロセスでアクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があります。`App` コンストラクタで `_notificationService.Initialize()` を `Register()` の前に移動しました。

これに伴い、`Register()` が失敗した場合でもイベント配線自体は行われるようになったため、`notificationRegistered` フラグは削除しました（失敗時の warning ログは維持）。

### 2. アプリ未起動時の通知アクティベーション処理を追加

アプリ未起動時に通知ボタンを押すと新プロセスが `ExtendedActivationKind.AppNotification` で起動されますが、この経路では `NotificationInvoked` は発火しません。`OnLaunched` で activation kind を判別し、`AppNotification` の場合は:

- ウィンドウを表示する（`--tray` 指定より優先）
- 起動引数（`openUrl` / `launchReview` / `openApp`）を `NotificationService.HandleActivation`（`NotificationInvoked` ハンドラと同一ロジック）で処理する

なお `launchReview` は新プロセスではイベント履歴（UI 一覧）が復元されないため、対象イベントが見つからない場合はログ出力のうえウィンドウ表示のみとなります（従来はプロセス起動すらされなかったため改善）。

## 確認方法

1. トレイ常駐中にレビューイベント通知を発生させ、「アプリを開く」を押す → ウィンドウが前面表示されること
2. アプリ未起動の状態で通知ボタンを押す → アプリが起動しウィンドウが表示されること
3. 「PRを開く」「レビューを起動」も同一経路のため合わせて確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)