### PR TITLE
feat: イベント行キャプションに PR 番号を表示しハイパーリンク化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Recent review events のイベント行キャプションに PR 番号を表示するようにした（`owner/repo #123` 形式）。キャプションは `HyperlinkButton` になり、クリックで PR を直接開ける（URL は既存の `UrlValidator.IsSafeGitHubUrl` で検証）。これに伴い行の「PRを開く」ボタンは削除し、行 UI のボタン過密を緩和した（#129）
+
 ### Fixed
 - レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正。実行中プロセスで通知アクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があるため、購読順序を入れ替えた。また、アプリ未起動時に通知ボタンから新プロセスが起動された場合は `NotificationInvoked` が発火しないため、`OnLaunched` で activation kind が `AppNotification` の場合に起動引数（`openUrl` / `launchReview` / `openApp`）を処理し、ウィンドウを表示するようにした（#130）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Recent review events のイベント行キャプションに PR 番号を表示するようにした（`owner/repo #123` 形式）。キャプションは `HyperlinkButton` になり、クリックで PR を直接開ける（URL は既存の `UrlValidator.IsSafeGitHubUrl` で検証）。これに伴い行の「PRを開く」ボタンは削除し、行 UI のボタン過密を緩和した（#129）
+- Recent review events のイベント行キャプションに PR 番号を表示するようにした（`owner/repo #123` 形式）。キャプションは `HyperlinkButton` になり、クリックで PR を直接開ける（URL は既存の `UrlValidator.IsSafeGitHubUrl` で検証）。これに伴い行の「PRを開く」ボタンは削除し、行 UI のボタン過密を緩和した（#129）。レビュー対応として、`PrNumber` が 0 以下（JSON 未指定等）の場合は `owner/repo #0` のような無効なキャプションにならないよう `Repository` のみへフォールバックするようにし、`AutomationProperties.Name` の固定文字列指定を削除して `Content`（`PrCaption`）がそのままアクセシブル名として使われるようにした（スクリーンリーダーで全リンクが同一名に聞こえる問題を解消）
 
 ### Fixed
 - レビューイベントのトースト通知で「アプリを開く」等のボタンを押しても反応しない不具合を修正。実行中プロセスで通知アクティベーションを受け取るには `NotificationInvoked` ハンドラの登録を `AppNotificationManager.Register()` より前に行う必要があるため、購読順序を入れ替えた。また、アプリ未起動時に通知ボタンから新プロセスが起動された場合は `NotificationInvoked` が発火しないため、`OnLaunched` で activation kind が `AppNotification` の場合に起動引数（`openUrl` / `launchReview` / `openApp`）を処理し、ウィンドウを表示するようにした（#130）。レビュー対応として、`NotificationService.Initialize()` を `Register()` より前に呼ぶよう順序を変えたことで、self-contained モードで `Insights.Resource.dll` が見つからない環境では `Initialize()` 側でも同じ `COMException` が発生しうるため、`Register()` と同条件で捕捉して警告ログに落とし、起動クラッシュを防ぐようにした

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -181,12 +181,15 @@
                                 <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,2">
                                     <StackPanel Grid.Column="0" Spacing="2">
                                         <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap" FontWeight="Medium"/>
-                                        <TextBlock Text="{x:Bind Repository}" FontSize="11" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
+                                        <HyperlinkButton Content="{x:Bind PrCaption}"
+                                                         AutomationProperties.Name="PRを開く"
+                                                         Click="OnOpenPrClick"
+                                                         CommandParameter="{x:Bind PrUrl}"
+                                                         FontSize="11"
+                                                         Padding="0"
+                                                         HorizontalAlignment="Left"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                                        <Button Content="PRを開く"
-                                                Click="OnOpenPrClick"
-                                                CommandParameter="{x:Bind PrUrl}"/>
                                         <Button Content="レビュー起動"
                                                 Click="OnLaunchReviewClick"
                                                 CommandParameter="{x:Bind}"/>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -182,7 +182,6 @@
                                     <StackPanel Grid.Column="0" Spacing="2">
                                         <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap" FontWeight="Medium"/>
                                         <HyperlinkButton Content="{x:Bind PrCaption}"
-                                                         AutomationProperties.Name="PRを開く"
                                                          Click="OnOpenPrClick"
                                                          CommandParameter="{x:Bind PrUrl}"
                                                          FontSize="11"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -856,7 +856,7 @@ internal sealed partial class MainWindow : Window
 
     private void OnOpenPrClick(object sender, RoutedEventArgs e)
     {
-        if (sender is Button button && button.CommandParameter is string url)
+        if (sender is Microsoft.UI.Xaml.Controls.Primitives.ButtonBase button && button.CommandParameter is string url)
         {
             if (Helpers.UrlValidator.IsSafeGitHubUrl(url))
             {

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
@@ -34,7 +34,7 @@ internal sealed class ReviewEvent
     public DateTime ReceivedTime { get; set; } = DateTime.Now;
 
     [JsonIgnore]
-    public string PrCaption => $"{Repository} #{PrNumber}";
+    public string PrCaption => PrNumber > 0 ? $"{Repository} #{PrNumber}" : Repository;
 
     public void Validate()
     {

--- a/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/ReviewEvent.cs
@@ -33,6 +33,9 @@ internal sealed class ReviewEvent
     [JsonIgnore]
     public DateTime ReceivedTime { get; set; } = DateTime.Now;
 
+    [JsonIgnore]
+    public string PrCaption => $"{Repository} #{PrNumber}";
+
     public void Validate()
     {
         if (string.IsNullOrWhiteSpace(EventId))


### PR DESCRIPTION
Closes #129

> **Note**: #135 (PR スタック 1/4) の上に積んでいます。マージは #135 が先です。

## 概要

Recent review events のイベント行キャプションに PR 番号を表示し、どの PR のイベントか一目で分かるようにします。

## 変更内容

- キャプション 2 行目を `Repository`（例: `owner/repo`）から `owner/repo #123` 形式（`ReviewEvent.PrCaption`）に変更
- おまけ提案どおりキャプションを `HyperlinkButton` にし、クリックで PR を直接開けるようにした
  - URL は既存の `UrlValidator.IsSafeGitHubUrl` で検証（既存の `OnOpenPrClick` を再利用）
  - `HyperlinkButton` は `Button` 派生でないため、`OnOpenPrClick` の sender 判定を `ButtonBase` に変更
- 「PRを開く」ボタンを行から削除し、行 UI 再設計（#127）に向けたボタン過密を緩和

## 確認方法

1. レビューイベント受信後、行キャプション 2 行目が `owner/repo #123` のリンク表示になること
2. リンククリックで既定ブラウザに PR が開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)