### PR TITLE
feat: イベント行に片付け（dismiss）アクションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Recent review events の各行に ✕（片付ける）ボタンを追加し、対応が完了した PR のイベントを一覧から除去できるようにした。除去は行（eventId）単位で、同一 PR の後続イベントは通常どおり表示される。イベント一覧はアプリ再起動時に復元されないため片付け状態の永続化は行わない（#128）
+
 ### Changed
 - Recent review events のイベント行キャプションに PR 番号を表示するようにした（`owner/repo #123` 形式）。キャプションは `HyperlinkButton` になり、クリックで PR を直接開ける（URL は既存の `UrlValidator.IsSafeGitHubUrl` で検証）。これに伴い行の「PRを開く」ボタンは削除し、行 UI のボタン過密を緩和した（#129）
 

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -196,6 +196,13 @@
                                         <Button Content="コマンドをコピー"
                                                 Click="OnCopyLaunchCommandClick"
                                                 CommandParameter="{x:Bind}"/>
+                                        <Button AutomationProperties.Name="イベントを片付ける"
+                                                ToolTipService.ToolTip="このイベントを一覧から片付ける"
+                                                Click="OnDismissEventClick"
+                                                CommandParameter="{x:Bind}"
+                                                Padding="6,4">
+                                            <FontIcon Glyph="&#xE711;" FontSize="12"/>
+                                        </Button>
                                     </StackPanel>
                                 </Grid>
                             </DataTemplate>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -854,6 +854,14 @@ internal sealed partial class MainWindow : Window
         });
     }
 
+    private void OnDismissEventClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.CommandParameter is Models.ReviewEvent reviewEvent)
+        {
+            _reviewEvents.Remove(reviewEvent);
+        }
+    }
+
     private void OnOpenPrClick(object sender, RoutedEventArgs e)
     {
         if (sender is Microsoft.UI.Xaml.Controls.Primitives.ButtonBase button && button.CommandParameter is string url)


### PR DESCRIPTION
Closes #128

> **Note**: #135 → #136 (PR スタック 3/4) の上に積んでいます。マージは #136 が先です。

## 概要

Recent review events の各行に ✕ ボタンを追加し、対応が完了した PR のイベントをユーザーが明示的に一覧から片付けられるようにします。

## 設計論点への回答

Issue の設計論点は以下のとおり最小構成に倒しました。

- **名称と意味**: 「購読終了」は Resource URI 購読の停止と誤解されるため、✕（dismiss）+ ツールチップ「このイベントを一覧から片付ける」を採用。将来 per-PR 購読（#93）に移行した際に実際の購読解除と統合する余地は残る
- **片付けの単位**: `eventId` 単位（押した行のみ除去）。同一 PR の後続イベントは通常どおり表示される
- **永続化**: 不要と判断。UI のイベント一覧はアプリ再起動時に復元されない実装（`NotificationCache.RecentEvents` は重複通知抑止用で UI には流れない）のため、片付け状態を保存する対象が存在しない
- **誤操作対策**: Undo は省略。片付けは通知・購読に影響せず、同一 PR に後続イベントが届けば再表示されるため影響が軽微

## 確認方法

1. イベント行の ✕ を押す → その行だけが一覧から消えること
2. 同一 PR の新しいイベントが届く → 新しい行として表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)