### PR TITLE
feat: 起動ロール設定を廃止しイベント行で両ロールのアクションを提供

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 起動ロールの設定切替を廃止し、イベント行で両ロールのアクションを提供するようにした（#127）
+  - Settings の「起動ロール」ラジオボタンと settings.json の `launcherRole` を削除。ランチャースロットは「どのボタンを押したか」だけで決まるため、`re-review-requests` の reviewer 強制ロジックも不要になり削除
+  - イベント行のアクションを「レビューする」（reviewer スロット起動）と「レビューに対応」（reviewed スロット起動）の 2 つの `SplitButton` に集約。primary クリックで起動、flyout の「コマンドをコピー」で従来どおり起動コマンドをクリップボードへコピーできる
+  - トースト通知の起動ボタンは推奨ロールに基づき「レビューする」（reviewer）を表示する。現行の購読イベント（`opened` / `synchronized` / `re-review-requested`）はいずれも次のアクションが reviewer side のため。reviewed side を推奨するイベント種別（レビューが投稿された等）は queue に未定義のため、未知の reason では起動ボタンを出さず「アプリを開く」で行 UI へ誘導する
+
 ### Added
 - Recent review events の各行に ✕（片付ける）ボタンを追加し、対応が完了した PR のイベントを一覧から除去できるようにした。除去は行（eventId）単位で、同一 PR の後続イベントは通常どおり表示される。イベント一覧はアプリ再起動時に復元されないため片付け状態の永続化は行わない（#128）
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/EnqueueReviewServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/EnqueueReviewServiceTests.cs
@@ -133,7 +133,7 @@ public class EnqueueReviewServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "mcp-resource-subscriber", "--skip-resource-list-check",
             "http://localhost:3000", new[] { "queue://review/queue" }, 30000,
-            "claude", "-p test", "claude", "-p test", "reviewer", 300000);
+            "claude", "-p test", "claude", "-p test", 300000);
 
         Mock<IProcessInstance> callProcess = CreateMockProcess(0, "{\"isError\":false,\"content\":[]}", string.Empty);
         Mock<IProcessInstance> versionProcess = CreateVersionOkMockProcess();

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -355,7 +355,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldPassArgumentsAndSecretsCorrectly()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", "super-secret-token");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -511,7 +511,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldSkipTokenAndArgumentsWhenEmpty()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", null);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -703,7 +703,7 @@ public class McpSubscriptionServiceTests : IDisposable
         await File.WriteAllTextAsync(testCmd, "@echo off\r\nif \"%1\"==\"--help\" (\r\n    exit /b 0\r\n)\r\nexit /b 1\r\n", Encoding.ASCII);
 
         var settingsService = new SettingsService(tempDir);
-        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
 
         var runner = new ProcessRunner();
         await using var service = new McpSubscriptionService(settingsService, _notificationService, _loggingService, runner);
@@ -1101,7 +1101,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "queue://uri-two" },
-            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var launchedUris = new System.Collections.Concurrent.ConcurrentBag<string>();
@@ -1154,7 +1154,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "ratelimit://status/claude" },
-            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var launchedUris = new System.Collections.Concurrent.ConcurrentBag<string>();
@@ -1204,7 +1204,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "ratelimit://status/claude" },
-            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var mockRunner = new Mock<IProcessRunner>();
@@ -1240,7 +1240,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "queue://uri-two" },
-            30000, "review-raven", "", "review-raven", "", "reviewer", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         int retryingCount = 0;

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -64,7 +64,6 @@ public class ReviewLauncherServiceTests : IDisposable
         string reviewerArgs = "--reviewer-arg",
         string reviewedCmd = "reviewed-cmd",
         string reviewedArgs = "--reviewed-arg",
-        string role = "reviewer",
         int timeoutMs = 10000)
     {
         _settingsService.UpdateSettings(
@@ -72,7 +71,7 @@ public class ReviewLauncherServiceTests : IDisposable
             "http://localhost:3000", new[] { "queue://res" }, 30000,
             reviewerCmd, reviewerArgs,
             reviewedCmd, reviewedArgs,
-            role, timeoutMs);
+            timeoutMs);
     }
 
     [Fact]
@@ -101,7 +100,7 @@ public class ReviewLauncherServiceTests : IDisposable
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act
-        LauncherResult result = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+        LauncherResult result = await service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, CancellationToken.None);
 
         // Assert
         result.Success.Should().BeTrue();
@@ -139,12 +138,12 @@ public class ReviewLauncherServiceTests : IDisposable
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act & Assert
-        Task<LauncherResult> firstRunTask = service.LaunchAsync(reviewEvent, CancellationToken.None);
+        Task<LauncherResult> firstRunTask = service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, CancellationToken.None);
 
         // Wait a small delay to make sure the first run has set _isRunning to true
         await Task.Delay(100);
 
-        LauncherResult secondResult = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+        LauncherResult secondResult = await service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, CancellationToken.None);
         secondResult.Success.Should().BeFalse();
         secondResult.ErrorMessage.Should().Contain("already running");
 
@@ -178,7 +177,7 @@ public class ReviewLauncherServiceTests : IDisposable
         using var cts = new CancellationTokenSource();
 
         // Act
-        Task<LauncherResult> launchTask = service.LaunchAsync(reviewEvent, cts.Token);
+        Task<LauncherResult> launchTask = service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, cts.Token);
 
         await Task.Delay(100);
         cts.Cancel();
@@ -216,7 +215,7 @@ public class ReviewLauncherServiceTests : IDisposable
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act
-        LauncherResult result = await service.LaunchAsync(reviewEvent, CancellationToken.None);
+        LauncherResult result = await service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, CancellationToken.None);
 
         // Assert
         result.Success.Should().BeFalse();
@@ -225,26 +224,25 @@ public class ReviewLauncherServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData("queue://review/re-review-requests", "reviewer", "reviewer-cmd")]
-    [InlineData("queue://review/queue", "reviewer", "reviewer-cmd")]
-    [InlineData("queue://review/queue", "reviewed", "reviewed-cmd")]
-    public async Task LaunchAsync_ShouldSelectCorrectSlotBySourceAndRole(
-        string source, string role, string expectedCmd)
+    [InlineData("reviewer", "reviewer-cmd")]
+    [InlineData("reviewed", "reviewed-cmd")]
+    public async Task LaunchAsync_ShouldSelectCorrectSlotByRole(
+        string roleName, string expectedCmd)
     {
         // Arrange
+        LauncherRole role = roleName == "reviewer" ? LauncherRole.Reviewer : LauncherRole.Reviewed;
         var reviewEvent = new ReviewEvent
         {
             EventId = "test-slot",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
             PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
-            Source = source,
+            Source = "queue://review/queue",
         };
 
         ConfigureSettings(
             reviewerCmd: "reviewer-cmd", reviewerArgs: "--reviewer-arg",
-            reviewedCmd: "reviewed-cmd", reviewedArgs: "--reviewed-arg",
-            role: role);
+            reviewedCmd: "reviewed-cmd", reviewedArgs: "--reviewed-arg");
 
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
         ProcessStartInfo? capturedPsi = null;
@@ -257,7 +255,7 @@ public class ReviewLauncherServiceTests : IDisposable
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act
-        await service.LaunchAsync(reviewEvent, CancellationToken.None);
+        await service.LaunchAsync(reviewEvent, role, CancellationToken.None);
 
         // Assert
         capturedPsi.Should().NotBeNull();
@@ -265,32 +263,31 @@ public class ReviewLauncherServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData("queue://review/re-review-requests", "reviewer", "reviewer-cmd", "--reviewer-arg")]
-    [InlineData("queue://review/queue", "reviewer", "reviewer-cmd", "--reviewer-arg")]
-    [InlineData("queue://review/queue", "reviewed", "reviewed-cmd", "--reviewed-arg")]
-    public void BuildCommandLine_ShouldSelectCorrectSlotBySourceAndRole(
-        string source, string role, string expectedCmd, string expectedArg)
+    [InlineData("reviewer", "reviewer-cmd", "--reviewer-arg")]
+    [InlineData("reviewed", "reviewed-cmd", "--reviewed-arg")]
+    public void BuildCommandLine_ShouldSelectCorrectSlotByRole(
+        string roleName, string expectedCmd, string expectedArg)
     {
         // Arrange
+        LauncherRole role = roleName == "reviewer" ? LauncherRole.Reviewer : LauncherRole.Reviewed;
         var reviewEvent = new ReviewEvent
         {
             EventId = "test-copy",
             Repository = "scottlz0310/squirrel-notifier",
             PrNumber = 52,
             PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
-            Source = source,
+            Source = "queue://review/queue",
         };
 
         ConfigureSettings(
             reviewerCmd: "reviewer-cmd", reviewerArgs: "--reviewer-arg",
-            reviewedCmd: "reviewed-cmd", reviewedArgs: "--reviewed-arg",
-            role: role);
+            reviewedCmd: "reviewed-cmd", reviewedArgs: "--reviewed-arg");
 
         var mockRunner = new Mock<IProcessRunner>();
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act
-        string commandLine = service.BuildCommandLine(reviewEvent);
+        string commandLine = service.BuildCommandLine(reviewEvent, role);
 
         // Assert
         commandLine.Should().Be($"{expectedCmd} {expectedArg}");
@@ -313,14 +310,13 @@ public class ReviewLauncherServiceTests : IDisposable
 
         ConfigureSettings(
             reviewerCmd: "claude",
-            reviewerArgs: "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
-            role: "reviewer");
+            reviewerArgs: "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"");
 
         var mockRunner = new Mock<IProcessRunner>();
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
 
         // Act
-        string commandLine = service.BuildCommandLine(reviewEvent);
+        string commandLine = service.BuildCommandLine(reviewEvent, LauncherRole.Reviewer);
 
         // Assert
         commandLine.Should().Be("claude -p \"/thread-owl-pr-reviewer scottlz0310/squirrel-notifier#123 を opened モードでレビューしてください\"");

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -119,10 +119,9 @@ public class SettingsServiceTests : IDisposable
         string reviewerArgs = "--reviewer-arg",
         string reviewedCmd = "reviewed-cmd",
         string reviewedArgs = "--reviewed-arg",
-        string role = "reviewer",
         int launcherTimeout = 150000)
     {
-        _settingsService.UpdateSettings(cmd, args, url, uris ?? _defaultUris, timeout, reviewerCmd, reviewerArgs, reviewedCmd, reviewedArgs, role, launcherTimeout);
+        _settingsService.UpdateSettings(cmd, args, url, uris ?? _defaultUris, timeout, reviewerCmd, reviewerArgs, reviewedCmd, reviewedArgs, launcherTimeout);
     }
 
     [Fact]
@@ -142,7 +141,6 @@ public class SettingsServiceTests : IDisposable
         _settingsService.Settings.ReviewerLauncherArguments.Should().Be("--reviewer-arg");
         _settingsService.Settings.ReviewedLauncherCommandPath.Should().Be("reviewed-cmd");
         _settingsService.Settings.ReviewedLauncherArguments.Should().Be("--reviewed-arg");
-        _settingsService.Settings.LauncherRole.Should().Be("reviewer");
         _settingsService.Settings.LauncherTimeoutMs.Should().Be(150000);
     }
 
@@ -173,10 +171,6 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void UpdateSettings_ShouldThrowForEmptyReviewedCommandPath()
         => FluentActions.Invoking(() => UpdateSettingsDefault(reviewedCmd: "")).Should().Throw<ArgumentException>();
-
-    [Fact]
-    public void UpdateSettings_ShouldThrowForInvalidRole()
-        => FluentActions.Invoking(() => UpdateSettingsDefault(role: "invalid")).Should().Throw<ArgumentException>();
 
     [Theory]
     [InlineData(0)]

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -40,7 +40,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="240">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -75,36 +75,28 @@
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Timeout (ms):" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="4" Grid.Column="1" x:Name="TimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="起動ロール:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="16">
-                        <RadioButton x:Name="ReviewerRoleRadio" Content="reviewer（レビュアー）"
-                                     GroupName="LauncherRole" Checked="OnLauncherRoleChanged"/>
-                        <RadioButton x:Name="ReviewedRoleRadio" Content="reviewed（実装者）"
-                                     GroupName="LauncherRole" Checked="OnLauncherRoleChanged"/>
-                    </StackPanel>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Reviewer Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" x:Name="ReviewerPathBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Reviewer Path:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="ReviewerPathBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Reviewer Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="ReviewerArgumentsBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Reviewer Args:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="7" Grid.Column="1" x:Name="ReviewerArgumentsBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Reviewed Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="7" Grid.Column="1" x:Name="ReviewedPathBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Reviewed Path:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="8" Grid.Column="1" x:Name="ReviewedPathBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="8" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="9" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
+                    <NumberBox Grid.Row="9" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
 
-                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
-                    <NumberBox Grid.Row="10" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
-
-                    <TextBlock Grid.Row="11" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="11" Grid.Column="1" x:Name="AutoStartToggle"
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="10" Grid.Column="1" x:Name="AutoStartToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnAutoStartToggled"/>
 
-                    <TextBlock Grid.Row="12" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="11" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
                         <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
                     </StackPanel>
@@ -190,12 +182,30 @@
                                                          HorizontalAlignment="Left"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-                                        <Button Content="レビュー起動"
-                                                Click="OnLaunchReviewClick"
-                                                CommandParameter="{x:Bind}"/>
-                                        <Button Content="コマンドをコピー"
-                                                Click="OnCopyLaunchCommandClick"
-                                                CommandParameter="{x:Bind}"/>
+                                        <SplitButton Content="レビューする"
+                                                     AutomationProperties.Name="reviewer としてレビューを起動"
+                                                     Click="OnLaunchReviewerClick"
+                                                     CommandParameter="{x:Bind}">
+                                            <SplitButton.Flyout>
+                                                <MenuFlyout Placement="Bottom">
+                                                    <MenuFlyoutItem Text="コマンドをコピー"
+                                                                    Click="OnCopyReviewerCommandClick"
+                                                                    CommandParameter="{x:Bind}"/>
+                                                </MenuFlyout>
+                                            </SplitButton.Flyout>
+                                        </SplitButton>
+                                        <SplitButton Content="レビューに対応"
+                                                     AutomationProperties.Name="reviewed としてレビュー対応を起動"
+                                                     Click="OnLaunchReviewedClick"
+                                                     CommandParameter="{x:Bind}">
+                                            <SplitButton.Flyout>
+                                                <MenuFlyout Placement="Bottom">
+                                                    <MenuFlyoutItem Text="コマンドをコピー"
+                                                                    Click="OnCopyReviewedCommandClick"
+                                                                    CommandParameter="{x:Bind}"/>
+                                                </MenuFlyout>
+                                            </SplitButton.Flyout>
+                                        </SplitButton>
                                         <Button AutomationProperties.Name="イベントを片付ける"
                                                 ToolTipService.ToolTip="このイベントを一覧から片付ける"
                                                 Click="OnDismissEventClick"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -130,8 +130,6 @@ internal sealed partial class MainWindow : Window
         ReviewerArgumentsBox.Text = settings.ReviewerLauncherArguments;
         ReviewedPathBox.Text = settings.ReviewedLauncherCommandPath;
         ReviewedArgumentsBox.Text = settings.ReviewedLauncherArguments;
-        ReviewerRoleRadio.IsChecked = settings.LauncherRole != "reviewed";
-        ReviewedRoleRadio.IsChecked = settings.LauncherRole == "reviewed";
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
 
         ReasonComboBox.ItemsSource = _enqueueReviewReasons;
@@ -685,16 +683,6 @@ internal sealed partial class MainWindow : Window
         SaveCurrentSettings();
     }
 
-    private void OnLauncherRoleChanged(object sender, RoutedEventArgs e)
-    {
-        if (_isInitializing)
-        {
-            return;
-        }
-
-        SaveCurrentSettings();
-    }
-
     private void SaveCurrentSettings()
     {
         try
@@ -718,7 +706,6 @@ internal sealed partial class MainWindow : Window
             string reviewerArguments = ReviewerArgumentsBox.Text;
             string reviewedPath = ReviewedPathBox.Text;
             string reviewedArguments = ReviewedArgumentsBox.Text;
-            string launcherRole = ReviewedRoleRadio.IsChecked == true ? "reviewed" : "reviewer";
             int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 300000 : (int)LauncherTimeoutBox.Value;
 
             _settingsService.UpdateSettings(
@@ -731,7 +718,6 @@ internal sealed partial class MainWindow : Window
                 reviewerArguments,
                 reviewedPath,
                 reviewedArguments,
-                launcherRole,
                 launcherTimeoutMs);
         }
         catch
@@ -884,14 +870,14 @@ internal sealed partial class MainWindow : Window
         }
     }
 
-    private void OnLaunchReviewRequested(object? sender, string eventId)
+    private void OnLaunchReviewRequested(object? sender, Models.LaunchReviewRequest request)
     {
         _ = DispatcherQueue.TryEnqueue(async () =>
         {
             Models.ReviewEvent? targetEvent = null;
             foreach (Models.ReviewEvent ev in _reviewEvents)
             {
-                if (ev.EventId == eventId)
+                if (ev.EventId == request.EventId)
                 {
                     targetEvent = ev;
                     break;
@@ -900,33 +886,52 @@ internal sealed partial class MainWindow : Window
 
             if (targetEvent == null)
             {
-                await _loggingService.WriteAsync($"Launch request ignored: event with ID {eventId} not found in history.").ConfigureAwait(false);
+                await _loggingService.WriteAsync($"Launch request ignored: event with ID {request.EventId} not found in history.").ConfigureAwait(false);
                 return;
             }
 
             ShowWindowFromTray();
-            await ExecuteReviewAsync(targetEvent).ConfigureAwait(false);
+            await ExecuteReviewAsync(targetEvent, request.Role).ConfigureAwait(false);
         });
     }
 
-    private async void OnLaunchReviewClick(object sender, RoutedEventArgs e)
+    private async void OnLaunchReviewerClick(SplitButton sender, SplitButtonClickEventArgs args)
     {
-        if (sender is Button button && button.CommandParameter is Models.ReviewEvent reviewEvent)
+        if (sender.CommandParameter is Models.ReviewEvent reviewEvent)
         {
-            await ExecuteReviewAsync(reviewEvent).ConfigureAwait(false);
+            await ExecuteReviewAsync(reviewEvent, Models.LauncherRole.Reviewer).ConfigureAwait(false);
         }
     }
 
-    private void OnCopyLaunchCommandClick(object sender, RoutedEventArgs e)
+    private async void OnLaunchReviewedClick(SplitButton sender, SplitButtonClickEventArgs args)
     {
-        if (sender is not Button button || button.CommandParameter is not Models.ReviewEvent reviewEvent)
+        if (sender.CommandParameter is Models.ReviewEvent reviewEvent)
         {
-            return;
+            await ExecuteReviewAsync(reviewEvent, Models.LauncherRole.Reviewed).ConfigureAwait(false);
         }
+    }
 
+    private void OnCopyReviewerCommandClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem item && item.CommandParameter is Models.ReviewEvent reviewEvent)
+        {
+            CopyLaunchCommand(reviewEvent, Models.LauncherRole.Reviewer);
+        }
+    }
+
+    private void OnCopyReviewedCommandClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem item && item.CommandParameter is Models.ReviewEvent reviewEvent)
+        {
+            CopyLaunchCommand(reviewEvent, Models.LauncherRole.Reviewed);
+        }
+    }
+
+    private void CopyLaunchCommand(Models.ReviewEvent reviewEvent, Models.LauncherRole role)
+    {
         try
         {
-            string commandLine = _launcherService.BuildCommandLine(reviewEvent);
+            string commandLine = _launcherService.BuildCommandLine(reviewEvent, role);
 
             var dataPackage = new DataPackage();
             dataPackage.SetText(commandLine);
@@ -972,7 +977,7 @@ internal sealed partial class MainWindow : Window
         }
     }
 
-    private async Task ExecuteReviewAsync(Models.ReviewEvent reviewEvent)
+    private async Task ExecuteReviewAsync(Models.ReviewEvent reviewEvent, Models.LauncherRole role)
     {
         if (_launcherService.IsRunning)
         {
@@ -1004,7 +1009,7 @@ internal sealed partial class MainWindow : Window
                 XamlRoot = Content.XamlRoot,
             };
 
-            Task<LauncherResult> launchTask = _launcherService.LaunchAsync(reviewEvent, cts.Token);
+            Task<LauncherResult> launchTask = _launcherService.LaunchAsync(reviewEvent, role, cts.Token);
             IAsyncOperation<ContentDialogResult> dialogTask = dialog.ShowAsync(ContentDialogPlacement.Popup);
 
             Task completedTask = await Task.WhenAny(launchTask, dialogTask.AsTask()).ConfigureAwait(true);

--- a/winui3/SquirrelNotifier.WinUI3/Models/LaunchReviewRequest.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LaunchReviewRequest.cs
@@ -1,0 +1,10 @@
+// <copyright file="LaunchReviewRequest.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// トースト通知の「レビューする」ボタンから要求されたレビュー起動。
+/// </summary>
+internal sealed record LaunchReviewRequest(string EventId, LauncherRole Role);

--- a/winui3/SquirrelNotifier.WinUI3/Models/LaunchReviewRequest.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LaunchReviewRequest.cs
@@ -5,6 +5,6 @@
 namespace SquirrelNotifier.WinUI3.Models;
 
 /// <summary>
-/// トースト通知の「レビューする」ボタンから要求されたレビュー起動。
+/// トースト通知の「レビューする」ボタンから要求されたレビュー起動.
 /// </summary>
 internal sealed record LaunchReviewRequest(string EventId, LauncherRole Role);

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherRole.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherRole.cs
@@ -1,0 +1,15 @@
+// <copyright file="LauncherRole.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// レビュー起動に使うランチャースロット。ユーザーが押したアクション
+/// （レビューする / レビューに対応）で決まり、グローバル設定は持たない。
+/// </summary>
+internal enum LauncherRole
+{
+    Reviewer,
+    Reviewed,
+}

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherRole.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherRole.cs
@@ -6,10 +6,13 @@ namespace SquirrelNotifier.WinUI3.Models;
 
 /// <summary>
 /// レビュー起動に使うランチャースロット。ユーザーが押したアクション
-/// （レビューする / レビューに対応）で決まり、グローバル設定は持たない。
+/// （レビューする / レビューに対応）で決まり、グローバル設定は持たない.
 /// </summary>
 internal enum LauncherRole
 {
+    /// <summary>reviewer 側（自分がレビューする側）のランチャースロット.</summary>
     Reviewer,
+
+    /// <summary>reviewed 側（レビューを受ける側）のランチャースロット.</summary>
     Reviewed,
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/INotificationService.cs
@@ -17,5 +17,5 @@ internal interface INotificationService
 
     event System.EventHandler? OpenAppRequested;
 
-    event System.EventHandler<string>? LaunchReviewRequested;
+    event System.EventHandler<LaunchReviewRequest>? LaunchReviewRequested;
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
@@ -12,9 +12,9 @@ internal interface IReviewLauncherService
 {
     bool IsRunning { get; }
 
-    Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, CancellationToken cancellationToken);
+    Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken);
 
     void Cancel();
 
-    string BuildCommandLine(ReviewEvent reviewEvent);
+    string BuildCommandLine(ReviewEvent reviewEvent, LauncherRole role);
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/NotificationService.cs
@@ -50,7 +50,14 @@ internal sealed class NotificationService : INotificationService
         }
     }
 
-    public event EventHandler<string>? LaunchReviewRequested;
+    public event EventHandler<LaunchReviewRequest>? LaunchReviewRequested;
+
+    // 現行の購読イベント（opened / synchronized / re-review-requested）はいずれも
+    // 「次のアクションは reviewer side（レビューする）」に対応する（#127 決定事項 3）。
+    // reviewed side を推奨するイベント種別（レビューが投稿された等）は queue に未定義のため、
+    // 未知の reason では起動ボタンを出さず「アプリを開く」で両ロールの行 UI へ誘導する。
+    private static bool IsReviewerRecommended(string reason)
+        => reason is "opened" or "synchronized" or "re-review-requested";
 
     public void NotifyReviewEvent(ReviewEvent reviewEvent)
     {
@@ -69,9 +76,13 @@ internal sealed class NotificationService : INotificationService
                     .AddArgument("url", reviewEvent.PrUrl));
             }
 
-            builder.AddButton(new AppNotificationButton("レビューを起動")
-                .AddArgument("action", "launchReview")
-                .AddArgument("eventId", reviewEvent.EventId));
+            if (IsReviewerRecommended(reviewEvent.Reason))
+            {
+                builder.AddButton(new AppNotificationButton("レビューする")
+                    .AddArgument("action", "launchReview")
+                    .AddArgument("role", "reviewer")
+                    .AddArgument("eventId", reviewEvent.EventId));
+            }
 
             builder.AddButton(new AppNotificationButton("アプリを開く")
                 .AddArgument("action", "openApp"));
@@ -127,7 +138,11 @@ internal sealed class NotificationService : INotificationService
             {
                 if (!string.IsNullOrEmpty(eventId))
                 {
-                    LaunchReviewRequested?.Invoke(this, eventId);
+                    // role 引数を持たない旧形式の通知（アプリ更新前に表示されたもの）は reviewer として扱う
+                    LauncherRole role = args.Arguments.TryGetValue("role", out string? roleValue) && roleValue == "reviewed"
+                        ? LauncherRole.Reviewed
+                        : LauncherRole.Reviewer;
+                    LaunchReviewRequested?.Invoke(this, new LaunchReviewRequest(eventId, role));
                 }
             }
             else if (action == "openApp")

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -44,7 +44,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         _processRunner = processRunner ?? new ProcessRunner();
     }
 
-    public async Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, CancellationToken cancellationToken)
+    public async Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(reviewEvent);
 
@@ -62,10 +62,10 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
             _isRunning = true;
         }
 
-        await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber}").ConfigureAwait(false);
+        await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber} (role={role})").ConfigureAwait(false);
 
         AppSettings settings = _settingsService.Settings;
-        (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, reviewEvent);
+        (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
         int timeoutMs = settings.LauncherTimeoutMs;
 
         _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -179,25 +179,23 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     // コマンド文字列を組み立てる（クリップボードコピー用）。コマンドパスは
     // ResolveCommandPath で解決した絶対パスではなく、設定値そのもの（例: "claude"）を使う。
     // ユーザーが自分のターミナルへ貼り付けて実行する用途では、そちらの方が可搬性が高く分かりやすいため。
-    public string BuildCommandLine(ReviewEvent reviewEvent)
+    public string BuildCommandLine(ReviewEvent reviewEvent, LauncherRole role)
     {
         ArgumentNullException.ThrowIfNull(reviewEvent);
 
         AppSettings settings = _settingsService.Settings;
-        (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, reviewEvent);
+        (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
         System.Collections.Generic.List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
 
         return CommandLineFormatter.Format(commandPath, args);
     }
 
-    // re-review-requests URI は常に reviewer スロット、queue URI は LauncherRole で切り替え
-    private static (string CommandPath, string ArgumentsTemplate) ResolveLauncherSlot(AppSettings settings, ReviewEvent reviewEvent)
+    // スロットはユーザーが押したアクションのロールだけで決まる（#127）
+    private static (string CommandPath, string ArgumentsTemplate) ResolveLauncherSlot(AppSettings settings, LauncherRole role)
     {
-        bool useReviewer = reviewEvent.Source.Contains("re-review-requests", StringComparison.OrdinalIgnoreCase)
-            || settings.LauncherRole == "reviewer";
-        string commandPath = useReviewer ? settings.ReviewerLauncherCommandPath : settings.ReviewedLauncherCommandPath;
-        string argumentsTemplate = useReviewer ? settings.ReviewerLauncherArguments : settings.ReviewedLauncherArguments;
-        return (commandPath, argumentsTemplate);
+        return role == LauncherRole.Reviewer
+            ? (settings.ReviewerLauncherCommandPath, settings.ReviewerLauncherArguments)
+            : (settings.ReviewedLauncherCommandPath, settings.ReviewedLauncherArguments);
     }
 
     private void KillActiveProcess()

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -225,7 +225,6 @@ internal sealed class SettingsService
         string reviewerLauncherArguments,
         string reviewedLauncherCommandPath,
         string reviewedLauncherArguments,
-        string launcherRole,
         int launcherTimeoutMs)
     {
         if (string.IsNullOrWhiteSpace(commandPath))
@@ -259,11 +258,6 @@ internal sealed class SettingsService
             throw new ArgumentException("Reviewed launcher command path cannot be empty", nameof(reviewedLauncherCommandPath));
         }
 
-        if (launcherRole != "reviewer" && launcherRole != "reviewed")
-        {
-            throw new ArgumentException("Launcher role must be 'reviewer' or 'reviewed'", nameof(launcherRole));
-        }
-
         if (launcherTimeoutMs <= 0 || launcherTimeoutMs > 300000)
         {
             throw new ArgumentOutOfRangeException(nameof(launcherTimeoutMs), "Launcher timeout must be between 1 and 300000 ms");
@@ -279,7 +273,6 @@ internal sealed class SettingsService
         _settings.ReviewerLauncherArguments = reviewerLauncherArguments;
         _settings.ReviewedLauncherCommandPath = reviewedLauncherCommandPath;
         _settings.ReviewedLauncherArguments = reviewedLauncherArguments;
-        _settings.LauncherRole = launcherRole;
         _settings.LauncherTimeoutMs = launcherTimeoutMs;
         SaveSettings();
     }
@@ -314,9 +307,6 @@ internal sealed class AppSettings
     public string ReviewedLauncherCommandPath { get; set; } = "claude";
 
     public string ReviewedLauncherArguments { get; set; } = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
-
-    // queue://review/queue に対して使うロール ("reviewer" | "reviewed")
-    public string LauncherRole { get; set; } = "reviewer";
 
     public bool LauncherSlotsMigrated { get; set; }
 


### PR DESCRIPTION
Closes #127

> **Note**: #135 → #136 → #137 (PR スタック 4/4) の上に積んでいます。マージは #137 が先です。

## 概要

レビュー起動ロール（reviewer / reviewed）のグローバル設定切替を廃止し、イベント行のボタン側で両ロールに対応します。Issue の決定事項（2026-07-05）に沿った実装です。

## 変更内容

### 決定事項 1: LauncherRole 設定の廃止

- Settings の「起動ロール」ラジオボタンと `AppSettings.LauncherRole`（settings.json の `launcherRole`）を削除
- `SettingsService.UpdateSettings` から `launcherRole` パラメータと検証を削除（既存 settings.json に残る `launcherRole` はデシリアライズ時に無視されるため移行処理は不要）

### 決定事項 2: スロット解決の単純化

- `ResolveLauncherSlot` は押されたボタンのロール（`LauncherRole` enum）だけでスロットを決定
- `re-review-requests` URI の reviewer 強制ロジックは等価になるため削除
- `IReviewLauncherService.LaunchAsync` / `BuildCommandLine` に `LauncherRole` 引数を追加

### 行 UI（Issue 推奨の SplitButton 案）

```
owner/repo #123 のキャプション   [レビューする ▾] [レビューに対応 ▾] [✕]
```

- SplitButton の primary クリック = 起動、flyout = 「コマンドをコピー」
- 「PRを開く」はキャプションのハイパーリンク（#129）、✕ は片付け（#128）で対応済み

### 決定事項 3: 推奨ロール（部分実装）

- **確認事項の結果**: 現行の購読イベント（reason: `opened` / `synchronized` / `re-review-requested`）はいずれも次のアクションが reviewer side であり、reviewed side を示すイベント種別（「レビューが投稿された」等）は queue に存在しません
- トースト通知の起動ボタンは既知 reason で「レビューする」（reviewer 起動、`role=reviewer` 引数付き）を表示。未知 reason では起動ボタンを出さず「アプリを開く」で両ロールの行 UI へ誘導
- 行の推奨側強調表示は**見送り**: 現状すべてのイベントが reviewer 推奨のため全行が同一表示となり情報量がなく、また SplitButton には標準の accent スタイルがないため。reviewed side イベントが queue に追加された時点で意味を持つため、thread-owl / queue 側へのイベント種別追加と合わせて followup とするのが妥当です（必要なら Issue 化します）

## テスト

- `ReviewLauncherServiceTests`: スロット選択テストを Source×ロール設定ベースからロール引数ベースに書き換え
- `SettingsServiceTests`: `launcherRole` 検証テストを削除
- 291 件全テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)