### PR TITLE
feat: レートリミット監視エージェントを Settings で選択できるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- レートリミット監視対象の CLI エージェントを Settings で選択できるようにした（#139）。「レートリミット状態」セクションに claude-code / agy（Antigravity CLI）のチェックボックスを追加し、選択したエージェントの statusline フックが書き出すローカル JSON ファイル（`%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json`）を「更新」時に読み取って表示する。調査の結果 `ratelimit://` を提供する MCP サーバーは存在せず、レートリミット情報は各 CLI エージェント自身の statusline フックからローカルに取得する必要があることが判明したため、既存の MCP `resources/read` 経由の取得（`ratelimit://` URI、サーバー側の将来対応に備え維持）とは別に、ローカルファイル経由の取得経路を追加した。statusline スクリプト自体の拡張（レートリミット検知時のファイル書き出し）はユーザーの dotfiles 側で行うため、`docs/statusline-integration.md` と claude-code / agy 向けのサンプルスクリプトを追加した。エージェント定義は `RateLimitAgentCatalog` に集約し、将来の追加・削除が容易な構成にした。codex は statusline フックが外部コマンドに JSON を渡さず現時点で技術的に対応不可能なため、対応待ちとして選択不可の状態で表示する
+
 ### Changed
 - 起動ロールの設定切替を廃止し、イベント行で両ロールのアクションを提供するようにした（#127）
   - Settings の「起動ロール」ラジオボタンと settings.json の `launcherRole` を削除。ランチャースロットは「どのボタンを押したか」だけで決まるため、`re-review-requests` の reviewer 強制ロジックも不要になり削除

--- a/docs/samples/agy-ratelimit-snippet.ps1
+++ b/docs/samples/agy-ratelimit-snippet.ps1
@@ -1,0 +1,42 @@
+# squirrel-notifier 連携: agy (Antigravity CLI) の statusline JSON からレートリミット
+# 状態を共通スキーマに変換してローカルファイルへ書き出す（#139）。
+#
+# 使い方: 既存の statusline スクリプト（例: agy/statusline.ps1）で $data に
+# stdin の JSON をパースした後、以下の関数呼び出しを追記する。
+#   Write-SquirrelNotifierRateLimitStatus -Data $data
+
+function Write-SquirrelNotifierRateLimitStatus {
+    param($Data)
+
+    if (-not $Data -or -not $Data.quota) {
+        return
+    }
+
+    $outDir = Join-Path $env:LOCALAPPDATA "SquirrelNotifier\ratelimit-status"
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+    $bucketLabels = [ordered]@{
+        "3p-5h"         = "agy 3rd-party 5時間枠"
+        "3p-weekly"     = "agy 3rd-party 週次枠"
+        "gemini-5h"     = "agy Gemini 5時間枠"
+        "gemini-weekly" = "agy Gemini 週次枠"
+    }
+
+    $limits = @()
+    foreach ($key in $bucketLabels.Keys) {
+        $bucket = $Data.quota.$key
+        if ($bucket -and $bucket.reset_time) {
+            $limits += [PSCustomObject]@{
+                id      = "agy-$key"
+                label   = $bucketLabels[$key]
+                resetAt = $bucket.reset_time
+            }
+        }
+    }
+
+    $payload = @{ limits = $limits } | ConvertTo-Json -Depth 5
+    $tempPath = Join-Path $outDir "agy.json.tmp"
+    $finalPath = Join-Path $outDir "agy.json"
+    Set-Content -Path $tempPath -Value $payload -Encoding utf8
+    Move-Item -Path $tempPath -Destination $finalPath -Force
+}

--- a/docs/samples/claude-code-ratelimit-snippet.sh
+++ b/docs/samples/claude-code-ratelimit-snippet.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# squirrel-notifier 連携: claude-code の statusLine JSON からレートリミット状態を
+# 共通スキーマに変換してローカルファイルへ書き出す（#139）。
+#
+# 使い方: 既存の statusline スクリプト（例: ~/.claude/statusline-command.sh）で
+# `input=$(cat)` により stdin の JSON を読み込んだ直後に、以下の関数呼び出しを追記する。
+#   write_squirrel_notifier_ratelimit_status "$input"
+#
+# 依存: jq, GNU date（Git for Windows の bash に同梱）
+
+write_squirrel_notifier_ratelimit_status() {
+  local input="$1"
+  local out_dir="${LOCALAPPDATA}/SquirrelNotifier/ratelimit-status"
+  mkdir -p "$out_dir" 2>/dev/null || return 0
+
+  local five_reset seven_reset limits="[]"
+  five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)
+  seven_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty' 2>/dev/null)
+
+  if [ -n "$five_reset" ]; then
+    local five_iso
+    five_iso=$(date -u -d "@${five_reset}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+    if [ -n "$five_iso" ]; then
+      limits=$(echo "$limits" | jq --arg id "claude-code-5h" --arg label "claude-code 5時間枠" --arg reset "$five_iso" \
+        '. + [{"id":$id,"label":$label,"resetAt":$reset}]')
+    fi
+  fi
+
+  if [ -n "$seven_reset" ]; then
+    local seven_iso
+    seven_iso=$(date -u -d "@${seven_reset}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+    if [ -n "$seven_iso" ]; then
+      limits=$(echo "$limits" | jq --arg id "claude-code-7d" --arg label "claude-code 週次枠" --arg reset "$seven_iso" \
+        '. + [{"id":$id,"label":$label,"resetAt":$reset}]')
+    fi
+  fi
+
+  local tmp_path="${out_dir}/claude-code.json.tmp"
+  local final_path="${out_dir}/claude-code.json"
+  echo "{\"limits\":${limits}}" > "$tmp_path" 2>/dev/null && mv -f "$tmp_path" "$final_path" 2>/dev/null
+}

--- a/docs/statusline-integration.md
+++ b/docs/statusline-integration.md
@@ -1,0 +1,81 @@
+# レートリミット監視: statusline 連携（#139）
+
+## 背景
+
+レートリミット解除の事前通知予約機能（#114）が必要とする情報（5時間枠・週次枠の使用率・リセット時刻）は、MCP サーバーが提供するものではなく、**ローカルで動作している CLI エージェントクライアント自身が持つ情報**である。
+
+各エージェントには「statusline」フック（セッション中に外部コマンドへ JSON を stdin 経由で渡し、ターミナルのステータス表示をカスタマイズできる機構）があり、その JSON にレートリミット情報が含まれる。squirrel-notifier はこの情報を MCP 経由ではなく、**ローカルファイル経由**で取得する。
+
+```
+[CLI エージェント] --statusline JSON--> [拡張した statusline スクリプト] --共通スキーマで書き出し--> [ローカル JSON ファイル] --読み取り--> [squirrel-notifier]
+```
+
+squirrel-notifier リポジトリ側は「ローカルファイルを読み取る機能」のみを実装する。各エージェントの statusline スクリプト自体の拡張（レートリミット検知時のファイル書き出し追加）は、ユーザー自身の dotfiles / env-config 側で行う。このページはそのための手順書。
+
+## 対応エージェント
+
+| エージェント ID | 対応状況 |
+|---|---|
+| `claude-code` | 対応可能（statusline フックあり） |
+| `agy`（Antigravity CLI） | 対応可能（statusline フックあり） |
+| `codex` | **対応待ち**。Codex CLI の `tui.status_line` は組み込みアイテムを TUI に表示するだけで外部コマンドに JSON を渡す仕組みがなく、`notify` フックにも rate limit フィールドが無い。機械可読な usage 出力は未実装（[openai/codex#16037](https://github.com/openai/codex/issues/16037)、[#20310](https://github.com/openai/codex/issues/20310)）。実装され次第対応する |
+
+## 書き出し先パス
+
+```
+%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json
+```
+
+`<agentId>` は上表のエージェント ID（`claude-code` / `agy`）。squirrel-notifier の Settings 画面で対応するチェックボックスを ON にすると、このパスを読み取り対象に追加する。
+
+## 共通スキーマ
+
+書き出す JSON は squirrel-notifier の `RateLimitStatusPayload` / `RateLimitInfo` がそのまま読める形式にする。**使用率（%）は squirrel-notifier 側で表示・利用しないため含めなくてよい**。必要なのは `id` / `label` / `resetAt`（ISO 8601 文字列）のみ。
+
+```json
+{
+  "limits": [
+    { "id": "claude-code-5h", "label": "claude-code 5時間枠", "resetAt": "2026-07-06T13:30:00Z" },
+    { "id": "claude-code-7d", "label": "claude-code 週次枠",   "resetAt": "2026-07-13T00:00:00Z" }
+  ]
+}
+```
+
+書き込みはアトミックに行う（`.tmp` に書いてから `rename`/`Move-Item`）。squirrel-notifier 自身の `CacheService.SaveAsync` も同じパターンを採用している。
+
+## エージェント別の実データ構造とサンプル
+
+### claude-code
+
+`statusLine` フックの JSON に `rate_limits.five_hour` / `rate_limits.seven_day` が含まれる（`resets_at` は UNIX epoch 秒）：
+
+```json
+"rate_limits": {
+  "five_hour": { "used_percentage": 73, "resets_at": 1783312200 },
+  "seven_day": { "used_percentage": 45, "resets_at": 1783764000 }
+}
+```
+
+サンプル: [`samples/claude-code-ratelimit-snippet.sh`](samples/claude-code-ratelimit-snippet.sh)（既存の statusline スクリプトの `input=$(cat)` 直後に呼び出しを追記する形の bash 関数）
+
+### agy（Antigravity CLI）
+
+`quota` フィールドに `3p-5h` / `3p-weekly` / `gemini-5h` / `gemini-weekly` の4バケットがあり、それぞれ `reset_time`（ISO 8601 文字列）を持つ：
+
+```json
+"quota": {
+  "3p-5h":         { "remaining_fraction": 1,      "reset_time": "2026-06-30T07:49:12Z" },
+  "3p-weekly":     { "remaining_fraction": 0.615,  "reset_time": "2026-07-04T00:57:20Z" },
+  "gemini-5h":     { "remaining_fraction": 1,      "reset_time": "2026-06-30T07:49:12Z" },
+  "gemini-weekly": { "remaining_fraction": 1,      "reset_time": "2026-07-07T02:49:12Z" }
+}
+```
+
+サンプル: [`samples/agy-ratelimit-snippet.ps1`](samples/agy-ratelimit-snippet.ps1)（既存の statusline スクリプトの末尾で呼び出しを追記する形の PowerShell 関数）
+
+## 適用手順
+
+1. 上記サンプルスクリプトの内容を、お使いの statusline スクリプト（例: `~/.claude/statusline-command.sh`、`agy` の `statusline.ps1`）に追記する
+2. エージェントを実際に使用し、statusline が一度呼ばれるのを待つ（`%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json` が生成されることを確認）
+3. squirrel-notifier の Settings 画面で対象エージェントのチェックボックスを ON にする
+4. 「レートリミット状態」セクションの「更新」を押す

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/RateLimitAgentCatalogTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/RateLimitAgentCatalogTests.cs
@@ -1,0 +1,32 @@
+// <copyright file="RateLimitAgentCatalogTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Models;
+
+public class RateLimitAgentCatalogTests
+{
+    [Fact]
+    public void All_ShouldContainClaudeCodeAndAgyAsAvailable()
+    {
+        RateLimitAgentCatalog.All.Should().Contain(a => a.Id == "claude-code" && a.IsAvailable);
+        RateLimitAgentCatalog.All.Should().Contain(a => a.Id == "agy" && a.IsAvailable);
+    }
+
+    [Fact]
+    public void All_ShouldContainCodexAsUnavailable()
+    {
+        RateLimitAgentCatalog.All.Should().Contain(a => a.Id == "codex" && !a.IsAvailable);
+    }
+
+    [Fact]
+    public void All_ShouldHaveUniqueIds()
+    {
+        RateLimitAgentCatalog.All.Select(a => a.Id).Should().OnlyHaveUniqueItems();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/RateLimitAgentOptionTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/RateLimitAgentOptionTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="RateLimitAgentOptionTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Models;
+
+public class RateLimitAgentOptionTests
+{
+    [Fact]
+    public void Constructor_ShouldSetProperties()
+    {
+        var option = new RateLimitAgentOption("claude-code", "claude-code", isAvailable: true);
+
+        option.Id.Should().Be("claude-code");
+        option.DisplayName.Should().Be("claude-code");
+        option.IsAvailable.Should().BeTrue();
+        option.IsMonitored.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMonitored_WhenChanged_ShouldRaisePropertyChanged()
+    {
+        var option = new RateLimitAgentOption("agy", "agy (Antigravity CLI)", isAvailable: true);
+        List<string?> raisedProperties = new();
+        option.PropertyChanged += (_, e) => raisedProperties.Add(e.PropertyName);
+
+        option.IsMonitored = true;
+
+        raisedProperties.Should().Contain(nameof(RateLimitAgentOption.IsMonitored));
+    }
+
+    [Fact]
+    public void IsMonitored_WhenSetToSameValue_ShouldNotRaisePropertyChanged()
+    {
+        var option = new RateLimitAgentOption("agy", "agy (Antigravity CLI)", isAvailable: true);
+        bool raised = false;
+        option.PropertyChanged += (_, _) => raised = true;
+
+        option.IsMonitored = false;
+
+        raised.Should().BeFalse();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitFileServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitFileServiceTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="RateLimitFileServiceTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Threading;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class RateLimitFileServiceTests : IDisposable
+{
+    private readonly string _settingsDirectory;
+
+    public RateLimitFileServiceTests()
+    {
+        _settingsDirectory = Path.Combine(Path.GetTempPath(), $"RateLimitFileServiceTests_{Guid.NewGuid()}");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_settingsDirectory))
+        {
+            Directory.Delete(_settingsDirectory, true);
+        }
+    }
+
+    [Fact]
+    public async Task ReadAgentStatusAsync_ShouldReturnNull_WhenFileDoesNotExist()
+    {
+        var service = new RateLimitFileService(_settingsDirectory);
+
+        string? result = await service.ReadAgentStatusAsync("claude-code", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadAgentStatusAsync_ShouldReturnContent_WhenFileExists()
+    {
+        string dir = Path.Combine(_settingsDirectory, "ratelimit-status");
+        Directory.CreateDirectory(dir);
+        string json = "{\"limits\":[{\"id\":\"five_hour\",\"label\":\"5h\",\"resetAt\":\"2026-07-06T12:00:00Z\"}]}";
+        await File.WriteAllTextAsync(Path.Combine(dir, "claude-code.json"), json);
+
+        var service = new RateLimitFileService(_settingsDirectory);
+
+        string? result = await service.ReadAgentStatusAsync("claude-code", CancellationToken.None);
+
+        result.Should().Be(json);
+    }
+
+    [Fact]
+    public async Task ReadAgentStatusAsync_ShouldBeIsolatedPerAgent()
+    {
+        string dir = Path.Combine(_settingsDirectory, "ratelimit-status");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "claude-code.json"), "{\"limits\":[]}");
+
+        var service = new RateLimitFileService(_settingsDirectory);
+
+        string? result = await service.ReadAgentStatusAsync("agy", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ReadAgentStatusAsync_ShouldThrow_WhenAgentIdIsBlank(string agentId)
+    {
+        var service = new RateLimitFileService(_settingsDirectory);
+
+        Func<Task> act = () => service.ReadAgentStatusAsync(agentId, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenSettingsDirectoryIsEmpty()
+    {
+        Action act = () => _ = new RateLimitFileService(string.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BuildSourceIdentifier_ShouldReturnAgentScheme()
+    {
+        RateLimitFileService.BuildSourceIdentifier("claude-code").Should().Be("agent://claude-code");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -240,6 +240,35 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
+    public void SettingsDirectory_ShouldReturnConstructorValue()
+    {
+        _settingsService.SettingsDirectory.Should().Be(_settingsDirectory);
+    }
+
+    [Fact]
+    public void UpdateRateLimitMonitoredAgentIds_ShouldUpdateAndPersist()
+    {
+        // Arrange
+        bool eventRaised = false;
+        _settingsService.SettingsChanged += (_, _) => eventRaised = true;
+
+        // Act
+        _settingsService.UpdateRateLimitMonitoredAgentIds(new[] { "claude-code", "agy" });
+
+        // Assert
+        _settingsService.Settings.RateLimitMonitoredAgentIds.Should().BeEquivalentTo(new[] { "claude-code", "agy" });
+        eventRaised.Should().BeTrue();
+
+        // Verify persistence
+        var anotherService = new SettingsService(_settingsDirectory, pnpmBinDir: string.Empty);
+        anotherService.Settings.RateLimitMonitoredAgentIds.Should().BeEquivalentTo(new[] { "claude-code", "agy" });
+    }
+
+    [Fact]
+    public void UpdateRateLimitMonitoredAgentIds_ShouldThrow_WhenNull()
+        => FluentActions.Invoking(() => _settingsService.UpdateRateLimitMonitoredAgentIds(null!)).Should().Throw<ArgumentNullException>();
+
+    [Fact]
     public void UpdateLastSkippedVersion_ShouldUpdateAndPersistVersion()
     {
         // Arrange

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -24,6 +24,7 @@ public partial class App : Application
     private readonly TaskSchedulerService _taskSchedulerService = new();
     private readonly EnqueueReviewService _enqueueReviewService;
     private readonly RateLimitReminderService _rateLimitReminderService;
+    private readonly RateLimitFileService _rateLimitFileService;
 
     public App()
     {
@@ -69,6 +70,7 @@ public partial class App : Application
         _autoUpdateService = new AutoUpdateService(_loggingService);
         _enqueueReviewService = new EnqueueReviewService(_settingsService, _loggingService);
         _rateLimitReminderService = new RateLimitReminderService(_notificationService);
+        _rateLimitFileService = new RateLimitFileService(_settingsService.SettingsDirectory);
     }
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
@@ -83,7 +85,7 @@ public partial class App : Application
         bool showWindow = isNotificationActivation
             || (!commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t"));
 
-        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, _enqueueReviewService, _rateLimitReminderService, showWindow);
+        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, _enqueueReviewService, _rateLimitReminderService, _rateLimitFileService, showWindow);
         _window.Closed += OnWindowClosed;
 
         _window.Activate();

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -133,6 +133,21 @@
                     <TextBlock Grid.Column="0" Text="レートリミット状態" FontWeight="SemiBold" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Content="更新" Click="OnRefreshRateLimitClick"/>
                 </Grid>
+                <TextBlock Text="監視対象:" FontSize="11" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
+                <ItemsControl x:Name="RateLimitAgentList">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" Spacing="12"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:RateLimitAgentOption">
+                            <CheckBox Content="{x:Bind DisplayName}"
+                                      IsChecked="{x:Bind IsMonitored, Mode=TwoWay}"
+                                      IsEnabled="{x:Bind IsAvailable}"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
                 <ListView x:Name="RateLimitList"
                           Height="90"
                           SelectionMode="None">

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -144,7 +144,7 @@ internal sealed partial class MainWindow : Window
         {
             var option = new Models.RateLimitAgentOption(definition.Id, definition.DisplayName, definition.IsAvailable)
             {
-                IsMonitored = settings.RateLimitMonitoredAgentIds.Contains(definition.Id),
+                IsMonitored = definition.IsAvailable && settings.RateLimitMonitoredAgentIds.Contains(definition.Id),
             };
             option.PropertyChanged += OnRateLimitAgentOptionChanged;
             _rateLimitAgentOptions.Add(option);
@@ -611,7 +611,9 @@ internal sealed partial class MainWindow : Window
         var fetchedLimits = new List<Models.RateLimitInfo>();
 
         // 1. ローカルファイル経由（statusline フック連携、#139）
-        List<Models.RateLimitAgentOption> monitoredAgents = _rateLimitAgentOptions.Where(o => o.IsMonitored).ToList();
+        // IsAvailable=false（codex 等、対応待ち）は settings.json の手動編集等で IsMonitored=true に
+        // なっていてもローカルファイル読み取りの対象にしない。
+        List<Models.RateLimitAgentOption> monitoredAgents = _rateLimitAgentOptions.Where(o => o.IsMonitored && o.IsAvailable).ToList();
         foreach (Models.RateLimitAgentOption agent in monitoredAgents)
         {
             try
@@ -639,29 +641,31 @@ internal sealed partial class MainWindow : Window
             .Where(uri => uri.StartsWith(Services.RateLimitStatusParser.UriScheme, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
+        // MCP 側の取得に失敗しても、既にローカルファイル経由で取得済みの結果は破棄せず
+        // 部分成功として表示する（#139 レビュー対応）。
         if (rateLimitUris.Count > 0)
         {
             string gatewayUrl = GatewayUrlBox.Text;
             if (!Uri.TryCreate(gatewayUrl, UriKind.Absolute, out Uri? endpoint))
             {
                 await ShowAlertDialogAsync("設定エラー", "Gateway URL が正しくありません。先に Gateway URL を設定してください。");
-                return;
             }
-
-            string? token = Environment.GetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN");
-            var probe = new Services.McpResourceProbe();
-
-            foreach (string uri in rateLimitUris)
+            else
             {
-                try
+                string? token = Environment.GetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN");
+                var probe = new Services.McpResourceProbe();
+
+                foreach (string uri in rateLimitUris)
                 {
-                    string json = await probe.ReadResourceTextAsync(endpoint, token, uri, CancellationToken.None).ConfigureAwait(true);
-                    fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, uri));
-                }
-                catch (Exception ex)
-                {
-                    await ShowAlertDialogAsync("取得エラー", Services.McpResourceProbe.GetUserMessage(ex));
-                    return;
+                    try
+                    {
+                        string json = await probe.ReadResourceTextAsync(endpoint, token, uri, CancellationToken.None).ConfigureAwait(true);
+                        fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, uri));
+                    }
+                    catch (Exception ex)
+                    {
+                        await ShowAlertDialogAsync("取得エラー", Services.McpResourceProbe.GetUserMessage(ex));
+                    }
                 }
             }
         }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -38,7 +38,9 @@ internal sealed partial class MainWindow : Window
     private readonly ITaskSchedulerService _taskSchedulerService;
     private readonly EnqueueReviewService _enqueueReviewService;
     private readonly IRateLimitReminderService _rateLimitReminderService;
+    private readonly RateLimitFileService _rateLimitFileService;
     private readonly ObservableCollection<Models.RateLimitInfo> _rateLimits = new();
+    private readonly ObservableCollection<Models.RateLimitAgentOption> _rateLimitAgentOptions = new();
     private bool _isCheckingForUpdates;
     private bool _hasShownErrorBalloon;
     private bool _isAutoStartToggling;
@@ -84,6 +86,7 @@ internal sealed partial class MainWindow : Window
         ITaskSchedulerService taskSchedulerService,
         EnqueueReviewService enqueueReviewService,
         IRateLimitReminderService rateLimitReminderService,
+        RateLimitFileService rateLimitFileService,
         bool showWindow = true)
     {
         InitializeComponent();
@@ -107,6 +110,7 @@ internal sealed partial class MainWindow : Window
         _taskSchedulerService = taskSchedulerService;
         _enqueueReviewService = enqueueReviewService;
         _rateLimitReminderService = rateLimitReminderService;
+        _rateLimitFileService = rateLimitFileService;
         _service.StatusTextChanged += OnStatusTextChanged;
         _service.StateChanged += OnStateChanged;
         _loggingService.LogAppended += OnLogAppended;
@@ -116,6 +120,7 @@ internal sealed partial class MainWindow : Window
         LogList.ItemsSource = _logEntries;
         ReviewEventList.ItemsSource = _reviewEvents;
         RateLimitList.ItemsSource = _rateLimits;
+        RateLimitAgentList.ItemsSource = _rateLimitAgentOptions;
 
         // Load settings
         AppSettings settings = _settingsService.Settings;
@@ -134,6 +139,16 @@ internal sealed partial class MainWindow : Window
 
         ReasonComboBox.ItemsSource = _enqueueReviewReasons;
         ReasonComboBox.SelectedIndex = 0;
+
+        foreach (Models.RateLimitAgentDefinition definition in Models.RateLimitAgentCatalog.All)
+        {
+            var option = new Models.RateLimitAgentOption(definition.Id, definition.DisplayName, definition.IsAvailable)
+            {
+                IsMonitored = settings.RateLimitMonitoredAgentIds.Contains(definition.Id),
+            };
+            option.PropertyChanged += OnRateLimitAgentOptionChanged;
+            _rateLimitAgentOptions.Add(option);
+        }
 
         _isInitializing = false;
 
@@ -593,42 +608,70 @@ internal sealed partial class MainWindow : Window
 
     private async void OnRefreshRateLimitClick(object sender, RoutedEventArgs e)
     {
-        string gatewayUrl = GatewayUrlBox.Text;
-        if (!Uri.TryCreate(gatewayUrl, UriKind.Absolute, out Uri? endpoint))
+        var fetchedLimits = new List<Models.RateLimitInfo>();
+
+        // 1. ローカルファイル経由（statusline フック連携、#139）
+        List<Models.RateLimitAgentOption> monitoredAgents = _rateLimitAgentOptions.Where(o => o.IsMonitored).ToList();
+        foreach (Models.RateLimitAgentOption agent in monitoredAgents)
         {
-            await ShowAlertDialogAsync("設定エラー", "Gateway URL が正しくありません。先に Gateway URL を設定してください。");
-            return;
+            try
+            {
+                string? json = await _rateLimitFileService.ReadAgentStatusAsync(agent.Id, CancellationToken.None).ConfigureAwait(true);
+                if (json == null)
+                {
+                    await ShowAlertDialogAsync(
+                        "レートリミット情報がありません",
+                        $"{agent.DisplayName} のレートリミット情報がまだありません。statusline スクリプトの拡張が必要です。詳細は docs/statusline-integration.md を参照してください。");
+                    continue;
+                }
+
+                fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, Services.RateLimitFileService.BuildSourceIdentifier(agent.Id)));
+            }
+            catch (Exception ex)
+            {
+                await ShowAlertDialogAsync("取得エラー", $"{agent.DisplayName} のレートリミット状態の読み取りに失敗しました: {ex.Message}");
+            }
         }
 
+        // 2. MCP ratelimit:// 経由（既存。サーバー側で将来対応された場合のために維持）
         List<string> rateLimitUris = ResourceUrisBox.Text
             .Split(_resourceUriLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Where(uri => uri.StartsWith(Services.RateLimitStatusParser.UriScheme, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        if (rateLimitUris.Count == 0)
+        if (rateLimitUris.Count > 0)
         {
-            await ShowAlertDialogAsync(
-                "URI 未設定",
-                $"{Services.RateLimitStatusParser.UriScheme} で始まる Resource URI が設定されていません。Resource URIs 欄に追加してください。");
-            return;
-        }
-
-        string? token = Environment.GetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN");
-        var probe = new Services.McpResourceProbe();
-        var fetchedLimits = new List<Models.RateLimitInfo>();
-
-        foreach (string uri in rateLimitUris)
-        {
-            try
+            string gatewayUrl = GatewayUrlBox.Text;
+            if (!Uri.TryCreate(gatewayUrl, UriKind.Absolute, out Uri? endpoint))
             {
-                string json = await probe.ReadResourceTextAsync(endpoint, token, uri, CancellationToken.None).ConfigureAwait(true);
-                fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, uri));
-            }
-            catch (Exception ex)
-            {
-                await ShowAlertDialogAsync("取得エラー", Services.McpResourceProbe.GetUserMessage(ex));
+                await ShowAlertDialogAsync("設定エラー", "Gateway URL が正しくありません。先に Gateway URL を設定してください。");
                 return;
             }
+
+            string? token = Environment.GetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN");
+            var probe = new Services.McpResourceProbe();
+
+            foreach (string uri in rateLimitUris)
+            {
+                try
+                {
+                    string json = await probe.ReadResourceTextAsync(endpoint, token, uri, CancellationToken.None).ConfigureAwait(true);
+                    fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, uri));
+                }
+                catch (Exception ex)
+                {
+                    await ShowAlertDialogAsync("取得エラー", Services.McpResourceProbe.GetUserMessage(ex));
+                    return;
+                }
+            }
+        }
+
+        if (monitoredAgents.Count == 0 && rateLimitUris.Count == 0)
+        {
+            await ShowAlertDialogAsync(
+                "監視対象未設定",
+                "レートリミット監視対象のエージェントが選択されていないか、Resource URIs に ratelimit:// で始まる URI が設定されていません。");
+            return;
         }
 
         _rateLimits.Clear();
@@ -637,6 +680,17 @@ internal sealed partial class MainWindow : Window
             info.IsReminderScheduled = _rateLimitReminderService.IsScheduled(info.ReminderKey);
             _rateLimits.Add(info);
         }
+    }
+
+    private void OnRateLimitAgentOptionChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_isInitializing || e.PropertyName != nameof(Models.RateLimitAgentOption.IsMonitored))
+        {
+            return;
+        }
+
+        List<string> monitoredIds = _rateLimitAgentOptions.Where(o => o.IsMonitored).Select(o => o.Id).ToList();
+        _settingsService.UpdateRateLimitMonitoredAgentIds(monitoredIds);
     }
 
     private void OnRateLimitReminderFired(object? sender, string reminderKey)

--- a/winui3/SquirrelNotifier.WinUI3/Models/RateLimitAgentDefinition.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/RateLimitAgentDefinition.cs
@@ -1,0 +1,28 @@
+// <copyright file="RateLimitAgentDefinition.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// statusline フック経由でレートリミット状態をローカルファイルに書き出せる CLI エージェントの定義.
+/// </summary>
+internal sealed record RateLimitAgentDefinition(string Id, string DisplayName, bool IsAvailable);
+
+/// <summary>
+/// レートリミット監視対象の候補エージェント一覧（#139）.
+/// 新しいエージェントを追加・削除する場合はこのリストのみを変更する.
+/// </summary>
+internal static class RateLimitAgentCatalog
+{
+    public static readonly IReadOnlyList<RateLimitAgentDefinition> All =
+    [
+        new RateLimitAgentDefinition("claude-code", "claude-code", IsAvailable: true),
+        new RateLimitAgentDefinition("agy", "agy (Antigravity CLI)", IsAvailable: true),
+
+        // codex は statusline フックが外部コマンドに JSON を渡さず、notify にも
+        // rate limit フィールドが無いため、現時点ではローカルファイル経由の取得が不可能.
+        // 参照: https://github.com/openai/codex/issues/16037, /issues/20310
+        new RateLimitAgentDefinition("codex", "codex (対応待ち)", IsAvailable: false),
+    ];
+}

--- a/winui3/SquirrelNotifier.WinUI3/Models/RateLimitAgentOption.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/RateLimitAgentOption.cs
@@ -1,0 +1,36 @@
+// <copyright file="RateLimitAgentOption.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.ComponentModel;
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// Settings の「レートリミット監視対象」チェックボックス一覧の表示用アイテム.
+/// </summary>
+internal sealed class RateLimitAgentOption(string id, string displayName, bool isAvailable) : INotifyPropertyChanged
+{
+    private bool _isMonitored;
+
+    public string Id { get; } = id;
+
+    public string DisplayName { get; } = displayName;
+
+    public bool IsAvailable { get; } = isAvailable;
+
+    public bool IsMonitored
+    {
+        get => _isMonitored;
+        set
+        {
+            if (_isMonitored != value)
+            {
+                _isMonitored = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsMonitored)));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitFileService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitFileService.cs
@@ -1,0 +1,47 @@
+// <copyright file="RateLimitFileService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// 各 CLI エージェントの statusline フックが書き出すレートリミット状態のローカル
+/// JSON ファイル（<c>&lt;settingsDirectory&gt;/ratelimit-status/&lt;agentId&gt;.json</c>）を読み取る.
+/// ファイルの中身は既存の <see cref="RateLimitStatusParser"/> が扱うスキーマ
+/// （<c>{"limits":[{"id","label","resetAt"}]}</c>）と同一であることを前提とする（#139）.
+/// </summary>
+internal sealed class RateLimitFileService
+{
+    private readonly string _directory;
+
+    public RateLimitFileService(string settingsDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(settingsDirectory))
+        {
+            throw new ArgumentException("設定保存先のディレクトリが不正です。", nameof(settingsDirectory));
+        }
+
+        _directory = Path.Combine(settingsDirectory, "ratelimit-status");
+    }
+
+    // agentId に対応するファイルが存在しない場合は null を返す（statusline スクリプト未拡張、
+    // またはまだ一度もレートリミット検知イベントが書き出されていないことを示す）.
+    public async Task<string?> ReadAgentStatusAsync(string agentId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(agentId))
+        {
+            throw new ArgumentException("agentId が空です。", nameof(agentId));
+        }
+
+        string path = Path.Combine(_directory, $"{agentId}.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        return await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+    }
+
+    // レートリミット表示に使う SourceUri（ReminderKey の一意化用）を組み立てる.
+    public static string BuildSourceIdentifier(string agentId) => $"agent://{agentId}";
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -15,6 +15,8 @@ internal sealed class SettingsService
 
     public AppSettings Settings => _settings;
 
+    public string SettingsDirectory => _settingsDirectory;
+
     public event EventHandler? SettingsChanged;
 
     public SettingsService()
@@ -215,6 +217,13 @@ internal sealed class SettingsService
         SaveSettings();
     }
 
+    public void UpdateRateLimitMonitoredAgentIds(IReadOnlyList<string> agentIds)
+    {
+        ArgumentNullException.ThrowIfNull(agentIds);
+        _settings.RateLimitMonitoredAgentIds = new List<string>(agentIds);
+        SaveSettings();
+    }
+
     public void UpdateSettings(
         string commandPath,
         string arguments,
@@ -313,4 +322,8 @@ internal sealed class AppSettings
     public int LauncherTimeoutMs { get; set; } = 300000;
 
     public string LastSkippedVersion { get; set; } = string.Empty;
+
+    // ローカルの statusline スクリプトがレートリミット状態を書き出すエージェント ID
+    // （RateLimitAgentCatalog 参照）のうち、監視対象として選択されているもの
+    public List<string> RateLimitMonitoredAgentIds { get; set; } = new();
 }


### PR DESCRIPTION
Closes #139

## 概要

レートリミット解除の事前通知予約機能（#114）で必要な `ratelimit://` Resource URI を手入力する必要があり、設定側に導線が無かった問題を解消します。

## 調査で判明した重要な事実（アーキテクチャの前提変更）

当初「`ratelimit://` は mcp-gateway 等の MCP サーバーが提供する」という前提で Issue が立てられていましたが、調査の結果これは誤りでした。

- `mcp-gateway` / `thread-owl` / `mcp-resource-subscriber` / `review-raven` の4リポジトリのいずれにも `ratelimit://` を提供する実装は存在しない
- 欲しい情報（5時間枠・週次枠の使用率とリセット時刻）は MCP サーバーが知る情報ではなく、**ローカルで動作する CLI エージェント自身が持つ情報**
- 各エージェントの **statusline フック**（stdin 経由で JSON を渡しターミナル表示をカスタマイズする機構）にこの情報が含まれることを実データで確認

### 対象3エージェントの実データ調査結果

| エージェント | statusline フック | 実データ |
|---|---|---|
| **claude-code** | ✅ | `rate_limits.{five_hour,seven_day}.resets_at`（UNIX epoch秒）を実際の statusline JSON で確認 |
| **agy（Antigravity CLI）** | ✅ | `quota.{3p-5h,3p-weekly,gemini-5h,gemini-weekly}.reset_time`（ISO8601）を実際のデバッグログで確認 |
| **codex** | ❌ | `tui.status_line` は組み込み表示のみで外部コマンドに JSON を渡さない。`notify` にも rate limit フィールドなし。機械可読な usage 出力も未実装（[openai/codex#16037](https://github.com/openai/codex/issues/16037)、[#20310](https://github.com/openai/codex/issues/20310)）。**現時点で技術的に対応不可能なため対応待ちとして除外** |

## 変更内容

### アーキテクチャ

```
[CLI エージェント] --statusline JSON--> [拡張した statusline スクリプト（squirrel-notifier 外）]
    --共通スキーマ {"limits":[{"id","label","resetAt"}]} で書き出し-->
[%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json] --読み取り--> [squirrel-notifier]
```

- 既存の MCP `ratelimit://` 経由の取得はサーバー側の将来対応に備え維持し、ローカルファイル経由の取得を追加してマージ表示
- `RateLimitAgentCatalog`（`Models/RateLimitAgentDefinition.cs`）にエージェント定義を集約し、将来の追加・削除を1箇所の変更で完結できるようにした
- statusline スクリプト自体の拡張（レートリミット検知時のファイル書き出し）は squirrel-notifier のスコープ外とし、`docs/statusline-integration.md` とサンプルスクリプト（`docs/samples/`）を用意してユーザーの dotfiles 側で適用する運用とした

### UI

「レートリミット状態」セクションに監視対象チェックボックス（claude-code / agy / codex[対応待ち・選択不可]）を追加。

## テスト

- `RateLimitFileServiceTests`: ローカルファイル読み取りの新規テスト
- `SettingsServiceTests`: `SettingsDirectory` / `UpdateRateLimitMonitoredAgentIds` の新規テスト
- 301 件全テスト合格、`dotnet format --verify-no-changes` 通過

## 確認方法

1. `docs/samples/` のスニペットを実際の statusline スクリプトに組み込む
2. エージェントを使用し `%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json` が生成されることを確認
3. Settings でエージェントのチェックボックスを ON にして「更新」→ レートリミット状態が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)