### PR TITLE
chore: v0.3.0 へバージョンバンプ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-06
+
 ### Added
 - レートリミット監視対象の CLI エージェントを Settings で選択できるようにした（#139）。「レートリミット状態」セクションに claude-code / agy（Antigravity CLI）のチェックボックスを追加し、選択したエージェントの statusline フックが書き出すローカル JSON ファイル（`%LOCALAPPDATA%\SquirrelNotifier\ratelimit-status\<agentId>.json`）を「更新」時に読み取って表示する。調査の結果 `ratelimit://` を提供する MCP サーバーは存在せず、レートリミット情報は各 CLI エージェント自身の statusline フックからローカルに取得する必要があることが判明したため、既存の MCP `resources/read` 経由の取得（`ratelimit://` URI、サーバー側の将来対応に備え維持）とは別に、ローカルファイル経由の取得経路を追加した。statusline スクリプト自体の拡張（レートリミット検知時のファイル書き出し）はユーザーの dotfiles 側で行うため、`docs/statusline-integration.md` と claude-code / agy 向けのサンプルスクリプトを追加した。エージェント定義は `RateLimitAgentCatalog` に集約し、将来の追加・削除が容易な構成にした。codex は statusline フックが外部コマンドに JSON を渡さず現時点で技術的に対応不可能なため、対応待ちとして選択不可の状態で表示する
 
@@ -142,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 開発用ツールセットの Python プロジェクト名を `squirrel-notifier-devtools` に変更
 - トレイ通知のイベント発生時、レビュー URL 開くボタンを（今回のスコープ外のため）一旦削除
 
-[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.1.1...v0.1.2

--- a/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
+++ b/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
@@ -5,9 +5,9 @@
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\squirrel-notifier.ico</ApplicationIcon>


### PR DESCRIPTION
## 概要

v0.3.0 リリース準備。#127〜#130、#139 の変更を含む。

## 変更内容

- `SquirrelNotifier.WinUI3.csproj` の Version/AssemblyVersion/FileVersion を `0.2.0` → `0.3.0` に更新
- `CHANGELOG.md` の `[Unreleased]` を `[0.3.0] - 2026-07-06` として確定、参照リンク定義も更新

## 含まれる変更（[0.3.0] セクション）

- feat: 起動ロールの設定切替を廃止し、イベント行で両ロールのアクションを提供（#127）
- feat: イベント行の「片付ける」アクション追加（#128）
- feat: イベント行キャプションに PR 番号を表示（#129）
- fix: 通知の「アプリを開く」ボタンが反応しない問題を修正（#130）
- feat: レートリミット監視対象の CLI エージェントを Settings で選択可能に（#139）

## 確認方法

- ビルド成功、既存テスト全合格を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)