### PR TITLE
feat: launcher エージェントを claude/codex/agy/copilot から選択できるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- reviewer / reviewed launcher スロットの実行エージェントを claude 固定から、claude / codex / agy / copilot のプリセットから選択できるようにした（#149）。`LauncherAgentCatalog` にエージェントごとの既定コマンド・引数テンプレート（codex / agy / copilot はスキル呼び出し機構を持たないため、プロンプト全文をテンプレートに埋め込む方式）と、レートリミット監視 agentId（`RateLimitAgentCatalog`）への対応付けを集約した。Settings UI にスロットごとのプリセット選択 ComboBox を追加し、選択時に command / arguments を既定値で埋める一方、従来どおりの自由編集も維持。保存時に現在の command / arguments を各プリセットの既定値と突き合わせて一致状況を判定し、どれとも一致しなければ「カスタム」として扱う。既存ユーザーの設定は一回限りの migration（`LauncherPresetsMigrated`）で移行時点の一致状況から初期プリセットを判定する。`SettingsService.ResolveLauncherRateLimitAgentId(LauncherRole)` により、launcher スロットからレートリミット監視 agentId を解決できるようにし、Auto-Pause（#147）が利用できるようにした。各エージェントへの MCP サーバー接続設定自体は Mcp-Docker の責務であり squirrel-notifier のスコープ外であることを `docs/launcher-agent-presets.md` に明記した。また、codex 等スキル機構を持たないエージェントが標準入力の EOF 待ちでハングする既知の問題（[openai/codex#20919](https://github.com/openai/codex/issues/20919)）を回避するため、`ReviewLauncherService` は起動直後に標準入力を閉じるようにした
+
 ## [0.3.0] - 2026-07-06
 
 ### Added

--- a/docs/launcher-agent-presets.md
+++ b/docs/launcher-agent-presets.md
@@ -1,0 +1,34 @@
+# 実行エージェントのプリセット化（#149）
+
+## 責務境界
+
+squirrel-notifier の launcher スロット（reviewer / reviewed）が扱うのは**どのコマンドをどの引数で起動するか**のみである。
+
+各エージェント（claude / codex / agy / copilot）が thread-owl 等の MCP サーバーへ接続するための設定（MCP サーバー登録、認証、ツール allowlist 等）は、squirrel-notifier のスコープ外であり、**Mcp-Docker の「CLI agent 設定自動化」の責務**とする。squirrel-notifier はプリセット選択に伴い MCP 接続設定を書き換えたり検証したりしない。
+
+## プリセット一覧
+
+`Models/LauncherAgentDefinition.cs` の `LauncherAgentCatalog.All` に集約する。新しいエージェントの追加・削除はこのカタログのみを変更すればよい。
+
+| プリセット ID | コマンド | 引数の方式 | rateLimitAgentId |
+|---|---|---|---|
+| `claude` | `claude` | `-p "/thread-owl-pr-reviewer ..."` のようなスキル呼び出し | `claude-code` |
+| `codex` | `codex` | `exec "..."` にプロンプト全文を埋め込み（スキル機構が無いため） | `codex`（レートリミット取得は対応待ち。[docs/statusline-integration.md](statusline-integration.md) 参照） |
+| `agy` | `agy` | `-p "..."` にプロンプト全文を埋め込み | `agy` |
+| `copilot` | `copilot` | `-p "..."` にプロンプト全文を埋め込み | `null`（レートリミット取得手段が無い） |
+
+codex / agy / copilot はスキル呼び出し機構を持たないため、claude 版スキルが行う指示内容（thread-owl MCP のツールを使ったレビュー・対応フロー）をプロンプト全文としてテンプレートに埋め込んでいる。実際に動作させるには、当該エージェントが thread-owl の MCP ツールを利用できるよう接続設定済みであることが前提（前述の責務境界により、この接続設定自体は squirrel-notifier の対象外）。
+
+## Settings UI での挙動
+
+- reviewer / reviewed 各スロットにプリセット選択 ComboBox を用意する。選択すると command / arguments が既定値で上書きされる
+- 選択後も command / arguments は自由編集できる。保存時（`LauncherAgentCatalog.ResolvePresetId`）に現在の command / arguments を各プリセットの既定値と突き合わせ、完全一致しなければ「カスタム」として扱う。プリセット選択 ComboBox はこの判定結果を表示するだけで、選択操作そのものを永続化するわけではない
+- 既存ユーザーの設定は `LauncherPresetsMigrated` フラグで一回だけ移行し、移行時点の command / arguments がどのプリセットと一致するかを判定して `ReviewerLauncherPresetId` / `ReviewedLauncherPresetId` に記録する
+
+## rateLimitAgentId の解決
+
+`SettingsService.ResolveLauncherRateLimitAgentId(LauncherRole)` が、指定したスロットに選択されているプリセットの `rateLimitAgentId` を返す。「カスタム」設定、および取得手段が無いプリセット（copilot）では `null` を返し、Auto-Pause（#147）はこれを gate 対象外として扱う。
+
+## codex exec のハング対策
+
+codex 等スキル機構を持たないエージェントは、プロンプトを引数で受け取っても標準入力の EOF を待って停止することがある（[openai/codex#20919](https://github.com/openai/codex/issues/20919)）。`ReviewLauncherService` は起動直後に標準入力を即座に閉じ、EOF を通知することでこれを回避している。

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
@@ -1,0 +1,67 @@
+// <copyright file="LauncherAgentCatalogTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Models;
+
+public class LauncherAgentCatalogTests
+{
+    [Fact]
+    public void All_ShouldHaveUniqueIds()
+    {
+        LauncherAgentCatalog.All.Select(a => a.Id).Should().OnlyHaveUniqueItems();
+    }
+
+    [Theory]
+    [InlineData("claude", "claude-code")]
+    [InlineData("codex", "codex")]
+    [InlineData("agy", "agy")]
+    [InlineData("copilot", null)]
+    public void All_ShouldMapExpectedRateLimitAgentId(string presetId, string? expectedRateLimitAgentId)
+    {
+        LauncherAgentDefinition? definition = LauncherAgentCatalog.Find(presetId);
+
+        definition.Should().NotBeNull();
+        definition!.RateLimitAgentId.Should().Be(expectedRateLimitAgentId);
+    }
+
+    [Fact]
+    public void Find_ShouldReturnNull_ForUnknownId()
+    {
+        LauncherAgentCatalog.Find("unknown-agent").Should().BeNull();
+    }
+
+    [Fact]
+    public void AllWithCustomOption_ShouldAppendCustomPreset()
+    {
+        LauncherAgentCatalog.AllWithCustomOption.Should().HaveCount(LauncherAgentCatalog.All.Count + 1);
+        LauncherAgentCatalog.AllWithCustomOption.Last().Id.Should().Be(LauncherAgentCatalog.CustomPresetId);
+    }
+
+    [Theory]
+    [InlineData("claude", "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "claude")]
+    [InlineData("claude", "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"", "reviewed", "claude")]
+    [InlineData("claude", "--something-else", "reviewer", LauncherAgentCatalog.CustomPresetId)]
+    [InlineData("unknown-cmd", "unknown-args", "reviewer", LauncherAgentCatalog.CustomPresetId)]
+    public void ResolvePresetId_ShouldMatchExactCommandAndArguments(string command, string arguments, string roleName, string expectedPresetId)
+    {
+        LauncherRole role = roleName == "reviewer" ? LauncherRole.Reviewer : LauncherRole.Reviewed;
+
+        LauncherAgentCatalog.ResolvePresetId(command, arguments, role).Should().Be(expectedPresetId);
+    }
+
+    [Fact]
+    public void ResolvePresetId_ShouldNotCrossMatchReviewerTemplateForReviewedRole()
+    {
+        // reviewer 用テンプレートを reviewed ロールで判定した場合は一致しない（custom 扱い）
+        LauncherAgentDefinition claude = LauncherAgentCatalog.Find("claude")!;
+
+        LauncherAgentCatalog.ResolvePresetId(claude.Command, claude.ReviewerArgumentsTemplate, LauncherRole.Reviewed)
+            .Should().Be(LauncherAgentCatalog.CustomPresetId);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/EnqueueReviewServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/EnqueueReviewServiceTests.cs
@@ -133,7 +133,8 @@ public class EnqueueReviewServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "mcp-resource-subscriber", "--skip-resource-list-check",
             "http://localhost:3000", new[] { "queue://review/queue" }, 30000,
-            "claude", "-p test", "claude", "-p test", 300000);
+            "claude", "-p test", "claude", "-p test", 300000,
+            "custom", "custom");
 
         Mock<IProcessInstance> callProcess = CreateMockProcess(0, "{\"isError\":false,\"content\":[]}", string.Empty);
         Mock<IProcessInstance> versionProcess = CreateVersionOkMockProcess();

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/McpSubscriptionServiceTests.cs
@@ -355,7 +355,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldPassArgumentsAndSecretsCorrectly()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
+        _settingsService.UpdateSettings("my-cmd", "--foo bar", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", "super-secret-token");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -511,7 +511,7 @@ public class McpSubscriptionServiceTests : IDisposable
     public async Task Start_ShouldSkipTokenAndArgumentsWhenEmpty()
     {
         // Arrange
-        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
+        _settingsService.UpdateSettings("my-cmd", "", "http://gateway:80", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
         Environment.SetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN", null);
 
         var preflightProcess = CreateMockProcess(0, "help", "");
@@ -703,7 +703,7 @@ public class McpSubscriptionServiceTests : IDisposable
         await File.WriteAllTextAsync(testCmd, "@echo off\r\nif \"%1\"==\"--help\" (\r\n    exit /b 0\r\n)\r\nexit /b 1\r\n", Encoding.ASCII);
 
         var settingsService = new SettingsService(tempDir);
-        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000);
+        settingsService.UpdateSettings(testCmd, "", "http://localhost:3000", new[] { "queue://res" }, 30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
 
         var runner = new ProcessRunner();
         await using var service = new McpSubscriptionService(settingsService, _notificationService, _loggingService, runner);
@@ -1101,7 +1101,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "queue://uri-two" },
-            30000, "review-raven", "", "review-raven", "", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var launchedUris = new System.Collections.Concurrent.ConcurrentBag<string>();
@@ -1154,7 +1154,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "ratelimit://status/claude" },
-            30000, "review-raven", "", "review-raven", "", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var launchedUris = new System.Collections.Concurrent.ConcurrentBag<string>();
@@ -1204,7 +1204,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "ratelimit://status/claude" },
-            30000, "review-raven", "", "review-raven", "", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         var mockRunner = new Mock<IProcessRunner>();
@@ -1240,7 +1240,7 @@ public class McpSubscriptionServiceTests : IDisposable
         _settingsService.UpdateSettings(
             "my-cmd", "", "http://gateway:80",
             new[] { "queue://uri-one", "queue://uri-two" },
-            30000, "review-raven", "", "review-raven", "", 300000);
+            30000, "review-raven", "", "review-raven", "", 300000, "custom", "custom");
 
         var preflightProcess = CreateMockProcess(0, "help", "");
         int retryingCount = 0;

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -44,6 +44,7 @@ public class ReviewLauncherServiceTests : IDisposable
         mockProcess.SetupGet(p => p.ExitCode).Returns(exitCode);
         mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout))));
         mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
+        mockProcess.SetupGet(p => p.StandardInput).Returns(new StreamWriter(new MemoryStream()));
 
         if (delayMs > 0)
         {
@@ -71,7 +72,8 @@ public class ReviewLauncherServiceTests : IDisposable
             "http://localhost:3000", new[] { "queue://res" }, 30000,
             reviewerCmd, reviewerArgs,
             reviewedCmd, reviewedArgs,
-            timeoutMs);
+            timeoutMs,
+            "custom", "custom");
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
 using SquirrelNotifier.WinUI3.Services;
 using Xunit;
 
@@ -119,9 +120,11 @@ public class SettingsServiceTests : IDisposable
         string reviewerArgs = "--reviewer-arg",
         string reviewedCmd = "reviewed-cmd",
         string reviewedArgs = "--reviewed-arg",
-        int launcherTimeout = 150000)
+        int launcherTimeout = 150000,
+        string reviewerPresetId = "custom",
+        string reviewedPresetId = "custom")
     {
-        _settingsService.UpdateSettings(cmd, args, url, uris ?? _defaultUris, timeout, reviewerCmd, reviewerArgs, reviewedCmd, reviewedArgs, launcherTimeout);
+        _settingsService.UpdateSettings(cmd, args, url, uris ?? _defaultUris, timeout, reviewerCmd, reviewerArgs, reviewedCmd, reviewedArgs, launcherTimeout, reviewerPresetId, reviewedPresetId);
     }
 
     [Fact]
@@ -142,6 +145,8 @@ public class SettingsServiceTests : IDisposable
         _settingsService.Settings.ReviewedLauncherCommandPath.Should().Be("reviewed-cmd");
         _settingsService.Settings.ReviewedLauncherArguments.Should().Be("--reviewed-arg");
         _settingsService.Settings.LauncherTimeoutMs.Should().Be(150000);
+        _settingsService.Settings.ReviewerLauncherPresetId.Should().Be("custom");
+        _settingsService.Settings.ReviewedLauncherPresetId.Should().Be("custom");
     }
 
     [Fact]
@@ -171,6 +176,14 @@ public class SettingsServiceTests : IDisposable
     [Fact]
     public void UpdateSettings_ShouldThrowForEmptyReviewedCommandPath()
         => FluentActions.Invoking(() => UpdateSettingsDefault(reviewedCmd: "")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyReviewerPresetId()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(reviewerPresetId: "")).Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void UpdateSettings_ShouldThrowForEmptyReviewedPresetId()
+        => FluentActions.Invoking(() => UpdateSettingsDefault(reviewedPresetId: "")).Should().Throw<ArgumentException>();
 
     [Theory]
     [InlineData(0)]
@@ -408,5 +421,132 @@ public class SettingsServiceTests : IDisposable
         {
             Directory.Delete(settingsDir, true);
         }
+    }
+
+    [Fact]
+    public void LauncherPresetsMigration_ShouldSetClaudePreset_WhenSettingsMatchClaudeDefaults()
+    {
+        // Arrange: 既定の claude command/arguments のまま LauncherPresetsMigrated が未実施の設定
+        LauncherAgentDefinition claude = LauncherAgentCatalog.Find("claude")!;
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierPresetMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = claude.Command,
+            ReviewerLauncherArguments = claude.ReviewerArgumentsTemplate,
+            ReviewedLauncherCommandPath = claude.Command,
+            ReviewedLauncherArguments = claude.ReviewedArgumentsTemplate,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = false,
+        };
+        File.WriteAllText(settingsPath, System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert
+            service.Settings.ReviewerLauncherPresetId.Should().Be("claude");
+            service.Settings.ReviewedLauncherPresetId.Should().Be("claude");
+            service.Settings.LauncherPresetsMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void LauncherPresetsMigration_ShouldSetCustomPreset_WhenSettingsAreCustomized()
+    {
+        // Arrange: プリセットのどれとも一致しないカスタム command/arguments
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierPresetMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "my-custom-tool",
+            ReviewerLauncherArguments = "--custom",
+            ReviewedLauncherCommandPath = "my-custom-tool",
+            ReviewedLauncherArguments = "--custom",
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = false,
+        };
+        File.WriteAllText(settingsPath, System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert
+            service.Settings.ReviewerLauncherPresetId.Should().Be(LauncherAgentCatalog.CustomPresetId);
+            service.Settings.ReviewedLauncherPresetId.Should().Be(LauncherAgentCatalog.CustomPresetId);
+            service.Settings.LauncherPresetsMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void LauncherPresetsMigration_ShouldSkipWhenAlreadyMigrated()
+    {
+        // Arrange: 既に移行済みで、実際の command/arguments とは矛盾する presetId を持つ設定
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierPresetMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        string settingsPath = Path.Combine(settingsDir, "settings.json");
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "my-custom-tool",
+            ReviewerLauncherArguments = "--custom",
+            ReviewerLauncherPresetId = "codex",
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = true,
+        };
+        File.WriteAllText(settingsPath, System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: 既に移行済みなので再判定されず、矛盾していても上書きされない
+            service.Settings.ReviewerLauncherPresetId.Should().Be("codex");
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("claude", "claude-code")]
+    [InlineData("codex", "codex")]
+    [InlineData("agy", "agy")]
+    [InlineData("copilot", null)]
+    public void ResolveLauncherRateLimitAgentId_ShouldReturnMappedId_ForKnownPresets(string presetId, string? expectedRateLimitAgentId)
+    {
+        LauncherAgentDefinition definition = LauncherAgentCatalog.Find(presetId)!;
+        _settingsService.UpdateSettings(
+            "cmd", "args", "http://localhost:3000", new[] { "queue://res" }, 30000,
+            definition.Command, definition.ReviewerArgumentsTemplate,
+            definition.Command, definition.ReviewedArgumentsTemplate,
+            300000, presetId, presetId);
+
+        _settingsService.ResolveLauncherRateLimitAgentId(LauncherRole.Reviewer).Should().Be(expectedRateLimitAgentId);
+        _settingsService.ResolveLauncherRateLimitAgentId(LauncherRole.Reviewed).Should().Be(expectedRateLimitAgentId);
+    }
+
+    [Fact]
+    public void ResolveLauncherRateLimitAgentId_ShouldReturnNull_ForCustomPreset()
+    {
+        UpdateSettingsDefault(reviewerPresetId: "custom", reviewedPresetId: "custom");
+
+        _settingsService.ResolveLauncherRateLimitAgentId(LauncherRole.Reviewer).Should().BeNull();
+        _settingsService.ResolveLauncherRateLimitAgentId(LauncherRole.Reviewed).Should().BeNull();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -40,7 +40,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="240">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -75,28 +75,38 @@
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Timeout (ms):" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="4" Grid.Column="1" x:Name="TimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Reviewer Path:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" x:Name="ReviewerPathBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Reviewer Preset:" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="5" Grid.Column="1" x:Name="ReviewerPresetComboBox"
+                              DisplayMemberPath="DisplayName"
+                              SelectionChanged="OnReviewerPresetSelectionChanged"/>
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Reviewer Args:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="ReviewerArgumentsBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Reviewer Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" x:Name="ReviewerPathBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Reviewed Path:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="7" Grid.Column="1" x:Name="ReviewedPathBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="Reviewer Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="7" Grid.Column="1" x:Name="ReviewerArgumentsBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="8" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Reviewed Preset:" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="8" Grid.Column="1" x:Name="ReviewedPresetComboBox"
+                              DisplayMemberPath="DisplayName"
+                              SelectionChanged="OnReviewedPresetSelectionChanged"/>
 
-                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
-                    <NumberBox Grid.Row="9" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Reviewed Path:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="9" Grid.Column="1" x:Name="ReviewedPathBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="10" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="10" Grid.Column="1" x:Name="AutoStartToggle"
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="10" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
+
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
+                    <NumberBox Grid.Row="11" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="12" Grid.Column="1" x:Name="AutoStartToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnAutoStartToggled"/>
 
-                    <TextBlock Grid.Row="11" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="11" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                    <TextBlock Grid.Row="13" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="13" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
                         <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
                     </StackPanel>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -44,6 +44,7 @@ internal sealed partial class MainWindow : Window
     private bool _isCheckingForUpdates;
     private bool _hasShownErrorBalloon;
     private bool _isAutoStartToggling;
+    private bool _isSyncingLauncherPresetSelection;
     private CancellationTokenSource? _copyFeedbackCts;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
@@ -136,6 +137,11 @@ internal sealed partial class MainWindow : Window
         ReviewedPathBox.Text = settings.ReviewedLauncherCommandPath;
         ReviewedArgumentsBox.Text = settings.ReviewedLauncherArguments;
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
+
+        ReviewerPresetComboBox.ItemsSource = Models.LauncherAgentCatalog.AllWithCustomOption;
+        ReviewedPresetComboBox.ItemsSource = Models.LauncherAgentCatalog.AllWithCustomOption;
+        UpdateLauncherPresetComboBoxSelection(ReviewerPresetComboBox, settings.ReviewerLauncherPresetId);
+        UpdateLauncherPresetComboBoxSelection(ReviewedPresetComboBox, settings.ReviewedLauncherPresetId);
 
         ReasonComboBox.ItemsSource = _enqueueReviewReasons;
         ReasonComboBox.SelectedIndex = 0;
@@ -411,6 +417,66 @@ internal sealed partial class MainWindow : Window
         }
 
         SaveCurrentSettings();
+    }
+
+    // プリセット選択（#149）: ComboBox で選んだプリセットの command / arguments を
+    // テキストボックスへ反映する。反映後の TextChanged から SaveCurrentSettings が呼ばれ、
+    // 実際に永続化されるプリセット ID は（選択操作ではなく）その時点のテキスト内容から
+    // LauncherAgentCatalog.ResolvePresetId で再判定する。自由編集でプリセットと乖離した場合に
+    // 「カスタム」表示へ自然に戻すため.
+    private void OnReviewerPresetSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing || _isSyncingLauncherPresetSelection)
+        {
+            return;
+        }
+
+        ApplyLauncherPreset(ReviewerPresetComboBox, ReviewerPathBox, ReviewerArgumentsBox, static d => d.ReviewerArgumentsTemplate);
+    }
+
+    private void OnReviewedPresetSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializing || _isSyncingLauncherPresetSelection)
+        {
+            return;
+        }
+
+        ApplyLauncherPreset(ReviewedPresetComboBox, ReviewedPathBox, ReviewedArgumentsBox, static d => d.ReviewedArgumentsTemplate);
+    }
+
+    private static void ApplyLauncherPreset(ComboBox comboBox, TextBox pathBox, TextBox argumentsBox, Func<Models.LauncherAgentDefinition, string> argumentsTemplateSelector)
+    {
+        if (comboBox.SelectedItem is not Models.LauncherAgentDefinition selected
+            || selected.Id == Models.LauncherAgentCatalog.CustomPresetId)
+        {
+            return;
+        }
+
+        pathBox.Text = selected.Command;
+        argumentsBox.Text = argumentsTemplateSelector(selected);
+    }
+
+    // combo box の選択を command / arguments の実値から再判定した presetId へ同期する。
+    // SelectionChanged のフィルイン処理を再帰させないよう _isSyncingLauncherPresetSelection で防護する.
+    private void UpdateLauncherPresetComboBoxSelection(ComboBox comboBox, string presetId)
+    {
+        Models.LauncherAgentDefinition? match = Models.LauncherAgentCatalog.AllWithCustomOption
+            .FirstOrDefault(d => d.Id == presetId);
+
+        if (Equals(comboBox.SelectedItem, match))
+        {
+            return;
+        }
+
+        _isSyncingLauncherPresetSelection = true;
+        try
+        {
+            comboBox.SelectedItem = match;
+        }
+        finally
+        {
+            _isSyncingLauncherPresetSelection = false;
+        }
     }
 
     private async void OnAutoDetectGatewayUrlClick(object sender, RoutedEventArgs e)
@@ -766,6 +832,11 @@ internal sealed partial class MainWindow : Window
             string reviewedArguments = ReviewedArgumentsBox.Text;
             int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 300000 : (int)LauncherTimeoutBox.Value;
 
+            string reviewerPresetId = Models.LauncherAgentCatalog.ResolvePresetId(reviewerPath, reviewerArguments, Models.LauncherRole.Reviewer);
+            string reviewedPresetId = Models.LauncherAgentCatalog.ResolvePresetId(reviewedPath, reviewedArguments, Models.LauncherRole.Reviewed);
+            UpdateLauncherPresetComboBoxSelection(ReviewerPresetComboBox, reviewerPresetId);
+            UpdateLauncherPresetComboBoxSelection(ReviewedPresetComboBox, reviewedPresetId);
+
             _settingsService.UpdateSettings(
                 commandPath,
                 arguments,
@@ -776,7 +847,9 @@ internal sealed partial class MainWindow : Window
                 reviewerArguments,
                 reviewedPath,
                 reviewedArguments,
-                launcherTimeoutMs);
+                launcherTimeoutMs,
+                reviewerPresetId,
+                reviewedPresetId);
         }
         catch
         {

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ internal sealed partial class MainWindow : Window
     private bool _hasShownErrorBalloon;
     private bool _isAutoStartToggling;
     private bool _isSyncingLauncherPresetSelection;
+    private bool _isApplyingLauncherPreset;
     private CancellationTokenSource? _copyFeedbackCts;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
@@ -411,7 +412,7 @@ internal sealed partial class MainWindow : Window
 
     private void OnSettingChanged(object sender, TextChangedEventArgs e)
     {
-        if (_isInitializing)
+        if (_isInitializing || _isApplyingLauncherPreset)
         {
             return;
         }
@@ -444,7 +445,7 @@ internal sealed partial class MainWindow : Window
         ApplyLauncherPreset(ReviewedPresetComboBox, ReviewedPathBox, ReviewedArgumentsBox, static d => d.ReviewedArgumentsTemplate);
     }
 
-    private static void ApplyLauncherPreset(ComboBox comboBox, TextBox pathBox, TextBox argumentsBox, Func<Models.LauncherAgentDefinition, string> argumentsTemplateSelector)
+    private void ApplyLauncherPreset(ComboBox comboBox, TextBox pathBox, TextBox argumentsBox, Func<Models.LauncherAgentDefinition, string> argumentsTemplateSelector)
     {
         if (comboBox.SelectedItem is not Models.LauncherAgentDefinition selected
             || selected.Id == Models.LauncherAgentCatalog.CustomPresetId)
@@ -452,8 +453,23 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
-        pathBox.Text = selected.Command;
-        argumentsBox.Text = argumentsTemplateSelector(selected);
+        // path / arguments の反映中は TextChanged 経由の SaveCurrentSettings を抑止し、
+        // 両方反映し終えた後で一度だけ再判定・保存する。反映中に保存すると、arguments が
+        // たまたま反映先プリセットの値と一致している場合に arguments 側の TextChanged が
+        // 発火せず（値が変わらないため）、path のみ変更された中間状態（= custom 判定）の
+        // まま presetId が固定されてしまう（#149 レビュー対応）.
+        _isApplyingLauncherPreset = true;
+        try
+        {
+            pathBox.Text = selected.Command;
+            argumentsBox.Text = argumentsTemplateSelector(selected);
+        }
+        finally
+        {
+            _isApplyingLauncherPreset = false;
+        }
+
+        SaveCurrentSettings();
     }
 
     // combo box の選択を command / arguments の実値から再判定した presetId へ同期する。

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
@@ -1,0 +1,120 @@
+// <copyright file="LauncherAgentDefinition.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// reviewer / reviewed launcher スロットへ既定のコマンド・引数テンプレートを提供する
+/// 実行エージェントの定義（#149）。.
+/// </summary>
+/// <param name="Id">プリセット ID。<see cref="RateLimitAgentDefinition.Id"/> とは独立した名前空間.</param>
+/// <param name="DisplayName">Settings UI に表示する名称.</param>
+/// <param name="Command">既定のコマンド（<c>CommandPath</c>）.</param>
+/// <param name="ReviewerArgumentsTemplate">reviewer スロット用の既定引数テンプレート.</param>
+/// <param name="ReviewedArgumentsTemplate">reviewed スロット用の既定引数テンプレート.</param>
+/// <param name="RateLimitAgentId">
+/// レートリミット監視エージェント ID（<see cref="RateLimitAgentCatalog"/> の Id）への対応付け。
+/// 取得手段が無いエージェントは <see langword="null"/>.
+/// </param>
+internal sealed record LauncherAgentDefinition(
+    string Id,
+    string DisplayName,
+    string Command,
+    string ReviewerArgumentsTemplate,
+    string ReviewedArgumentsTemplate,
+    string? RateLimitAgentId);
+
+/// <summary>
+/// launcher スロットに選択できる実行エージェントのプリセット一覧（#149）.
+/// 新しいエージェントを追加・削除する場合はこのリストのみを変更する.
+/// </summary>
+internal static class LauncherAgentCatalog
+{
+    /// <summary>
+    /// カタログのどのプリセットとも一致しない、自由編集された設定値を表す ID.
+    /// </summary>
+    public const string CustomPresetId = "custom";
+
+    /// <summary>
+    /// Settings UI のプリセット選択 ComboBox 専用の「カスタム」項目。command / arguments が
+    /// どのプリセットとも一致しない自由編集状態であることを表す（起動には使われない）.
+    /// </summary>
+    public static readonly LauncherAgentDefinition CustomPreset = new(
+        CustomPresetId, "カスタム", string.Empty, string.Empty, string.Empty, null);
+
+    public static readonly IReadOnlyList<LauncherAgentDefinition> All =
+    [
+        new LauncherAgentDefinition(
+            "claude",
+            "claude",
+            "claude",
+            "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"",
+            "claude-code"),
+
+        // codex / agy / copilot はスキル呼び出し機構を持たないため、プロンプト全文を
+        // テンプレートに埋め込む（MCP サーバー接続設定自体は Mcp-Docker の責務）.
+        new LauncherAgentDefinition(
+            "codex",
+            "codex",
+            "codex",
+            "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
+            "codex"),
+
+        new LauncherAgentDefinition(
+            "agy",
+            "agy (Antigravity CLI)",
+            "agy",
+            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
+            "agy"),
+
+        new LauncherAgentDefinition(
+            "copilot",
+            "copilot (GitHub Copilot CLI)",
+            "copilot",
+            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
+            null),
+    ];
+
+    /// <summary>
+    /// <see cref="All"/> に <see cref="CustomPreset"/> を加えた、Settings UI のプリセット選択
+    /// ComboBox 用の一覧.
+    /// </summary>
+    public static readonly IReadOnlyList<LauncherAgentDefinition> AllWithCustomOption = [.. All, CustomPreset];
+
+    /// <summary>
+    /// 指定した ID のプリセットを取得する。見つからない場合は <see langword="null"/>.
+    /// </summary>
+    /// <param name="id">プリセット ID.</param>
+    /// <returns>一致したプリセット。見つからない場合は <see langword="null"/>.</returns>
+    public static LauncherAgentDefinition? Find(string id) => All.FirstOrDefault(d => d.Id == id);
+
+    /// <summary>
+    /// 現在の command / arguments 値がどのプリセットと一致するかを判定する。
+    /// どれとも一致しない場合は <see cref="CustomPresetId"/> を返す.
+    /// </summary>
+    /// <param name="command">現在の command 値.</param>
+    /// <param name="arguments">現在の arguments 値.</param>
+    /// <param name="role">判定対象の launcher スロット.</param>
+    /// <returns>一致したプリセットの ID。一致しない場合は <see cref="CustomPresetId"/>.</returns>
+    public static string ResolvePresetId(string command, string arguments, LauncherRole role)
+    {
+        foreach (LauncherAgentDefinition definition in All)
+        {
+            string expectedArguments = role == LauncherRole.Reviewer
+                ? definition.ReviewerArgumentsTemplate
+                : definition.ReviewedArgumentsTemplate;
+
+            if (definition.Command == command && expectedArguments == arguments)
+            {
+                return definition.Id;
+            }
+        }
+
+        return CustomPresetId;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/IProcessRunner.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IProcessRunner.cs
@@ -19,6 +19,8 @@ internal interface IProcessInstance : IDisposable
 
     StreamReader StandardError { get; }
 
+    StreamWriter StandardInput { get; }
+
     void Kill(bool entireProcessTree);
 
     Task WaitForExitAsync(CancellationToken cancellationToken);

--- a/winui3/SquirrelNotifier.WinUI3/Services/ProcessRunner.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ProcessRunner.cs
@@ -34,6 +34,8 @@ internal sealed class ProcessInstance : IProcessInstance
 
     public StreamReader StandardError => _process.StandardError;
 
+    public StreamWriter StandardInput => _process.StandardInput;
+
     public void Kill(bool entireProcessTree)
     {
         _process.Kill(entireProcessTree);

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -87,6 +87,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                RedirectStandardInput = true,
                 StandardOutputEncoding = System.Text.Encoding.UTF8,
                 StandardErrorEncoding = System.Text.Encoding.UTF8,
             };
@@ -106,6 +107,10 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
 
                 _activeProcess = _processRunner.Start(psi);
             }
+
+            // codex exec 等、スキル呼び出し機構を持たずプロンプト全文を引数で受け取るエージェントは
+            // stdin の EOF を待って停止することがあるため、標準入力を即座に閉じて EOF を通知する.
+            _activeProcess.StandardInput.Close();
 
             // Start reading stdout / stderr as tasks to avoid deadlock
             Task<string> stdoutTask = _activeProcess.StandardOutput.ReadToEndAsync(combinedToken);

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using SquirrelNotifier.WinUI3.Models;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
@@ -62,6 +63,19 @@ internal sealed class SettingsService
             }
 
             _settings.LauncherSlotsMigrated = true;
+            SaveSettings();
+        }
+
+        // launcher スロットの command / arguments がどのエージェントプリセットと一致するかを
+        // 一回だけ判定して記録する（#149）。一致しない場合は「カスタム」として扱う.
+        if (!_settings.LauncherPresetsMigrated)
+        {
+            _settings.ReviewerLauncherPresetId = LauncherAgentCatalog.ResolvePresetId(
+                _settings.ReviewerLauncherCommandPath, _settings.ReviewerLauncherArguments, LauncherRole.Reviewer);
+            _settings.ReviewedLauncherPresetId = LauncherAgentCatalog.ResolvePresetId(
+                _settings.ReviewedLauncherCommandPath, _settings.ReviewedLauncherArguments, LauncherRole.Reviewed);
+
+            _settings.LauncherPresetsMigrated = true;
             SaveSettings();
         }
 
@@ -224,6 +238,22 @@ internal sealed class SettingsService
         SaveSettings();
     }
 
+    /// <summary>
+    /// 指定した launcher スロットに現在選択されているプリセットの rateLimitAgentId を解決する（#149）。
+    /// 「カスタム」設定、またはレートリミット取得手段が無いプリセット（copilot 等）の場合は
+    /// <see langword="null"/> を返す（Auto-Pause の gate 対象外として扱う #147）.
+    /// </summary>
+    /// <param name="role">解決対象の launcher スロット.</param>
+    /// <returns>対応する rateLimitAgentId。無い場合は <see langword="null"/>.</returns>
+    public string? ResolveLauncherRateLimitAgentId(LauncherRole role)
+    {
+        string presetId = role == LauncherRole.Reviewer
+            ? _settings.ReviewerLauncherPresetId
+            : _settings.ReviewedLauncherPresetId;
+
+        return LauncherAgentCatalog.Find(presetId)?.RateLimitAgentId;
+    }
+
     public void UpdateSettings(
         string commandPath,
         string arguments,
@@ -234,7 +264,9 @@ internal sealed class SettingsService
         string reviewerLauncherArguments,
         string reviewedLauncherCommandPath,
         string reviewedLauncherArguments,
-        int launcherTimeoutMs)
+        int launcherTimeoutMs,
+        string reviewerLauncherPresetId,
+        string reviewedLauncherPresetId)
     {
         if (string.IsNullOrWhiteSpace(commandPath))
         {
@@ -272,6 +304,16 @@ internal sealed class SettingsService
             throw new ArgumentOutOfRangeException(nameof(launcherTimeoutMs), "Launcher timeout must be between 1 and 300000 ms");
         }
 
+        if (string.IsNullOrWhiteSpace(reviewerLauncherPresetId))
+        {
+            throw new ArgumentException("Reviewer launcher preset id cannot be empty", nameof(reviewerLauncherPresetId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reviewedLauncherPresetId))
+        {
+            throw new ArgumentException("Reviewed launcher preset id cannot be empty", nameof(reviewedLauncherPresetId));
+        }
+
         _settings.SubscriberCommandPath = commandPath;
         _settings.SubscriberArguments = arguments;
         _settings.GatewayUrl = gatewayUrl;
@@ -283,6 +325,8 @@ internal sealed class SettingsService
         _settings.ReviewedLauncherCommandPath = reviewedLauncherCommandPath;
         _settings.ReviewedLauncherArguments = reviewedLauncherArguments;
         _settings.LauncherTimeoutMs = launcherTimeoutMs;
+        _settings.ReviewerLauncherPresetId = reviewerLauncherPresetId;
+        _settings.ReviewedLauncherPresetId = reviewedLauncherPresetId;
         SaveSettings();
     }
 }
@@ -318,6 +362,14 @@ internal sealed class AppSettings
     public string ReviewedLauncherArguments { get; set; } = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
 
     public bool LauncherSlotsMigrated { get; set; }
+
+    // launcher スロットに選択されているエージェントプリセット ID（LauncherAgentCatalog 参照）。
+    // 自由編集でどのプリセットとも一致しなくなった場合は LauncherAgentCatalog.CustomPresetId になる.
+    public string ReviewerLauncherPresetId { get; set; } = "claude";
+
+    public string ReviewedLauncherPresetId { get; set; } = "claude";
+
+    public bool LauncherPresetsMigrated { get; set; }
 
     public int LauncherTimeoutMs { get; set; } = 300000;
 


### PR DESCRIPTION
Closes #149

## 概要

reviewer / reviewed launcher スロットの実行コマンドが claude 固定（自由文字列の書き換えでのみ差し替え可能）だった問題を解消し、`LauncherAgentCatalog` によるプリセット選択方式に変更した。

## 変更内容

### `LauncherAgentCatalog`（新規: `Models/LauncherAgentDefinition.cs`）
- claude / codex / agy / copilot それぞれの既定コマンド・reviewer/reviewed 引数テンプレートを集約
- codex / agy / copilot はスキル呼び出し機構を持たないため、thread-owl MCP のツール利用を明示指示するプロンプト全文をテンプレートに埋め込み方式にした
- `rateLimitAgentId` への対応付け（claude→claude-code, codex→codex[対応待ち], agy→agy, copilot→null[取得手段なし]）
- `ResolvePresetId(command, arguments, role)` で現在の設定値がどのプリセットと一致するか判定し、一致しなければ `custom` を返す

### `SettingsService`
- `ReviewerLauncherPresetId` / `ReviewedLauncherPresetId` を追加し、`LauncherPresetsMigrated` フラグで既存ユーザー向けの一回限り migration を実装（現在の command/arguments がどのプリセットと一致するかを判定して初期値を設定）
- `ResolveLauncherRateLimitAgentId(LauncherRole)` を追加。Auto-Pause（#147）が launcher スロットからレートリミット監視 agentId を解決するための API

### Settings UI（`MainWindow.xaml` / `.xaml.cs`）
- reviewer / reviewed 各スロットにプリセット選択 ComboBox を追加。選択すると command / arguments が既定値で上書きされる
- 選択後も自由編集は可能。保存時に現在の command / arguments を各プリセットの既定値と突き合わせて再判定し、プリセットから外れた編集は自動的に「カスタム」表示へ戻す（ComboBox の選択自体は永続化の起点ではなく、あくまで判定結果の表示）

### `ReviewLauncherService`
- codex 等スキル機構を持たないエージェントが標準入力の EOF 待ちでハングする既知の問題（[openai/codex#20919](https://github.com/openai/codex/issues/20919)）を避けるため、起動直後に標準入力を閉じるようにした（`IProcessRunner` / `IProcessInstance` に `StandardInput` を追加）

### ドキュメント
- `docs/launcher-agent-presets.md`（新規）: 各エージェントへの MCP サーバー接続設定は Mcp-Docker の責務であり、squirrel-notifier はコマンド・引数のみを扱うという責務境界を明記

## 意図的にスコープ外とした点

- progress event 対応度フィールド（#143 の contract 未確定のため）→ 別Issue化: #151
- 既存の reviewed launcher 既定値のスキル名不一致バグ（`/thread-owl-review-cycle` が実在しない）→ 別Issue化: #150（本PRのカタログはこの既存バグをそのまま踏襲し、migration の一致判定に影響を与えないようにしている）

## テスト

- `LauncherAgentCatalogTests`（新規）、`SettingsServiceTests` に migration / `ResolveLauncherRateLimitAgentId` のケースを追加
- 既存テストの `UpdateSettings` 呼び出し箇所を新シグネチャに追従
- 329件全テスト合格、カバレッジ Line 89.26% / Branch 85.48% / Method 93.83%
- `dotnet format --verify-no-changes` / `dotnet build` / `dotnet test` すべて成功

## 確認方法

1. Settings 画面で Reviewer Preset / Reviewed Preset の ComboBox から codex 等を選択し、Path / Args が既定値で埋まることを確認
2. Args を手動編集した後、設定を再読込すると ComboBox が「カスタム」表示に切り替わることを確認
3. 既存ユーザー設定（claude 既定値のまま）で migration 後 `ReviewerLauncherPresetId` が `claude` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)