### PR TITLE
feat: エージェント実行イベントのストリーミング基盤と progress event contract を導入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- エージェント実行イベントのストリーミング基盤と構造化 progress event contract を導入した（#143）。`ReviewLauncherService` がプロセス終了後に stdout / stderr を一括取得していた方式を行単位の逐次読み取りへ変更し、`AgentExecutionSession` から stdout / stderr / progress / completed の型付きイベントを実行中に購読できるようにした（`IReviewLauncherService.StartSession`。既存の `LaunchAsync` と `LauncherResult` の意味は維持）。progress event は stdout に混在する行頭マーカー `@squirrel-progress ` 付きの 1 行 JSON（schemaVersion / phaseIndex / totalPhases / phaseLabel / message / verdict / timestamp）とし、phase はエージェント非依存の汎用構造（0 始まり index / total / label）で phase 数を固定しない。マーカー不一致・malformed JSON・未知 schemaVersion の行は通常ログとして安全に流し、実行は失敗させない。成功・失敗・キャンセル・タイムアウトは区別された terminal event として通知する。producer 側の統合は `docs/progress-event-contract.md` とスキル組み込み用スニペット `docs/samples/skill-progress-snippet.md` を参照（statusline 連携と同じく、スキル定義への適用はユーザーの dotfiles / skills 側で行う）
+
+### Changed
+- Launcher Timeout の既定値を 5 分から 30 分へ、設定上限を 5 分から 2 時間へ変更した（#143）。レビューサイクルは 5 分を大きく超えることがあり、「長時間実行の可視化」という親 Epic #142 の前提と矛盾していたため。既存ユーザーの保存済み設定値は変更されない
+
+### Added
 - reviewer / reviewed launcher スロットの実行エージェントを claude 固定から、claude / codex / agy / copilot のプリセットから選択できるようにした（#149）。`LauncherAgentCatalog` にエージェントごとの既定コマンド・引数テンプレート（codex / agy / copilot はスキル呼び出し機構を持たないため、プロンプト全文をテンプレートに埋め込む方式）と、レートリミット監視 agentId（`RateLimitAgentCatalog`）への対応付けを集約した。Settings UI にスロットごとのプリセット選択 ComboBox を追加し、選択時に command / arguments を既定値で埋める一方、従来どおりの自由編集も維持。保存時に現在の command / arguments を各プリセットの既定値と突き合わせて一致状況を判定し、どれとも一致しなければ「カスタム」として扱う。既存ユーザーの設定は一回限りの migration（`LauncherPresetsMigrated`）で移行時点の一致状況から初期プリセットを判定する。`SettingsService.ResolveLauncherRateLimitAgentId(LauncherRole)` により、launcher スロットからレートリミット監視 agentId を解決できるようにし、Auto-Pause（#147）が利用できるようにした。各エージェントへの MCP サーバー接続設定自体は Mcp-Docker の責務であり squirrel-notifier のスコープ外であることを `docs/launcher-agent-presets.md` に明記した。また、codex 等スキル機構を持たないエージェントが標準入力の EOF 待ちでハングする既知の問題（[openai/codex#20919](https://github.com/openai/codex/issues/20919)）を回避するため、`ReviewLauncherService` は起動直後に標準入力を閉じるようにした
 
 ## [0.3.0] - 2026-07-06

--- a/docs/progress-event-contract.md
+++ b/docs/progress-event-contract.md
@@ -1,0 +1,54 @@
+# エージェント実行の progress event contract（#143）
+
+## 背景
+
+squirrel-notifier の launcher は、エージェント実行中の stdout / stderr を逐次読み取り、UI 層へ型付きイベント（stdout / stderr / progress / completed）として配信する（`AgentExecutionSession`）。
+
+このうち **progress**（phase 表示・Verdict）は自然言語ログからの推測では扱わず、エージェント（またはラッパー）が明示的に出力する構造化イベントのみを解釈する。このページはその contract（producer が出力すべき形式）を定義する。
+
+```
+[エージェント / スキル] --stdout に @squirrel-progress JSONL を混在--> [squirrel-notifier ReviewLauncherService]
+    --型付きイベント--> [AgentExecutionSession] --購読--> [UI（ライブログウィンドウ #144）]
+```
+
+squirrel-notifier リポジトリ側は「マーカー行を解釈する機能」のみを実装する。各エージェントのスキル定義への出力指示の組み込みは、ユーザー自身の dotfiles / skills 側で行う（レートリミットの [statusline 連携](statusline-integration.md) と同じ責務分担）。
+
+## 輸送路
+
+progress event は **stdout に混在する、行頭マーカー付きの 1 行 JSON（JSONL）** として出力する。
+
+- 行頭マーカー: `@squirrel-progress `（半角スペース 1 つを含む完全一致、大文字小文字区別あり）
+- マーカーの直後から行末までが JSON オブジェクト 1 個
+- 1 イベント = 1 行。改行を含む JSON は不可
+
+```
+@squirrel-progress {"schemaVersion":1,"phaseIndex":3,"totalPhases":8,"phaseLabel":"修正","message":"accept 2件を修正中","timestamp":"2026-07-11T10:00:00Z"}
+```
+
+通常ログとの偶然の衝突は、行頭マーカーと schemaVersion 検証の二段構えで排除する。マーカーに一致しない行・JSON として不正な行・検証に通らない行は、すべて**通常の stdout ログとしてそのまま流れる**（launcher の実行自体は失敗しない）。
+
+## schema v1
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `schemaVersion` | int | ✅ | `1` 固定。将来の互換性のないスキーマ変更でインクリメントする。未知のバージョンは通常ログとして扱われる |
+| `phaseIndex` | int | ✅ | 現在の phase の **0 始まり**インデックス（0 以上） |
+| `totalPhases` | int | ✅ | ワークフロー全体の phase 数（1 以上） |
+| `phaseLabel` | string | ✅ | phase の表示名（空白のみは不可）。例: `"修正"`, `"Verdict 待機"` |
+| `message` | string | — | phase 内の補足メッセージ |
+| `verdict` | string | — | レビュー Verdict が確定した時点で含める。例: `"APPROVED"` |
+| `timestamp` | string (ISO 8601) | — | producer 側のイベント時刻。省略時は squirrel-notifier 側の受信時刻のみが使われる |
+
+phase 構成はエージェント非依存であり、phase 数を固定しない。「Phase 0〜8」は claude のレビューワークフロー（thread-owl スキル）における一例であり、他のエージェント・ワークフローは独自の phase 構成で出力してよい（#149 のエージェント差し替えを許容するため）。
+
+## producer 統合（スキルへの組み込み）
+
+スキル定義に組み込むスニペットは [`samples/skill-progress-snippet.md`](samples/skill-progress-snippet.md) を参照。スキルの各 Phase 開始時にマーカー行を echo させることで、squirrel-notifier 側の phase 表示が動作する。
+
+構造化イベントを出力しないランチャー・エージェントはそのまま動作し、phase 表示のない indeterminate な「実行中」として扱われる。
+
+## consumer 側の挙動（参考）
+
+- `ReviewLauncherService` は stdout を行単位で読み取り、`ProgressEventParser` がマーカー行を `AgentProgressEvent` へ変換する
+- 有効な progress 行は `Progress` イベントとして配信され、`Stdout` イベントとしては重複配信されない（`LauncherResult.Stdout` の集約には生の行として含まれる）
+- 実行終了時は成功 / 失敗 / キャンセル / タイムアウトを区別した terminal event（`Completed`）が必ず 1 回配信される

--- a/docs/samples/skill-progress-snippet.md
+++ b/docs/samples/skill-progress-snippet.md
@@ -1,0 +1,26 @@
+# スキル組み込み用 progress event スニペット
+
+レビュー用スキル（`thread-owl-pr-reviewer` / `review-raven-thread-owl-cycle` 等）の SKILL.md に以下のセクションを追記すると、squirrel-notifier から起動した実行で phase 表示が動作する（contract の詳細は [progress-event-contract.md](../progress-event-contract.md) を参照）。
+
+phase の index / total / label は各スキルのワークフロー構成に合わせて読み替えること。
+
+---
+
+```markdown
+## 進捗イベントの出力（squirrel-notifier 連携）
+
+このワークフローの各 Phase を開始するとき、最初に以下の形式の 1 行を Bash ツールで stdout へ出力すること:
+
+echo '@squirrel-progress {"schemaVersion":1,"phaseIndex":<0始まりの現在Phase番号>,"totalPhases":<総Phase数>,"phaseLabel":"<Phase名>","timestamp":"<現在時刻 ISO 8601>"}'
+
+出力例（総 Phase 数 8 のワークフローで Phase 3「修正」を開始する場合）:
+
+echo '@squirrel-progress {"schemaVersion":1,"phaseIndex":3,"totalPhases":8,"phaseLabel":"修正","timestamp":"2026-07-11T10:00:00Z"}'
+
+ルール:
+- 1 イベント = 1 行。JSON 内に改行を含めない
+- 行頭マーカー `@squirrel-progress ` は正確に出力する（大文字小文字・スペースを変えない）
+- 最終 Verdict が確定した時点の出力には "verdict" フィールドを含める（例: "verdict":"APPROVED"）
+- 補足したい情報がある場合は "message" フィールドに短く含める
+- この出力はベストエフォートでよい。出力に失敗してもワークフロー自体は継続する
+```

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ProgressEventParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ProgressEventParserTests.cs
@@ -1,0 +1,84 @@
+// <copyright file="ProgressEventParserTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class ProgressEventParserTests
+{
+    [Fact]
+    public void TryParse_ShouldParseFullPayload()
+    {
+        const string line = "@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":3,\"totalPhases\":8,\"phaseLabel\":\"修正\",\"message\":\"accept 2件を修正中\",\"verdict\":\"APPROVED\",\"timestamp\":\"2026-07-11T10:00:00Z\"}";
+
+        bool parsed = ProgressEventParser.TryParse(line, out AgentProgressEvent? progressEvent);
+
+        parsed.Should().BeTrue();
+        progressEvent.Should().NotBeNull();
+        progressEvent!.SchemaVersion.Should().Be(1);
+        progressEvent.PhaseIndex.Should().Be(3);
+        progressEvent.TotalPhases.Should().Be(8);
+        progressEvent.PhaseLabel.Should().Be("修正");
+        progressEvent.Message.Should().Be("accept 2件を修正中");
+        progressEvent.Verdict.Should().Be("APPROVED");
+        progressEvent.Timestamp.Should().Be(new DateTimeOffset(2026, 7, 11, 10, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void TryParse_ShouldParseMinimalPayload_WithOptionalFieldsOmitted()
+    {
+        const string line = "@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"実行\"}";
+
+        bool parsed = ProgressEventParser.TryParse(line, out AgentProgressEvent? progressEvent);
+
+        parsed.Should().BeTrue();
+        progressEvent!.Message.Should().BeNull();
+        progressEvent.Verdict.Should().BeNull();
+        progressEvent.Timestamp.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParse_ShouldAcceptCaseInsensitivePropertyNames()
+    {
+        const string line = "@squirrel-progress {\"SchemaVersion\":1,\"PhaseIndex\":0,\"TotalPhases\":2,\"PhaseLabel\":\"sync\"}";
+
+        ProgressEventParser.TryParse(line, out AgentProgressEvent? progressEvent).Should().BeTrue();
+        progressEvent!.TotalPhases.Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("通常のログ行です")]
+    [InlineData("@squirrel-progress")]
+    [InlineData("@squirrel-progress{\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@SQUIRREL-PROGRESS {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress これはJSONではない")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,")]
+    [InlineData("@squirrel-progress [1,2,3]")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":2,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":\"1\",\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":-1,\"totalPhases\":1,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":0,\"phaseLabel\":\"x\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"\"}")]
+    [InlineData("@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":0,\"totalPhases\":1,\"phaseLabel\":\"  \"}")]
+    public void TryParse_ShouldRejectNonProgressLines(string? line)
+    {
+        // マーカー不一致・malformed JSON・未知 schemaVersion・必須項目欠落は
+        // すべて「通常ログとして扱うべき行」（false）になる（#143 AC）
+        bool parsed = ProgressEventParser.TryParse(line, out AgentProgressEvent? progressEvent);
+
+        parsed.Should().BeFalse();
+        progressEvent.Should().BeNull();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -3,8 +3,10 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -322,5 +324,205 @@ public class ReviewLauncherServiceTests : IDisposable
 
         // Assert
         commandLine.Should().Be("claude -p \"/thread-owl-pr-reviewer scottlz0310/squirrel-notifier#123 を opened モードでレビューしてください\"");
+    }
+
+    // ---- #143: 実行イベントのストリーミング ----
+
+    // イベント時刻の DI を検証するための固定時刻プロバイダー
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        public static readonly DateTimeOffset FixedNow = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => FixedNow;
+    }
+
+    private static ReviewEvent CreateReviewEvent(string eventId = "test-stream") => new()
+    {
+        EventId = eventId,
+        Repository = "scottlz0310/squirrel-notifier",
+        PrNumber = 52,
+        PrUrl = "https://github.com/scottlz0310/squirrel-notifier/pull/52",
+        Source = "queue://review/queue",
+    };
+
+    // stdout を実行中に逐次供給できる mock process。実プロセス同様、Kill でパイプが閉じて
+    // 読み取り側が EOF / IOException で終了する挙動を再現する.
+    private Mock<IProcessInstance> CreatePipeMockProcess(out StreamWriter stdoutWriter, out TaskCompletionSource exitTcs)
+    {
+        var server = new AnonymousPipeServerStream(PipeDirection.Out);
+        var client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle);
+        stdoutWriter = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = true };
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        exitTcs = tcs;
+
+        var mockProcess = new Mock<IProcessInstance>();
+        mockProcess.SetupGet(p => p.ExitCode).Returns(0);
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(client));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream()));
+        mockProcess.SetupGet(p => p.StandardInput).Returns(new StreamWriter(new MemoryStream()));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken t) => tcs.Task.WaitAsync(t));
+        mockProcess.Setup(p => p.Kill(It.IsAny<bool>())).Callback(server.Dispose);
+        return mockProcess;
+    }
+
+    [Fact]
+    public async Task StartSession_ShouldStreamStdoutAndProgressBeforeProcessExit()
+    {
+        // Arrange
+        const string progressLine = "@squirrel-progress {\"schemaVersion\":1,\"phaseIndex\":3,\"totalPhases\":8,\"phaseLabel\":\"修正\",\"message\":\"accept 2件\"}";
+        const string malformedLine = "@squirrel-progress {broken";
+
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out StreamWriter stdout, out TaskCompletionSource exitTcs);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object, new FixedTimeProvider());
+
+        // Act
+        AgentExecutionSession session = service.StartSession(CreateReviewEvent(), LauncherRole.Reviewer, CancellationToken.None);
+
+        using var readTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using IAsyncEnumerator<AgentExecutionEvent> events = session.ReadEventsAsync(readTimeout.Token).GetAsyncEnumerator();
+
+        // Assert: 通常ログはプロセス終了前に届く（#143 AC）
+        await stdout.WriteLineAsync("plain log line");
+        (await events.MoveNextAsync()).Should().BeTrue();
+        events.Current.Kind.Should().Be(AgentExecutionEventKind.Stdout);
+        events.Current.Text.Should().Be("plain log line");
+        events.Current.Timestamp.Should().Be(FixedTimeProvider.FixedNow);
+        session.Completion.IsCompleted.Should().BeFalse("プロセス終了前に stdout が購読側へ届くこと");
+
+        // 構造化 progress event は型付きモデルへ変換される
+        await stdout.WriteLineAsync(progressLine);
+        (await events.MoveNextAsync()).Should().BeTrue();
+        events.Current.Kind.Should().Be(AgentExecutionEventKind.Progress);
+        events.Current.Progress.Should().NotBeNull();
+        events.Current.Progress!.PhaseIndex.Should().Be(3);
+        events.Current.Progress.TotalPhases.Should().Be(8);
+        events.Current.Progress.PhaseLabel.Should().Be("修正");
+
+        // malformed な progress 行は通常ログとして流れ、実行は失敗しない
+        await stdout.WriteLineAsync(malformedLine);
+        (await events.MoveNextAsync()).Should().BeTrue();
+        events.Current.Kind.Should().Be(AgentExecutionEventKind.Stdout);
+        events.Current.Text.Should().Be(malformedLine);
+
+        // EOF + プロセス終了 → terminal event で列挙が終端する
+        stdout.Dispose();
+        exitTcs.SetResult();
+
+        (await events.MoveNextAsync()).Should().BeTrue();
+        events.Current.Kind.Should().Be(AgentExecutionEventKind.Completed);
+        events.Current.Outcome.Should().Be(AgentExecutionOutcome.Succeeded);
+        events.Current.Result.Should().NotBeNull();
+        events.Current.Result!.ExitCode.Should().Be(0);
+        (await events.MoveNextAsync()).Should().BeFalse("terminal event の後にイベントは無い");
+
+        // LauncherResult の集約 stdout は progress 行も含めた全行を保持する（既存セマンティクス維持）
+        LauncherResult result = await session.Completion;
+        result.Success.Should().BeTrue();
+        result.Stdout.Should().Be($"plain log line\n{progressLine}\n{malformedLine}");
+    }
+
+    [Fact]
+    public async Task StartSession_ShouldEmitCancelledTerminalEvent_WhenCancelled()
+    {
+        // Arrange: Kill のコールバックがパイプを閉じるため、writer 側の後始末は不要
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-cancel"), LauncherRole.Reviewer, cts.Token);
+        await Task.Delay(100);
+        cts.Cancel();
+
+        LauncherResult result = await session.Completion;
+
+        // Assert: キャンセルは terminal event（Cancelled）として通知され、reader task も残存しない
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("cancelled by user");
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+
+        var events = new List<AgentExecutionEvent>();
+        await foreach (AgentExecutionEvent e in session.ReadEventsAsync())
+        {
+            events.Add(e);
+        }
+
+        events.Should().ContainSingle(e => e.Kind == AgentExecutionEventKind.Completed)
+            .Which.Outcome.Should().Be(AgentExecutionOutcome.Cancelled);
+    }
+
+    [Fact]
+    public async Task StartSession_ShouldEmitTimedOutTerminalEvent_WhenTimedOut()
+    {
+        // Arrange
+        ConfigureSettings(timeoutMs: 200);
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Slow...", "", delayMs: 5000);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act
+        AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-timeout"), LauncherRole.Reviewer, CancellationToken.None);
+        LauncherResult result = await session.Completion;
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("timed out");
+
+        var events = new List<AgentExecutionEvent>();
+        await foreach (AgentExecutionEvent e in session.ReadEventsAsync())
+        {
+            events.Add(e);
+        }
+
+        events.Should().ContainSingle(e => e.Kind == AgentExecutionEventKind.Completed)
+            .Which.Outcome.Should().Be(AgentExecutionOutcome.TimedOut);
+    }
+
+    [Fact]
+    public async Task StartSession_ShouldReturnFailedSession_WhenAlreadyRunning()
+    {
+        // Arrange
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Running...", "", delayMs: 1000);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act: 1 本目の実行中に 2 本目のセッションを開始する
+        Task<LauncherResult> firstRun = service.LaunchAsync(CreateReviewEvent("test-stream-busy-1"), LauncherRole.Reviewer, CancellationToken.None);
+        await Task.Delay(100);
+        AgentExecutionSession second = service.StartSession(CreateReviewEvent("test-stream-busy-2"), LauncherRole.Reviewer, CancellationToken.None);
+
+        // Assert: 同時実行抑止は即座に Failed の terminal event を持つセッションになる
+        LauncherResult secondResult = await second.Completion;
+        secondResult.Success.Should().BeFalse();
+        secondResult.ErrorMessage.Should().Contain("already running");
+
+        var events = new List<AgentExecutionEvent>();
+        await foreach (AgentExecutionEvent e in second.ReadEventsAsync())
+        {
+            events.Add(e);
+        }
+
+        events.Should().ContainSingle().Which.Outcome.Should().Be(AgentExecutionOutcome.Failed);
+
+        (await firstRun).Success.Should().BeTrue();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -499,6 +499,41 @@ public class ReviewLauncherServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StartSession_ShouldNotStartProcess_WhenCancelledImmediatelyAfterStartSession()
+    {
+        // Arrange: StartSession 直後（fire-and-forget の RunSessionAsync がプロセスを起動する前）に
+        // Cancel() を呼ぶ開始前レース。CTS は StartSession 内で生成済みのため cancel が
+        // combinedToken に届き、プロセスは起動されず Cancelled で終端する（#143 レビュー対応）
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "should not run", "");
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act: StartSession が戻った直後に同期的に Cancel する
+        AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-cancel-before-start"), LauncherRole.Reviewer, CancellationToken.None);
+        service.Cancel();
+
+        LauncherResult result = await session.Completion;
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("cancelled by user");
+        mockRunner.Verify(r => r.Start(It.IsAny<ProcessStartInfo>()), Times.Never);
+
+        var events = new List<AgentExecutionEvent>();
+        await foreach (AgentExecutionEvent e in session.ReadEventsAsync())
+        {
+            events.Add(e);
+        }
+
+        events.Should().ContainSingle(e => e.Kind == AgentExecutionEventKind.Completed)
+            .Which.Outcome.Should().Be(AgentExecutionOutcome.Cancelled);
+    }
+
+    [Fact]
     public async Task StartSession_ShouldEmitTimedOutTerminalEvent_WhenTimedOut()
     {
         // Arrange

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -464,6 +464,41 @@ public class ReviewLauncherServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StartSession_ShouldEmitCancelledTerminalEvent_WhenCancelMethodInvoked()
+    {
+        // Arrange: Cancel() は内部 CTS のみを cancel し、呼び出し元トークンは cancel されない経路。
+        // timeout（TimedOut）に誤分類されないことを固定する（#143 レビュー対応）
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        // Act
+        AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-cancel-method"), LauncherRole.Reviewer, CancellationToken.None);
+        await Task.Delay(100);
+        service.Cancel();
+
+        LauncherResult result = await session.Completion;
+
+        // Assert: Cancel() 自身と OCE ハンドラの両方が Kill を呼ぶため AtLeastOnce で検証
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("cancelled by user");
+        mockProcess.Verify(p => p.Kill(true), Times.AtLeastOnce);
+
+        var events = new List<AgentExecutionEvent>();
+        await foreach (AgentExecutionEvent e in session.ReadEventsAsync())
+        {
+            events.Add(e);
+        }
+
+        events.Should().ContainSingle(e => e.Kind == AgentExecutionEventKind.Completed)
+            .Which.Outcome.Should().Be(AgentExecutionOutcome.Cancelled);
+    }
+
+    [Fact]
     public async Task StartSession_ShouldEmitTimedOutTerminalEvent_WhenTimedOut()
     {
         // Arrange

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -189,10 +189,33 @@ public class SettingsServiceTests : IDisposable
     [InlineData(0)]
     [InlineData(-100)]
     [InlineData(300001)]
-    public void UpdateSettings_ShouldThrowArgumentOutOfRangeExceptionForInvalidTimeout(int invalidTimeout)
+    public void UpdateSettings_ShouldThrowArgumentOutOfRangeExceptionForInvalidNotificationTimeout(int invalidTimeout)
     {
         FluentActions.Invoking(() => UpdateSettingsDefault(timeout: invalidTimeout)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    // launcher timeout は長時間レビューサイクルを考慮し、通知タイムアウトとは別に上限 2 時間（#143）
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-100)]
+    [InlineData(7200001)]
+    public void UpdateSettings_ShouldThrowArgumentOutOfRangeExceptionForInvalidLauncherTimeout(int invalidTimeout)
+    {
         FluentActions.Invoking(() => UpdateSettingsDefault(launcherTimeout: invalidTimeout)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void UpdateSettings_ShouldAcceptLauncherTimeoutUpToTwoHours()
+    {
+        UpdateSettingsDefault(launcherTimeout: 7200000);
+
+        _settingsService.Settings.LauncherTimeoutMs.Should().Be(7200000);
+    }
+
+    [Fact]
+    public void Settings_ShouldDefaultLauncherTimeoutToThirtyMinutes()
+    {
+        new AppSettings().LauncherTimeoutMs.Should().Be(1800000);
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -98,7 +98,7 @@
                     <TextBox Grid.Row="10" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
 
                     <TextBlock Grid.Row="11" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
-                    <NumberBox Grid.Row="11" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="300000" ValueChanged="OnTimeoutChanged"/>
+                    <NumberBox Grid.Row="11" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="7200000" ValueChanged="OnTimeoutChanged"/>
 
                     <TextBlock Grid.Row="12" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
                     <ToggleSwitch Grid.Row="12" Grid.Column="1" x:Name="AutoStartToggle"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -846,7 +846,7 @@ internal sealed partial class MainWindow : Window
             string reviewerArguments = ReviewerArgumentsBox.Text;
             string reviewedPath = ReviewedPathBox.Text;
             string reviewedArguments = ReviewedArgumentsBox.Text;
-            int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 300000 : (int)LauncherTimeoutBox.Value;
+            int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 1800000 : (int)LauncherTimeoutBox.Value;
 
             string reviewerPresetId = Models.LauncherAgentCatalog.ResolvePresetId(reviewerPath, reviewerArguments, Models.LauncherRole.Reviewer);
             string reviewedPresetId = Models.LauncherAgentCatalog.ResolvePresetId(reviewedPath, reviewedArguments, Models.LauncherRole.Reviewed);

--- a/winui3/SquirrelNotifier.WinUI3/Models/AgentExecutionEvent.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/AgentExecutionEvent.cs
@@ -1,0 +1,65 @@
+// <copyright file="AgentExecutionEvent.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// エージェント実行セッションが配信するイベントの種別.
+/// </summary>
+internal enum AgentExecutionEventKind
+{
+    /// <summary>stdout の 1 行（構造化 progress event ではない通常ログ）.</summary>
+    Stdout,
+
+    /// <summary>stderr の 1 行.</summary>
+    Stderr,
+
+    /// <summary>構造化 progress event（<see cref="AgentProgressEvent"/>）.</summary>
+    Progress,
+
+    /// <summary>実行終了を示す terminal event。<see cref="AgentExecutionEvent.Outcome"/> と <see cref="AgentExecutionEvent.Result"/> を持つ.</summary>
+    Completed,
+}
+
+/// <summary>
+/// 実行終了時の結果分類.
+/// </summary>
+internal enum AgentExecutionOutcome
+{
+    /// <summary>ExitCode 0 で正常終了.</summary>
+    Succeeded,
+
+    /// <summary>非ゼロ ExitCode、または起動・実行エラー.</summary>
+    Failed,
+
+    /// <summary>ユーザー操作によりキャンセルされた.</summary>
+    Cancelled,
+
+    /// <summary>LauncherTimeoutMs を超過して強制終了された.</summary>
+    TimedOut,
+}
+
+/// <summary>
+/// エージェント実行セッション（<see cref="Services.AgentExecutionSession"/>）が UI 層へ逐次配信するイベント（#143）.
+/// </summary>
+internal sealed record AgentExecutionEvent
+{
+    /// <summary>Gets イベント種別.</summary>
+    public required AgentExecutionEventKind Kind { get; init; }
+
+    /// <summary>Gets squirrel-notifier 側で観測したイベント時刻.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Gets ログ 1 行のテキスト。Kind が Stdout / Stderr の場合のみ非 null.</summary>
+    public string? Text { get; init; }
+
+    /// <summary>Gets 構造化 progress event。Kind が Progress の場合のみ非 null.</summary>
+    public AgentProgressEvent? Progress { get; init; }
+
+    /// <summary>Gets 実行終了の結果分類。Kind が Completed の場合のみ非 null.</summary>
+    public AgentExecutionOutcome? Outcome { get; init; }
+
+    /// <summary>Gets 実行結果。Kind が Completed の場合のみ非 null.</summary>
+    public LauncherResult? Result { get; init; }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Models/AgentProgressEvent.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/AgentProgressEvent.cs
@@ -1,0 +1,25 @@
+// <copyright file="AgentProgressEvent.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// エージェント（またはラッパー）が stdout へ出力する構造化 progress event（#143）。
+/// phase はエージェント非依存の汎用構造（index / total / label）であり、phase 数は固定しない.
+/// </summary>
+/// <param name="SchemaVersion">contract のスキーマバージョン。現行は 1.</param>
+/// <param name="PhaseIndex">現在の phase の 0 始まりインデックス.</param>
+/// <param name="TotalPhases">ワークフロー全体の phase 数（1 以上）.</param>
+/// <param name="PhaseLabel">phase の表示名（例: "修正", "Verdict 待機"）.</param>
+/// <param name="Message">phase 内の補足メッセージ。省略可.</param>
+/// <param name="Verdict">レビュー Verdict（例: "APPROVED"）。省略可.</param>
+/// <param name="Timestamp">producer 側が付与したイベント時刻。省略可.</param>
+internal sealed record AgentProgressEvent(
+    int SchemaVersion,
+    int PhaseIndex,
+    int TotalPhases,
+    string PhaseLabel,
+    string? Message,
+    string? Verdict,
+    DateTimeOffset? Timestamp);

--- a/winui3/SquirrelNotifier.WinUI3/Services/AgentExecutionSession.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/AgentExecutionSession.cs
@@ -1,0 +1,93 @@
+// <copyright file="AgentExecutionSession.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// 1 回のエージェント実行のライフサイクルを集約し、stdout / stderr / progress / completed の
+/// 型付きイベントを実行中に逐次配信するセッション（#143）。
+/// イベントは <see cref="ReadEventsAsync"/> で購読し、最終結果は <see cref="Completion"/> で待機する.
+/// </summary>
+internal sealed class AgentExecutionSession
+{
+    // 購読者が居なくてもプロセス出力の書き込みをブロックさせないため unbounded にする。
+    // メモリ上限（rolling buffer）は UI 層（#144）の責務.
+    private readonly Channel<AgentExecutionEvent> _channel = Channel.CreateUnbounded<AgentExecutionEvent>(
+        new UnboundedChannelOptions
+        {
+            // stdout / stderr の pump が並行して書き込む
+            SingleWriter = false,
+            SingleReader = false,
+        });
+
+    private readonly TaskCompletionSource<LauncherResult> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private readonly TimeProvider _timeProvider;
+
+    internal AgentExecutionSession(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <summary>Gets 実行の最終結果。terminal event（Completed）の発行と同時に完了する.</summary>
+    public Task<LauncherResult> Completion => _completion.Task;
+
+    /// <summary>
+    /// 実行イベントを発生順に購読する。セッション終了（Completed 発行）後は列挙が終端する.
+    /// </summary>
+    /// <param name="cancellationToken">購読を中断するためのトークン。実行自体はキャンセルされない.</param>
+    /// <returns>実行イベントの非同期シーケンス.</returns>
+    public IAsyncEnumerable<AgentExecutionEvent> ReadEventsAsync(CancellationToken cancellationToken = default)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+
+    internal void PublishStdout(string line)
+        => Publish(new AgentExecutionEvent
+        {
+            Kind = AgentExecutionEventKind.Stdout,
+            Timestamp = _timeProvider.GetUtcNow(),
+            Text = line,
+        });
+
+    internal void PublishStderr(string line)
+        => Publish(new AgentExecutionEvent
+        {
+            Kind = AgentExecutionEventKind.Stderr,
+            Timestamp = _timeProvider.GetUtcNow(),
+            Text = line,
+        });
+
+    internal void PublishProgress(AgentProgressEvent progress)
+        => Publish(new AgentExecutionEvent
+        {
+            Kind = AgentExecutionEventKind.Progress,
+            Timestamp = _timeProvider.GetUtcNow(),
+            Progress = progress,
+        });
+
+    // terminal event を発行してチャンネルを終端し、Completion を確定する。
+    // 二重呼び出しは TryComplete / TrySetResult により無害化される.
+    internal void Complete(AgentExecutionOutcome outcome, LauncherResult result)
+    {
+        Publish(new AgentExecutionEvent
+        {
+            Kind = AgentExecutionEventKind.Completed,
+            Timestamp = _timeProvider.GetUtcNow(),
+            Outcome = outcome,
+            Result = result,
+        });
+        _channel.Writer.TryComplete();
+        _completion.TrySetResult(result);
+    }
+
+    private void Publish(AgentExecutionEvent executionEvent)
+        => _channel.Writer.TryWrite(executionEvent);
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IReviewLauncherService.cs
@@ -14,6 +14,16 @@ internal interface IReviewLauncherService
 
     Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// 実行を開始し、stdout / stderr / progress / completed を逐次購読できるセッションを返す（#143）。
+    /// 既に実行中の場合は、即座に Failed の terminal event を持つセッションを返す（同時実行抑止）.
+    /// </summary>
+    /// <param name="reviewEvent">起動対象のレビューイベント.</param>
+    /// <param name="role">使用するランチャースロット.</param>
+    /// <param name="cancellationToken">実行をキャンセルするためのトークン.</param>
+    /// <returns>実行イベントの購読と最終結果の待機に使うセッション.</returns>
+    AgentExecutionSession StartSession(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken);
+
     void Cancel();
 
     string BuildCommandLine(ReviewEvent reviewEvent, LauncherRole role);

--- a/winui3/SquirrelNotifier.WinUI3/Services/ProgressEventParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ProgressEventParser.cs
@@ -1,0 +1,105 @@
+// <copyright file="ProgressEventParser.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// stdout に混在する構造化 progress event（行頭マーカー付き JSONL）のパーサー（#143）。
+/// マーカー不一致・malformed JSON・未対応 schemaVersion の行は progress event として扱わず、
+/// 呼び出し側が通常の stdout ログとして処理する.
+/// </summary>
+internal static class ProgressEventParser
+{
+    /// <summary>
+    /// progress event 行の行頭マーカー（末尾スペース含む完全一致）。
+    /// 通常ログとの偶然の衝突は、このマーカーと schemaVersion 検証の二段構えで排除する.
+    /// </summary>
+    public const string LineMarker = "@squirrel-progress ";
+
+    /// <summary>現在サポートする schemaVersion.</summary>
+    public const int SupportedSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// 1 行を progress event として解釈を試みる.
+    /// </summary>
+    /// <param name="line">stdout の 1 行.</param>
+    /// <param name="progressEvent">解釈に成功した場合の progress event.</param>
+    /// <returns>有効な progress event の場合 <see langword="true"/>。それ以外（通常ログとして扱うべき行）は <see langword="false"/>.</returns>
+    public static bool TryParse(string? line, out AgentProgressEvent? progressEvent)
+    {
+        progressEvent = null;
+
+        if (line == null || !line.StartsWith(LineMarker, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string payload = line[LineMarker.Length..];
+
+        ProgressEventPayload? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<ProgressEventPayload>(payload, _options);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (parsed == null
+            || parsed.SchemaVersion != SupportedSchemaVersion
+            || parsed.PhaseIndex is null or < 0
+            || parsed.TotalPhases is null or < 1
+            || string.IsNullOrWhiteSpace(parsed.PhaseLabel))
+        {
+            return false;
+        }
+
+        progressEvent = new AgentProgressEvent(
+            parsed.SchemaVersion.Value,
+            parsed.PhaseIndex.Value,
+            parsed.TotalPhases.Value,
+            parsed.PhaseLabel,
+            parsed.Message,
+            parsed.Verdict,
+            parsed.Timestamp);
+        return true;
+    }
+
+    // JSON との対応付け専用の中間 DTO。必須項目の欠落を null で検出するため、
+    // すべて nullable にして TryParse 側で検証する.
+    private sealed class ProgressEventPayload
+    {
+        [JsonPropertyName("schemaVersion")]
+        public int? SchemaVersion { get; set; }
+
+        [JsonPropertyName("phaseIndex")]
+        public int? PhaseIndex { get; set; }
+
+        [JsonPropertyName("totalPhases")]
+        public int? TotalPhases { get; set; }
+
+        [JsonPropertyName("phaseLabel")]
+        public string? PhaseLabel { get; set; }
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+
+        [JsonPropertyName("verdict")]
+        public string? Verdict { get; set; }
+
+        [JsonPropertyName("timestamp")]
+        public DateTimeOffset? Timestamp { get; set; }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -17,6 +18,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     private readonly SettingsService _settingsService;
     private readonly LoggingService _loggingService;
     private readonly IProcessRunner _processRunner;
+    private readonly TimeProvider _timeProvider;
     private readonly object _lock = new();
 
     private bool _isRunning;
@@ -37,138 +39,47 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     public ReviewLauncherService(
         SettingsService settingsService,
         LoggingService loggingService,
-        IProcessRunner? processRunner = null)
+        IProcessRunner? processRunner = null,
+        TimeProvider? timeProvider = null)
     {
         _settingsService = settingsService;
         _loggingService = loggingService;
         _processRunner = processRunner ?? new ProcessRunner();
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
     {
+        AgentExecutionSession session = StartSession(reviewEvent, role, cancellationToken);
+        return await session.Completion.ConfigureAwait(false);
+    }
+
+    // 実行を開始し、イベント購読用のセッションを即座に返す（#143）。
+    // 実行結果は session.Completion で待機できる。LaunchAsync はこのメソッドの薄いラッパー.
+    public AgentExecutionSession StartSession(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(reviewEvent);
+
+        var session = new AgentExecutionSession(_timeProvider);
 
         lock (_lock)
         {
             if (_isRunning)
             {
-                return new LauncherResult
+                session.Complete(AgentExecutionOutcome.Failed, new LauncherResult
                 {
                     Success = false,
                     ErrorMessage = "A review action is already running.",
-                };
+                });
+                return session;
             }
 
             _isRunning = true;
         }
 
-        await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber} (role={role})").ConfigureAwait(false);
-
-        AppSettings settings = _settingsService.Settings;
-        (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
-        int timeoutMs = settings.LauncherTimeoutMs;
-
-        _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _activeCts.CancelAfter(timeoutMs);
-        CancellationToken combinedToken = _activeCts.Token;
-
-        try
-        {
-            string resolvedPath = SettingsService.ResolveCommandPath(commandPath);
-            if (string.IsNullOrWhiteSpace(resolvedPath))
-            {
-                throw new InvalidOperationException("Launcher command path is empty or invalid.");
-            }
-
-            var psi = new ProcessStartInfo
-            {
-                FileName = resolvedPath,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-                StandardOutputEncoding = System.Text.Encoding.UTF8,
-                StandardErrorEncoding = System.Text.Encoding.UTF8,
-            };
-
-            // Build and add safe arguments
-            System.Collections.Generic.List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
-            foreach (string arg in args)
-            {
-                psi.ArgumentList.Add(arg);
-            }
-
-            await LogAsync($"Launching: {commandPath} with safe arguments").ConfigureAwait(false);
-
-            lock (_lock)
-            {
-                combinedToken.ThrowIfCancellationRequested();
-
-                _activeProcess = _processRunner.Start(psi);
-            }
-
-            // codex exec 等、スキル呼び出し機構を持たずプロンプト全文を引数で受け取るエージェントは
-            // stdin の EOF を待って停止することがあるため、標準入力を即座に閉じて EOF を通知する.
-            _activeProcess.StandardInput.Close();
-
-            // Start reading stdout / stderr as tasks to avoid deadlock
-            Task<string> stdoutTask = _activeProcess.StandardOutput.ReadToEndAsync(combinedToken);
-            Task<string> stderrTask = _activeProcess.StandardError.ReadToEndAsync(combinedToken);
-
-            await _activeProcess.WaitForExitAsync(combinedToken).ConfigureAwait(false);
-
-            string stdout = await stdoutTask.ConfigureAwait(false);
-            string stderr = await stderrTask.ConfigureAwait(false);
-
-            int exitCode = _activeProcess.ExitCode;
-
-            await LogAsync($"Review process finished. ExitCode={exitCode}").ConfigureAwait(false);
-
-            return new LauncherResult
-            {
-                Success = exitCode == 0,
-                ExitCode = exitCode,
-                Stdout = stdout,
-                Stderr = stderr,
-            };
-        }
-        catch (OperationCanceledException)
-        {
-            string reason = cancellationToken.IsCancellationRequested ? "cancelled by user" : "timed out";
-            await LogAsync($"Review process was {reason}.").ConfigureAwait(false);
-
-            KillActiveProcess();
-
-            return new LauncherResult
-            {
-                Success = false,
-                ErrorMessage = $"Review process was {reason}.",
-            };
-        }
-        catch (Exception ex)
-        {
-            await LogAsync($"Failed to run review process: {ex.Message}").ConfigureAwait(false);
-
-            KillActiveProcess();
-
-            return new LauncherResult
-            {
-                Success = false,
-                ErrorMessage = ex.Message,
-            };
-        }
-        finally
-        {
-            lock (_lock)
-            {
-                _activeProcess?.Dispose();
-                _activeProcess = null;
-                _activeCts?.Dispose();
-                _activeCts = null;
-                _isRunning = false;
-            }
-        }
+        // RunSessionAsync は例外をすべて terminal event に変換するため fire-and-forget で安全
+        _ = RunSessionAsync(session, reviewEvent, role, cancellationToken);
+        return session;
     }
 
     public void Cancel()
@@ -190,9 +101,192 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
 
         AppSettings settings = _settingsService.Settings;
         (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
-        System.Collections.Generic.List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
+        List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
 
         return CommandLineFormatter.Format(commandPath, args);
+    }
+
+    private async Task RunSessionAsync(AgentExecutionSession session, ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
+    {
+        Task<string>? stdoutTask = null;
+        Task<string>? stderrTask = null;
+
+        try
+        {
+            await LogAsync($"User requested review execution for PR: {reviewEvent.Repository}#{reviewEvent.PrNumber} (role={role})").ConfigureAwait(false);
+
+            AppSettings settings = _settingsService.Settings;
+            (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
+            int timeoutMs = settings.LauncherTimeoutMs;
+
+            _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _activeCts.CancelAfter(timeoutMs);
+            CancellationToken combinedToken = _activeCts.Token;
+
+            string resolvedPath = SettingsService.ResolveCommandPath(commandPath);
+            if (string.IsNullOrWhiteSpace(resolvedPath))
+            {
+                throw new InvalidOperationException("Launcher command path is empty or invalid.");
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = resolvedPath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+                StandardErrorEncoding = System.Text.Encoding.UTF8,
+            };
+
+            // Build and add safe arguments
+            List<string> args = LauncherArgumentBuilder.BuildArguments(argumentsTemplate, reviewEvent);
+            foreach (string arg in args)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            await LogAsync($"Launching: {commandPath} with safe arguments").ConfigureAwait(false);
+
+            lock (_lock)
+            {
+                combinedToken.ThrowIfCancellationRequested();
+
+                _activeProcess = _processRunner.Start(psi);
+            }
+
+            // codex exec 等、スキル呼び出し機構を持たずプロンプト全文を引数で受け取るエージェントは
+            // stdin の EOF を待って停止することがあるため、標準入力を即座に閉じて EOF を通知する.
+            _activeProcess.StandardInput.Close();
+
+            // 実行中の逐次配信（#143）: 終了後一括の ReadToEndAsync ではなく行単位で読み取り、
+            // stdout / stderr の各ストリーム内の順序を維持したままセッションへ流す。
+            // WaitForExitAsync と並行して読み進めることでパイプ詰まりによる deadlock も回避する.
+            stdoutTask = PumpStdoutAsync(_activeProcess.StandardOutput, session, combinedToken);
+            stderrTask = PumpStderrAsync(_activeProcess.StandardError, session, combinedToken);
+
+            await _activeProcess.WaitForExitAsync(combinedToken).ConfigureAwait(false);
+
+            string stdout = await stdoutTask.ConfigureAwait(false);
+            string stderr = await stderrTask.ConfigureAwait(false);
+
+            int exitCode = _activeProcess.ExitCode;
+
+            await LogAsync($"Review process finished. ExitCode={exitCode}").ConfigureAwait(false);
+
+            session.Complete(
+                exitCode == 0 ? AgentExecutionOutcome.Succeeded : AgentExecutionOutcome.Failed,
+                new LauncherResult
+                {
+                    Success = exitCode == 0,
+                    ExitCode = exitCode,
+                    Stdout = stdout,
+                    Stderr = stderr,
+                });
+        }
+        catch (OperationCanceledException)
+        {
+            bool cancelledByUser = cancellationToken.IsCancellationRequested;
+            string reason = cancelledByUser ? "cancelled by user" : "timed out";
+            await LogAsync($"Review process was {reason}.").ConfigureAwait(false);
+
+            KillActiveProcess();
+            await WaitForPumpsAsync(stdoutTask, stderrTask).ConfigureAwait(false);
+
+            session.Complete(
+                cancelledByUser ? AgentExecutionOutcome.Cancelled : AgentExecutionOutcome.TimedOut,
+                new LauncherResult
+                {
+                    Success = false,
+                    ErrorMessage = $"Review process was {reason}.",
+                });
+        }
+        catch (Exception ex)
+        {
+            await LogAsync($"Failed to run review process: {ex.Message}").ConfigureAwait(false);
+
+            KillActiveProcess();
+            await WaitForPumpsAsync(stdoutTask, stderrTask).ConfigureAwait(false);
+
+            session.Complete(AgentExecutionOutcome.Failed, new LauncherResult
+            {
+                Success = false,
+                ErrorMessage = ex.Message,
+            });
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _activeProcess?.Dispose();
+                _activeProcess = null;
+                _activeCts?.Dispose();
+                _activeCts = null;
+                _isRunning = false;
+            }
+        }
+    }
+
+    private static async Task<string> PumpStdoutAsync(StreamReader reader, AgentExecutionSession session, CancellationToken cancellationToken)
+    {
+        var lines = new List<string>();
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is string line)
+        {
+            lines.Add(line);
+
+            if (ProgressEventParser.TryParse(line, out AgentProgressEvent? progress))
+            {
+                session.PublishProgress(progress!);
+            }
+            else
+            {
+                // マーカー不一致・malformed JSON・未知 schemaVersion は通常ログとして流す（#143 AC）
+                session.PublishStdout(line);
+            }
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    private static async Task<string> PumpStderrAsync(StreamReader reader, AgentExecutionSession session, CancellationToken cancellationToken)
+    {
+        var lines = new List<string>();
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is string line)
+        {
+            lines.Add(line);
+            session.PublishStderr(line);
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    // キャンセル・タイムアウト・例外時に reader task を残存させないための後始末。
+    // プロセス kill / トークンキャンセルに伴う読み取り側の例外は正常な終了経路として扱う.
+    private static async Task WaitForPumpsAsync(Task<string>? stdoutTask, Task<string>? stderrTask)
+    {
+        foreach (Task<string>? pump in new[] { stdoutTask, stderrTask })
+        {
+            if (pump == null)
+            {
+                continue;
+            }
+
+            try
+            {
+                await pump.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
     }
 
     // スロットはユーザーが押したアクションのロールだけで決まる（#127）

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -62,6 +62,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         ArgumentNullException.ThrowIfNull(reviewEvent);
 
         var session = new AgentExecutionSession(_timeProvider);
+        CancellationTokenSource cts;
 
         lock (_lock)
         {
@@ -77,10 +78,18 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
 
             _isRunning = true;
             _cancelRequested = false;
+
+            // StartSession 直後（fire-and-forget の RunSessionAsync がプロセスを起動する前）の
+            // Cancel() が無視されないよう、CTS はここで生成して _activeCts に公開しておく。
+            // Cancel() は同じ lock 内で _activeCts を cancel するため、StartSession が戻った
+            // 時点以降のキャンセルは必ず combinedToken（プロセス起動前の
+            // ThrowIfCancellationRequested）に届く.
+            cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _activeCts = cts;
         }
 
         // RunSessionAsync は例外をすべて terminal event に変換するため fire-and-forget で安全
-        _ = RunSessionAsync(session, reviewEvent, role, cancellationToken);
+        _ = RunSessionAsync(session, reviewEvent, role, cts, cancellationToken);
         return session;
     }
 
@@ -112,7 +121,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         return CommandLineFormatter.Format(commandPath, args);
     }
 
-    private async Task RunSessionAsync(AgentExecutionSession session, ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
+    private async Task RunSessionAsync(AgentExecutionSession session, ReviewEvent reviewEvent, LauncherRole role, CancellationTokenSource cts, CancellationToken cancellationToken)
     {
         Task<string>? stdoutTask = null;
         Task<string>? stderrTask = null;
@@ -125,9 +134,10 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
             (string commandPath, string argumentsTemplate) = ResolveLauncherSlot(settings, role);
             int timeoutMs = settings.LauncherTimeoutMs;
 
-            _activeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _activeCts.CancelAfter(timeoutMs);
-            CancellationToken combinedToken = _activeCts.Token;
+            // CTS 自体は StartSession が生成済み（開始前キャンセルのレース対策）。
+            // timeout の起点はここ（設定読み取り後）から.
+            cts.CancelAfter(timeoutMs);
+            CancellationToken combinedToken = cts.Token;
 
             string resolvedPath = SettingsService.ResolveCommandPath(commandPath);
             if (string.IsNullOrWhiteSpace(resolvedPath))

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -22,6 +22,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     private readonly object _lock = new();
 
     private bool _isRunning;
+    private bool _cancelRequested;
     private IProcessInstance? _activeProcess;
     private CancellationTokenSource? _activeCts;
 
@@ -75,6 +76,7 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
             }
 
             _isRunning = true;
+            _cancelRequested = false;
         }
 
         // RunSessionAsync は例外をすべて terminal event に変換するため fire-and-forget で安全
@@ -86,6 +88,10 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     {
         lock (_lock)
         {
+            // Cancel() は内部 CTS だけを cancel し、呼び出し元の cancellationToken には
+            // 伝播しない。timeout（内部 CTS の CancelAfter）と区別して terminal event を
+            // Cancelled に分類できるよう、手動キャンセルの発生をフラグで記録する.
+            _cancelRequested = true;
             _activeCts?.Cancel();
             KillActiveProcess();
         }
@@ -188,7 +194,14 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         }
         catch (OperationCanceledException)
         {
-            bool cancelledByUser = cancellationToken.IsCancellationRequested;
+            bool cancelledByUser;
+            lock (_lock)
+            {
+                // 呼び出し元トークン経由（cancellationToken）と Cancel() 経由（_cancelRequested）の
+                // どちらも user-cancel。どちらでもなければ内部 CTS の CancelAfter による timeout.
+                cancelledByUser = cancellationToken.IsCancellationRequested || _cancelRequested;
+            }
+
             string reason = cancelledByUser ? "cancelled by user" : "timed out";
             await LogAsync($"Review process was {reason}.").ConfigureAwait(false);
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -299,9 +299,11 @@ internal sealed class SettingsService
             throw new ArgumentException("Reviewed launcher command path cannot be empty", nameof(reviewedLauncherCommandPath));
         }
 
-        if (launcherTimeoutMs <= 0 || launcherTimeoutMs > 300000)
+        // レビューサイクルは 5 分を大きく超えるため、通知タイムアウト（上限 300000ms）とは
+        // 別に上限 2 時間まで許容する（#143）
+        if (launcherTimeoutMs <= 0 || launcherTimeoutMs > 7200000)
         {
-            throw new ArgumentOutOfRangeException(nameof(launcherTimeoutMs), "Launcher timeout must be between 1 and 300000 ms");
+            throw new ArgumentOutOfRangeException(nameof(launcherTimeoutMs), "Launcher timeout must be between 1 and 7200000 ms");
         }
 
         if (string.IsNullOrWhiteSpace(reviewerLauncherPresetId))
@@ -371,7 +373,8 @@ internal sealed class AppSettings
 
     public bool LauncherPresetsMigrated { get; set; }
 
-    public int LauncherTimeoutMs { get; set; } = 300000;
+    // 長時間のレビューサイクル（30 分超もありうる）を 5 分で強制終了しないよう既定 30 分（#143）
+    public int LauncherTimeoutMs { get; set; } = 1800000;
 
     public string LastSkippedVersion { get; set; } = string.Empty;
 


### PR DESCRIPTION
Closes #143

## 概要

親 Epic #142 の実行可視化基盤として、`ReviewLauncherService` のプロセス終了後一括取得（`ReadToEndAsync`）を実行中の逐次イベント配信へ変更し、バージョン付き構造化 progress event contract を定義した。

## 設計論点の確定内容（実装前に確認済み）

| 論点 | 決定 |
|---|---|
| 輸送路 | stdout 行頭マーカー `@squirrel-progress ` + 1 行 JSON。マーカー一致 + schemaVersion 検証の二段構えで通常ログとの衝突を排除 |
| 最初の producer | (b) スキル組み込みスニペット + docs（statusline 連携 #140 と同じ「本体はスキーマと解釈のみ、適用はユーザーの skills/dotfiles 側」の責務分担）。claude stream-json adapter は phase を生成できないため不採用 |
| LauncherTimeoutMs | 既定 5 分 → 30 分、上限 5 分 → 2 時間。既存ユーザーの保存済み値は不変 |

## 変更内容

### ストリーミング基盤
- `AgentExecutionSession`（新規）: Channel ベースで stdout / stderr / progress / completed の型付きイベントを `IAsyncEnumerable` として購読可能。最終結果は `Completion` で待機
- `IReviewLauncherService.StartSession`（新規）: セッションを即座に返す。既存の `LaunchAsync` はその薄いラッパーとして再実装し、`LauncherResult` の意味・同時実行抑止・cancellation / timeout / process tree cleanup の既存契約を維持
- stdout / stderr は行単位で読み取り、各ストリーム内の順序を維持したまま逐次配信。`WaitForExitAsync` と並行読み取りでパイプ詰まりによる deadlock を回避
- 成功 / 失敗 / キャンセル / タイムアウトを `AgentExecutionOutcome` で区別した terminal event として必ず 1 回通知。キャンセル・例外時は pump task を残存させず後始末する
- 時刻は `TimeProvider` を DI（テストでは固定時刻で検証）

### progress event contract（schema v1）
- `AgentProgressEvent`（schemaVersion / phaseIndex / totalPhases / phaseLabel / message / verdict / timestamp）
- phase はエージェント非依存の汎用構造（0 始まり index / total / label）で phase 数を固定しない（#149 のエージェント差し替えを許容）
- `ProgressEventParser`: マーカー不一致・malformed JSON・未知 schemaVersion・必須項目欠落はすべて通常 stdout ログとして安全に流し、実行を失敗させない

### producer 統合
- `docs/progress-event-contract.md`: contract 仕様と responsibilities
- `docs/samples/skill-progress-snippet.md`: レビュースキルへ貼り付ける出力指示スニペット

### タイムアウト
- `LauncherTimeoutMs`: 既定 1800000ms（30 分）・上限 7200000ms（2 時間）へ変更（通知タイムアウト側は従来どおり上限 5 分）

## スコープ外（Issue 記載どおり）

- WinUI 3 ライブログウィンドウ（#144。本 PR は購読契約までを提供）
- 自然言語ログからの phase 推測
- progress event 対応度フィールドの `LauncherAgentCatalog` への追加（#151）

## テスト

- `ProgressEventParserTests`（新規・パラメータ化）: 有効 / 最小 / 大文字小文字非依存 / 18 種の reject ケース
- `ReviewLauncherServiceTests` に追加: AnonymousPipe による「プロセス終了前に stdout / progress が届く」検証、malformed 行の通常ログ化、キャンセル / タイムアウト / 同時実行抑止の terminal event
- `SettingsServiceTests`: timeout 境界の分割（通知 300000 / launcher 7200000）と新既定値
- 360 件全テスト合格、カバレッジ Line 89.17% / Branch 85.67% / Method 94.29%
- `dotnet format --verify-no-changes` / `dotnet build` / `dotnet test` すべて成功

## 確認方法

1. `docs/samples/skill-progress-snippet.md` の内容をレビュースキル（SKILL.md）へ追記
2. squirrel-notifier からレビュー起動し、スキルが `@squirrel-progress {...}` 行を echo すると `AgentExecutionSession` の購読側で `Progress` イベント（phaseIndex / totalPhases / phaseLabel）が届くことを確認（UI 表示は #144）
3. Settings の Launcher Timeout に 300000 超の値（例: 1800000）を設定できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)