### PR TITLE
fix: reviewed launcher 既定のスキル呼び出しを実在するスキル名へ修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- reviewed launcher 既定値のスキル呼び出し名が実在しない `/thread-owl-review-cycle` になっており、デフォルト設定のまま「レビューに対応」を実行しても意図したレビュー対応サイクルが起動しない不具合を修正した（#150）。`AppSettings.ReviewedLauncherArguments` の既定値と `LauncherAgentCatalog` の claude プリセットを実在するスキル名 `/review-raven-thread-owl-cycle` へ修正。旧既定値のまま使っている既存ユーザーは一回限りの migration（`ReviewedLauncherSkillMigrated`）で新既定値へ移行し、カスタマイズ済みの値は変更しない。この migration はプリセット判定（`LauncherPresetsMigrated`）より先に実行され、`ReviewedLauncherPresetId` が「カスタム」に誤判定されることを防ぐ
+
 ### Added
 - エージェント実行イベントのストリーミング基盤と構造化 progress event contract を導入した（#143）。`ReviewLauncherService` がプロセス終了後に stdout / stderr を一括取得していた方式を行単位の逐次読み取りへ変更し、`AgentExecutionSession` から stdout / stderr / progress / completed の型付きイベントを実行中に購読できるようにした（`IReviewLauncherService.StartSession`。既存の `LaunchAsync` と `LauncherResult` の意味は維持）。progress event は stdout に混在する行頭マーカー `@squirrel-progress ` 付きの 1 行 JSON（schemaVersion / phaseIndex / totalPhases / phaseLabel / message / verdict / timestamp）とし、phase はエージェント非依存の汎用構造（0 始まり index / total / label）で phase 数を固定しない。マーカー不一致・malformed JSON・未知 schemaVersion の行は通常ログとして安全に流し、実行は失敗させない。成功・失敗・キャンセル・タイムアウトは区別された terminal event として通知する。producer 側の統合は `docs/progress-event-contract.md` とスキル組み込み用スニペット `docs/samples/skill-progress-snippet.md` を参照（statusline 連携と同じく、スキル定義への適用はユーザーの dotfiles / skills 側で行う）
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
@@ -45,7 +45,7 @@ public class LauncherAgentCatalogTests
 
     [Theory]
     [InlineData("claude", "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "claude")]
-    [InlineData("claude", "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"", "reviewed", "claude")]
+    [InlineData("claude", "-p \"/review-raven-thread-owl-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"", "reviewed", "claude")]
     [InlineData("claude", "--something-else", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     [InlineData("unknown-cmd", "unknown-args", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     public void ResolvePresetId_ShouldMatchExactCommandAndArguments(string command, string arguments, string roleName, string expectedPresetId)

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -546,6 +546,109 @@ public class SettingsServiceTests : IDisposable
         }
     }
 
+    [Fact]
+    public void ReviewedLauncherSkillMigration_ShouldRewriteLegacyDefaultArguments()
+    {
+        // Arrange: 旧既定値（実在しない /thread-owl-review-cycle を呼ぶテンプレート）のままの設定
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierSkillMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewedLauncherCommandPath = "claude",
+            ReviewedLauncherArguments = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"",
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = false,
+            ReviewedLauncherSkillMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: 新既定値へ書き換わり、後続のプリセット判定でも claude と一致する
+            service.Settings.ReviewedLauncherArguments.Should().Be(LauncherAgentCatalog.Find("claude")!.ReviewedArgumentsTemplate);
+            service.Settings.ReviewedLauncherArguments.Should().Contain("/review-raven-thread-owl-cycle");
+            service.Settings.ReviewedLauncherPresetId.Should().Be("claude");
+            service.Settings.ReviewedLauncherSkillMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("claude", "-p custom-args")]
+    [InlineData("my-custom-tool", "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"")]
+    public void ReviewedLauncherSkillMigration_ShouldNotRewriteCustomizedSettings(string reviewedCmd, string reviewedArgs)
+    {
+        // Arrange: command / arguments のどちらかが旧既定値と異なる（カスタマイズ済み）設定
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierSkillMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewedLauncherCommandPath = reviewedCmd,
+            ReviewedLauncherArguments = reviewedArgs,
+            LauncherSlotsMigrated = true,
+            ReviewedLauncherSkillMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert: カスタマイズ済みの値は変更されない
+            service.Settings.ReviewedLauncherCommandPath.Should().Be(reviewedCmd);
+            service.Settings.ReviewedLauncherArguments.Should().Be(reviewedArgs);
+            service.Settings.ReviewedLauncherSkillMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void ReviewedLauncherSkillMigration_ShouldSkipWhenAlreadyMigrated()
+    {
+        // Arrange: migration 済みフラグが立っている場合は旧既定値でも書き換えない
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierSkillMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        const string legacyArgs = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
+        var seed = new AppSettings
+        {
+            ReviewedLauncherCommandPath = "claude",
+            ReviewedLauncherArguments = legacyArgs,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = true,
+            ReviewedLauncherSkillMigrated = true,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            // Act
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            // Assert
+            service.Settings.ReviewedLauncherArguments.Should().Be(legacyArgs);
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void Settings_ShouldDefaultReviewedLauncherArgumentsToExistingSkillName()
+    {
+        new AppSettings().ReviewedLauncherArguments.Should().Contain("/review-raven-thread-owl-cycle");
+    }
+
     [Theory]
     [InlineData("claude", "claude-code")]
     [InlineData("codex", "codex")]

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
@@ -50,7 +50,7 @@ internal static class LauncherAgentCatalog
             "claude",
             "claude",
             "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
-            "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"",
+            "-p \"/review-raven-thread-owl-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"",
             "claude-code"),
 
         // codex / agy / copilot はスキル呼び出し機構を持たないため、プロンプト全文を

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -66,6 +66,22 @@ internal sealed class SettingsService
             SaveSettings();
         }
 
+        // reviewed launcher の旧既定値は実在しないスキル名（/thread-owl-review-cycle）を呼んでいた（#150）。
+        // 旧既定値のまま使っているユーザーのみ修正後の既定値へ一回だけ移行する（カスタマイズ済みの
+        // 値は変更しない）。後続の LauncherPresetsMigrated 判定が新しいカタログ値と一致するよう、
+        // この migration はプリセット判定より先に実行する.
+        if (!_settings.ReviewedLauncherSkillMigrated)
+        {
+            const string legacyReviewedLauncherArgs = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
+            if (_settings.ReviewedLauncherCommandPath == "claude" && _settings.ReviewedLauncherArguments == legacyReviewedLauncherArgs)
+            {
+                _settings.ReviewedLauncherArguments = LauncherAgentCatalog.Find("claude")!.ReviewedArgumentsTemplate;
+            }
+
+            _settings.ReviewedLauncherSkillMigrated = true;
+            SaveSettings();
+        }
+
         // launcher スロットの command / arguments がどのエージェントプリセットと一致するかを
         // 一回だけ判定して記録する（#149）。一致しない場合は「カスタム」として扱う.
         if (!_settings.LauncherPresetsMigrated)
@@ -361,9 +377,12 @@ internal sealed class AppSettings
     // reviewed-side スロット
     public string ReviewedLauncherCommandPath { get; set; } = "claude";
 
-    public string ReviewedLauncherArguments { get; set; } = "-p \"/thread-owl-review-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
+    public string ReviewedLauncherArguments { get; set; } = "-p \"/review-raven-thread-owl-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"";
 
     public bool LauncherSlotsMigrated { get; set; }
+
+    // reviewed launcher 既定値のスキル名修正（#150）を既存ユーザーへ適用する一回限り migration のフラグ
+    public bool ReviewedLauncherSkillMigrated { get; set; }
 
     // launcher スロットに選択されているエージェントプリセット ID（LauncherAgentCatalog 参照）。
     // 自由編集でどのプリセットとも一致しなくなった場合は LauncherAgentCatalog.CustomPresetId になる.


### PR DESCRIPTION
Closes #150

## 概要

reviewed launcher の既定値が実在しないスキル名 `/thread-owl-review-cycle` を呼んでおり、デフォルト設定のまま「レビューに対応」を実行しても意図したレビュー対応サイクルが起動しない不具合を修正した。実在するスキル名は `/review-raven-thread-owl-cycle`。

## 変更内容

### スキル名の修正（2箇所同時）
- `AppSettings.ReviewedLauncherArguments` の既定値
- `LauncherAgentCatalog` の claude プリセットの `ReviewedArgumentsTemplate`

両者は #149 のプリセット一致判定（`ResolvePresetId`）で突き合わせられるため、必ず同時に修正する必要がある。

### 既存ユーザーの migration
旧既定値（`claude` + 旧テンプレート完全一致）のまま使っているユーザーを、一回限りの migration（`ReviewedLauncherSkillMigrated` フラグ）で新既定値へ移行する。カスタマイズ済みの値（command または arguments が旧既定値と異なる）は変更しない。

**migration の実行順序**: `LauncherPresetsMigrated`（プリセット判定）より**先**に実行する。旧既定値を先に新カタログ値へ直しておくことで、v0.3.x から一気に更新したユーザー（プリセット判定未実施）でも `ReviewedLauncherPresetId` が正しく `claude` と判定され、「カスタム」への誤判定を防ぐ。

## テスト

- `ReviewedLauncherSkillMigration_ShouldRewriteLegacyDefaultArguments`: 旧既定値 → 新既定値へ書き換わり、プリセット判定も `claude` になる
- `ReviewedLauncherSkillMigration_ShouldNotRewriteCustomizedSettings`（パラメータ化）: arguments のみカスタム / command のみ異なる場合は変更されない
- `ReviewedLauncherSkillMigration_ShouldSkipWhenAlreadyMigrated`: migration 済みなら旧文字列でも書き換えない
- `Settings_ShouldDefaultReviewedLauncherArgumentsToExistingSkillName`: 新規既定値の検証
- `LauncherAgentCatalogTests` の InlineData を新スキル名へ更新
- 367 件全テスト合格、`dotnet format --verify-no-changes` / `dotnet build` / `dotnet test` すべて成功

## 確認方法

1. 旧既定値のまま（または新規インストール状態）でアプリを起動し、settings.json の `ReviewedLauncherArguments` に `/review-raven-thread-owl-cycle` が入っていることを確認
2. Settings の Reviewed Preset が「claude」と表示されること（「カスタム」に化けないこと）を確認
3. イベント行の「レビューに対応」を実行し、実際にレビュー対応サイクルが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)