### PR TITLE
feat: ライブログウィンドウの表示ロジック層を追加（#144 第1弾）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- エージェント実行ライブログウィンドウ（#144）の表示ロジック層を追加した（第1弾。Window / XAML と MainWindow 統合は次の PR）。`AgentExecutionViewModel` が #143 の型付きイベントを表示状態（phase 進捗・Verdict・terminal 状態・ログ行）へ変換し、行数上限 1000 行の rolling buffer で長時間実行でも UI メモリを無制限に増やさない。表示前の各行には ANSI エスケープ・制御文字の除去（`AnsiControlSanitizer`）と機密値マスキング（`SecretMasker`）を適用する。マスキング対象は「既知トークン形式のパターン（GitHub PAT / sk- 系 API キー / Bearer ヘッダ）」と「squirrel-notifier 自身が参照する `MCP_PROBE_AUTH_TOKEN` の値」に明示的に限定し、ルール外の機密値は保護対象外であることを `docs/live-log-window.md` に明記した。あわせて work area 内右下へ clamp 配置する `WindowPlacementCalculator` と、成功時自動クローズの設定（`LiveLogAutoCloseEnabled`、既定有効）を追加した
+
 ### Fixed
 - reviewed launcher 既定値のスキル呼び出し名が実在しない `/thread-owl-review-cycle` になっており、デフォルト設定のまま「レビューに対応」を実行しても意図したレビュー対応サイクルが起動しない不具合を修正した（#150）。`AppSettings.ReviewedLauncherArguments` の既定値と `LauncherAgentCatalog` の claude プリセットを実在するスキル名 `/review-raven-thread-owl-cycle` へ修正。旧既定値のまま使っている既存ユーザーは一回限りの migration（`ReviewedLauncherSkillMigrated`）で新既定値へ移行し、カスタマイズ済みの値は変更しない。この migration はプリセット判定（`LauncherPresetsMigrated`）より先に実行され、`ReviewedLauncherPresetId` が「カスタム」に誤判定されることを防ぐ
 

--- a/docs/live-log-window.md
+++ b/docs/live-log-window.md
@@ -1,0 +1,45 @@
+# エージェント実行ライブログウィンドウ（#144）
+
+エージェント実行セッション（#143 の `AgentExecutionSession`）の進捗とログをリアルタイム表示する小型サブウィンドウ。表示ロジックは `ViewModels/AgentExecutionViewModel` に分離されており、Window / XAML コードビハインドは薄い接続層に留める。
+
+## 表示仕様
+
+- stdout / stderr / progress をログ行として視覚的に区別して表示する
+- phase（#143 contract の 0 始まり index / total / label）を ProgressBar と状態テキストで表示する。progress event を出力しないランチャーは実行終了まで indeterminate（不確定）表示になる
+- 成功・失敗・キャンセル・タイムアウトの terminal 状態を区別して表示する
+- 成功終了時は短い猶予の後に自動クローズする（Settings の `LiveLogAutoCloseEnabled` で無効化可能）。失敗・キャンセル・タイムアウト時は診断のため保持する
+- ログは行数上限付きの rolling buffer（`AgentExecutionViewModel.MaxLogLines` = 1000 行）で管理し、長時間実行でも UI メモリが無制限に増加しない
+
+## ログのサニタイズ
+
+表示前に各行へ以下を適用する（`Helpers/AnsiControlSanitizer`）:
+
+- ANSI エスケープシーケンス（CSI / OSC / Fe）の除去
+- 水平タブ（`\t`）を除く C0 制御文字と DEL の除去
+
+## 機密値マスキング
+
+表示前に各行へマスキング（`Helpers/SecretMasker`、`***` へ置換）を適用する。**マスキング対象は以下の 2 種類に明示的に限定する**:
+
+### (a) 既知トークン形式のパターン
+
+| 対象 | パターン概要 |
+|---|---|
+| GitHub classic / OAuth / installation トークン | `ghp_` / `gho_` / `ghu_` / `ghs_` / `ghr_` + 英数字 16 文字以上 |
+| GitHub fine-grained PAT | `github_pat_` + 英数字・アンダースコア 22 文字以上 |
+| sk- 形式 API キー（OpenAI / Anthropic 等） | `sk-` + 英数字・記号 16 文字以上（`sk-ant-` / `sk-proj-` を包含） |
+| Authorization ヘッダ | `Bearer <トークン>` のトークン部 |
+
+### (b) squirrel-notifier 自身が参照する認証情報
+
+- 環境変数 `MCP_PROBE_AUTH_TOKEN` の値と一致する文字列
+
+### 保護対象外（重要）
+
+任意テキストからの機密値検出は原理的に不可能なため、**上記ルールに合致しない機密値は保護対象外**である。例:
+
+- 上記以外の形式の独自トークン・パスワード・接続文字列
+- 改行やエスケープで分断されたトークン
+- エージェントが出力する、squirrel-notifier が関知しない認証情報
+
+エージェントに渡すプロンプトやスキル定義の側で、機密値を stdout に出力しない運用を優先すること。

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/AnsiControlSanitizerTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/AnsiControlSanitizerTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="AnsiControlSanitizerTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class AnsiControlSanitizerTests
+{
+    [Theory]
+    [InlineData("\x1b[31m赤色\x1b[0m", "赤色")]
+    [InlineData("\x1b[1;32;40mbold\x1b[m", "bold")]
+    [InlineData("\x1b[2J\x1b[Hクリア", "クリア")]
+    [InlineData("\x1b]0;window title\x07本文", "本文")]
+    [InlineData("\x1b]8;;https://example.com\x1b\\リンク", "リンク")]
+    [InlineData("\x1b[31", "")]
+    [InlineData("\x1bMabc", "abc")]
+    [InlineData("前\x1b[0K後", "前後")]
+    public void Sanitize_ShouldRemoveAnsiEscapeSequences(string input, string expected)
+    {
+        AnsiControlSanitizer.Sanitize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("a\u0007b", "ab")]
+    [InlineData("a\u0000b\u001Fc", "abc")]
+    [InlineData("a\u007Fb", "ab")]
+    [InlineData("a\rb", "ab")]
+    public void Sanitize_ShouldRemoveControlCharacters(string input, string expected)
+    {
+        AnsiControlSanitizer.Sanitize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("タブ\tは保持", "タブ\tは保持")]
+    [InlineData("普通のログ行です", "普通のログ行です")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void Sanitize_ShouldPreserveTabAndPlainText(string? input, string expected)
+    {
+        AnsiControlSanitizer.Sanitize(input!).Should().Be(expected);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/SecretMaskerTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/SecretMaskerTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="SecretMaskerTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class SecretMaskerTests
+{
+    private static SecretMasker CreateMasker(params string?[] knownSecrets) => new(knownSecrets);
+
+    [Theory]
+    [InlineData("token: ghp_abcdefghijklmnopqrstuvwxyz0123456789", "token: ***")]
+    [InlineData("gho_ABCDEFGHIJKLMNOP1234 を使用", "*** を使用")]
+    [InlineData("github_pat_11ABCDEFG0abcdefghijklmnopqrstuv", "***")]
+    [InlineData("key=sk-ant-api03-abcdefghijklmnop", "key=***")]
+    [InlineData("sk-proj-1234567890abcdefghij", "***")]
+    [InlineData("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload", "Authorization: Bearer ***")]
+    [InlineData("authorization: bearer abc123def456", "authorization: Bearer ***")]
+    public void Mask_ShouldMaskKnownTokenPatterns(string input, string expected)
+    {
+        CreateMasker().Mask(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ghp_short は短すぎるので対象外")]
+    [InlineData("sk-abc は短すぎるので対象外")]
+    [InlineData("Bearer x は短すぎるので対象外")]
+    [InlineData("普通のログ行です")]
+    [InlineData("")]
+    public void Mask_ShouldNotChangeNonMatchingText(string input)
+    {
+        CreateMasker().Mask(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Mask_ShouldMaskKnownSecretValues()
+    {
+        SecretMasker masker = CreateMasker("my-local-auth-token");
+
+        masker.Mask("MCP_PROBE_AUTH_TOKEN=my-local-auth-token を送信").Should().Be("MCP_PROBE_AUTH_TOKEN=*** を送信");
+    }
+
+    [Fact]
+    public void Mask_ShouldMaskMultipleOccurrences()
+    {
+        SecretMasker masker = CreateMasker("secret-value");
+
+        masker.Mask("secret-value と secret-value").Should().Be("*** と ***");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Mask_ShouldIgnoreEmptyKnownSecrets(string? secret)
+    {
+        // null・空白の秘密値は照合対象にせず、任意のテキストがマスクされないこと
+        SecretMasker masker = CreateMasker(secret);
+
+        masker.Mask("どの部分もマスクされない通常テキスト").Should().Be("どの部分もマスクされない通常テキスト");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowForNullCollection()
+    {
+        FluentActions.Invoking(() => new SecretMasker(null!)).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CreateDefault_ShouldMaskEnvironmentToken()
+    {
+        const string envName = "MCP_PROBE_AUTH_TOKEN";
+        string? original = Environment.GetEnvironmentVariable(envName);
+        try
+        {
+            Environment.SetEnvironmentVariable(envName, "env-secret-token-xyz");
+
+            SecretMasker masker = SecretMasker.CreateDefault();
+
+            masker.Mask("token=env-secret-token-xyz").Should().Be("token=***");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envName, original);
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/WindowPlacementCalculatorTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/WindowPlacementCalculatorTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="WindowPlacementCalculatorTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class WindowPlacementCalculatorTests
+{
+    [Theory]
+    [InlineData(0, 0, 1920, 1080, 400, 300, 16, 1504, 764)]
+    [InlineData(0, 0, 1920, 1080, 400, 300, 0, 1520, 780)]
+
+    // マルチモニター: 負座標のセカンダリモニター（プライマリの左側）でも work area 内に収まる
+    [InlineData(-1920, 0, 1920, 1080, 400, 300, 16, -416, 764)]
+
+    // タスクバー分の work area オフセット（上側タスクバー等）
+    [InlineData(0, 48, 2560, 1392, 500, 400, 16, 2044, 1024)]
+    public void CalculateBottomRight_ShouldPlaceWindowInsideWorkArea(
+        int workX, int workY, int workWidth, int workHeight, int windowWidth, int windowHeight, int margin, int expectedX, int expectedY)
+    {
+        (int x, int y) = WindowPlacementCalculator.CalculateBottomRight(
+            workX, workY, workWidth, workHeight, windowWidth, windowHeight, margin);
+
+        x.Should().Be(expectedX);
+        y.Should().Be(expectedY);
+
+        // 左上が work area 内に収まっていること（画面外配置の防止）
+        x.Should().BeGreaterThanOrEqualTo(workX);
+        y.Should().BeGreaterThanOrEqualTo(workY);
+    }
+
+    [Theory]
+
+    // ウィンドウが work area より大きい場合は左上へ clamp する
+    [InlineData(0, 0, 800, 600, 1000, 700, 16, 0, 0)]
+    [InlineData(100, 50, 800, 600, 1000, 700, 16, 100, 50)]
+
+    // 高さのみ超過
+    [InlineData(0, 0, 1920, 400, 400, 500, 16, 1504, 0)]
+    public void CalculateBottomRight_ShouldClampToWorkAreaOrigin_WhenWindowIsLarger(
+        int workX, int workY, int workWidth, int workHeight, int windowWidth, int windowHeight, int margin, int expectedX, int expectedY)
+    {
+        (int x, int y) = WindowPlacementCalculator.CalculateBottomRight(
+            workX, workY, workWidth, workHeight, windowWidth, windowHeight, margin);
+
+        x.Should().Be(expectedX);
+        y.Should().Be(expectedY);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -649,6 +649,25 @@ public class SettingsServiceTests : IDisposable
         new AppSettings().ReviewedLauncherArguments.Should().Contain("/review-raven-thread-owl-cycle");
     }
 
+    [Fact]
+    public void Settings_ShouldDefaultLiveLogAutoCloseToEnabled()
+    {
+        new AppSettings().LiveLogAutoCloseEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateLiveLogAutoCloseEnabled_ShouldPersistValue()
+    {
+        // Act
+        _settingsService.UpdateLiveLogAutoCloseEnabled(false);
+
+        // Assert
+        _settingsService.Settings.LiveLogAutoCloseEnabled.Should().BeFalse();
+
+        var reloaded = new SettingsService(_settingsDirectory, pnpmBinDir: string.Empty);
+        reloaded.Settings.LiveLogAutoCloseEnabled.Should().BeFalse();
+    }
+
     [Theory]
     [InlineData("claude", "claude-code")]
     [InlineData("codex", "codex")]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/ViewModels/AgentExecutionViewModelTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/ViewModels/AgentExecutionViewModelTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="AgentExecutionViewModelTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.ViewModels;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.ViewModels;
+
+public class AgentExecutionViewModelTests
+{
+    private static readonly DateTimeOffset _now = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+
+    private static AgentExecutionViewModel CreateViewModel(bool autoCloseEnabled = true, params string?[] knownSecrets)
+        => new("owner/repo#1（レビューする）", autoCloseEnabled, new SecretMasker(knownSecrets));
+
+    private static AgentExecutionEvent StdoutEvent(string text)
+        => new() { Kind = AgentExecutionEventKind.Stdout, Timestamp = _now, Text = text };
+
+    private static AgentExecutionEvent StderrEvent(string text)
+        => new() { Kind = AgentExecutionEventKind.Stderr, Timestamp = _now, Text = text };
+
+    private static AgentExecutionEvent ProgressEvent(int phaseIndex, int totalPhases, string label, string? message = null, string? verdict = null)
+        => new()
+        {
+            Kind = AgentExecutionEventKind.Progress,
+            Timestamp = _now,
+            Progress = new AgentProgressEvent(1, phaseIndex, totalPhases, label, message, verdict, null),
+        };
+
+    private static AgentExecutionEvent CompletedEvent(AgentExecutionOutcome outcome, LauncherResult? result = null)
+        => new()
+        {
+            Kind = AgentExecutionEventKind.Completed,
+            Timestamp = _now,
+            Outcome = outcome,
+            Result = result ?? new LauncherResult { Success = outcome == AgentExecutionOutcome.Succeeded },
+        };
+
+    [Fact]
+    public void InitialState_ShouldBeRunningAndIndeterminate()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.IsRunning.Should().BeTrue();
+        vm.IsIndeterminate.Should().BeTrue();
+        vm.IsCompleted.Should().BeFalse();
+        vm.Outcome.Should().BeNull();
+        vm.Verdict.Should().BeNull();
+        vm.LogLines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Apply_Stdout_ShouldAppendSanitizedAndMaskedLine()
+    {
+        AgentExecutionViewModel vm = CreateViewModel(autoCloseEnabled: true, "local-secret");
+
+        vm.Apply(StdoutEvent("\x1b[32mtoken=local-secret\x1b[0m"));
+
+        vm.LogLines.Should().ContainSingle();
+        vm.LogLines[0].Kind.Should().Be(AgentExecutionEventKind.Stdout);
+        vm.LogLines[0].Text.Should().Be("token=***");
+        vm.LogLines[0].Timestamp.Should().Be(_now);
+    }
+
+    [Fact]
+    public void Apply_Stderr_ShouldAppendLineWithStderrKind()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(StderrEvent("error output"));
+
+        vm.LogLines.Should().ContainSingle().Which.Kind.Should().Be(AgentExecutionEventKind.Stderr);
+    }
+
+    [Fact]
+    public void Apply_Progress_ShouldUpdatePhaseStateAndAppendLogLine()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(ProgressEvent(3, 8, "修正", message: "accept 2件"));
+
+        vm.IsIndeterminate.Should().BeFalse();
+        vm.ProgressValue.Should().Be(50);
+        vm.StatusText.Should().Be("Phase 4/8: 修正");
+        vm.LogLines.Should().ContainSingle();
+        vm.LogLines[0].Kind.Should().Be(AgentExecutionEventKind.Progress);
+        vm.LogLines[0].Text.Should().Be("Phase 4/8: 修正 — accept 2件");
+    }
+
+    [Fact]
+    public void Apply_Progress_ShouldUpdateVerdict_AndKeepItAfterwards()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(ProgressEvent(7, 8, "Verdict 待機", verdict: "APPROVED"));
+        vm.Apply(ProgressEvent(7, 8, "Verdict 待機"));
+
+        vm.Verdict.Should().Be("APPROVED", "verdict 無しの後続イベントで上書きされない");
+    }
+
+    [Theory]
+    [InlineData(0, 8, 12.5)]
+    [InlineData(7, 8, 100)]
+
+    // phaseIndex が totalPhases 以上（1 始まりで出力する producer）でも 100% へ clamp
+    [InlineData(8, 8, 100)]
+    [InlineData(0, 1, 100)]
+    public void Apply_Progress_ShouldCalculateProgressValue(int phaseIndex, int totalPhases, double expected)
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(ProgressEvent(phaseIndex, totalPhases, "phase"));
+
+        vm.ProgressValue.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Succeeded", "完了しました")]
+    [InlineData("Cancelled", "キャンセルされました")]
+    [InlineData("TimedOut", "タイムアウトしました")]
+    public void Apply_Completed_ShouldSetTerminalState(string outcomeName, string expectedStatus)
+    {
+        AgentExecutionOutcome outcome = Enum.Parse<AgentExecutionOutcome>(outcomeName);
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(CompletedEvent(outcome));
+
+        vm.IsRunning.Should().BeFalse();
+        vm.IsCompleted.Should().BeTrue();
+        vm.Outcome.Should().Be(outcome);
+        vm.StatusText.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public void Apply_CompletedWithFailure_ShouldIncludeErrorMessage()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(CompletedEvent(
+            AgentExecutionOutcome.Failed,
+            new LauncherResult { Success = false, ErrorMessage = "起動に失敗" }));
+
+        vm.StatusText.Should().Be("失敗しました: 起動に失敗");
+    }
+
+    [Fact]
+    public void Apply_CompletedWithNonZeroExitCode_ShouldIncludeExitCode()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.Apply(CompletedEvent(
+            AgentExecutionOutcome.Failed,
+            new LauncherResult { Success = false, ExitCode = 2 }));
+
+        vm.StatusText.Should().Be("失敗しました（終了コード: 2）");
+    }
+
+    [Theory]
+    [InlineData("Succeeded", true, true)]
+    [InlineData("Succeeded", false, false)]
+    [InlineData("Failed", true, false)]
+    [InlineData("Cancelled", true, false)]
+    [InlineData("TimedOut", true, false)]
+    public void ShouldAutoClose_ShouldBeTrueOnlyForSuccessWithAutoCloseEnabled(
+        string outcomeName, bool autoCloseEnabled, bool expected)
+    {
+        AgentExecutionOutcome outcome = Enum.Parse<AgentExecutionOutcome>(outcomeName);
+        AgentExecutionViewModel vm = CreateViewModel(autoCloseEnabled);
+
+        vm.Apply(CompletedEvent(outcome));
+
+        vm.ShouldAutoClose.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Apply_ShouldTrimOldestLines_WhenExceedingMaxLogLines()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        for (int i = 0; i < AgentExecutionViewModel.MaxLogLines + 5; i++)
+        {
+            vm.Apply(StdoutEvent($"line-{i}"));
+        }
+
+        vm.LogLines.Should().HaveCount(AgentExecutionViewModel.MaxLogLines);
+        vm.LogLines[0].Text.Should().Be("line-5", "古い行から破棄される");
+        vm.LogLines[^1].Text.Should().Be($"line-{AgentExecutionViewModel.MaxLogLines + 4}");
+    }
+
+    [Fact]
+    public void ApplyBatch_ShouldApplyAllEventsInOrder()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+
+        vm.ApplyBatch(
+        [
+            StdoutEvent("first"),
+            ProgressEvent(0, 2, "sync"),
+            CompletedEvent(AgentExecutionOutcome.Succeeded),
+        ]);
+
+        vm.LogLines.Select(l => l.Kind).Should().ContainInOrder(
+            AgentExecutionEventKind.Stdout, AgentExecutionEventKind.Progress);
+        vm.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_Completed_ShouldRaisePropertyChangedForDerivedProperties()
+    {
+        AgentExecutionViewModel vm = CreateViewModel();
+        var changed = new List<string>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? string.Empty);
+
+        vm.Apply(CompletedEvent(AgentExecutionOutcome.Succeeded));
+
+        changed.Should().Contain(nameof(AgentExecutionViewModel.IsRunning));
+        changed.Should().Contain(nameof(AgentExecutionViewModel.Outcome));
+        changed.Should().Contain(nameof(AgentExecutionViewModel.IsCompleted));
+        changed.Should().Contain(nameof(AgentExecutionViewModel.ShouldAutoClose));
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/AnsiControlSanitizer.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/AnsiControlSanitizer.cs
@@ -1,0 +1,42 @@
+// <copyright file="AnsiControlSanitizer.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Text.RegularExpressions;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+/// <summary>
+/// エージェント出力のログ 1 行から ANSI エスケープシーケンスと制御文字を除去する（#144）。
+/// CLI エージェントは色付け・カーソル制御のためのエスケープを出力することがあり、
+/// そのまま UI へ流すと表示崩れや制御文字インジェクションの原因になる.
+/// </summary>
+internal static class AnsiControlSanitizer
+{
+    // CSI（ESC [ ... 終端バイト）、OSC（ESC ] ... BEL / ST。未終端も行末まで）、
+    // その他の Fe シーケンス（ESC + 1 文字）を除去する
+    private static readonly Regex _ansiEscapeRegex = new(
+        @"\x1B(?:\[[^@-~]*[@-~]?|\][^\x07\x1B]*(?:\x07|\x1B\\)?|[@-Z\\-_])?",
+        RegexOptions.Compiled);
+
+    // 水平タブ（0x09）を除く C0 制御文字と DEL を除去する
+    private static readonly Regex _controlCharRegex = new(
+        @"[\x00-\x08\x0A-\x1F\x7F]",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// ANSI エスケープシーケンスと制御文字を除去する。水平タブ（\t）のみ整形用として保持する.
+    /// </summary>
+    /// <param name="line">ログ 1 行.</param>
+    /// <returns>除去後の文字列.</returns>
+    public static string Sanitize(string line)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return string.Empty;
+        }
+
+        string withoutEscapes = _ansiEscapeRegex.Replace(line, string.Empty);
+        return _controlCharRegex.Replace(withoutEscapes, string.Empty);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/SecretMasker.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/SecretMasker.cs
@@ -1,0 +1,80 @@
+// <copyright file="SecretMasker.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+/// <summary>
+/// ログ表示前に機密値をマスクする（#144）。マスキング対象は以下の 2 種類に明示的に限定し、
+/// このルール外の機密値は保護対象外とする（詳細は docs/live-log-window.md）:
+/// (a) 既知トークン形式のパターン（GitHub PAT / sk- 系 API キー / Bearer ヘッダ）、
+/// (b) squirrel-notifier 自身が参照する認証情報（MCP_PROBE_AUTH_TOKEN）の値と一致する文字列.
+/// </summary>
+internal sealed class SecretMasker
+{
+    private const string _mask = "***";
+
+    // (a) 既知トークン形式のパターン。誤検出よりも取りこぼしを避ける安全側の長さ下限にする。
+    // 順に: GitHub classic / OAuth / installation トークン（gh[pousr]_）、GitHub fine-grained PAT、
+    // sk- 形式 API キー（OpenAI / Anthropic。sk-ant- / sk-proj- を包含）、Bearer ヘッダのトークン部
+    private static readonly Regex[] _knownTokenPatterns =
+    [
+        new(@"\bgh[pousr]_[A-Za-z0-9]{16,}\b", RegexOptions.Compiled),
+        new(@"\bgithub_pat_[A-Za-z0-9_]{22,}\b", RegexOptions.Compiled),
+        new(@"\bsk-[A-Za-z0-9_\-]{16,}\b", RegexOptions.Compiled),
+        new(@"\bBearer\s+[A-Za-z0-9._+/=\-]{8,}", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+    ];
+
+    // (b) squirrel-notifier 自身が保持する認証情報の実値（長い順に照合し部分マスクの重複を避ける）
+    private readonly string[] _knownSecrets;
+
+    public SecretMasker(IEnumerable<string?> knownSecrets)
+    {
+        ArgumentNullException.ThrowIfNull(knownSecrets);
+        _knownSecrets = knownSecrets
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(s => s.Length)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// プロセス環境から squirrel-notifier が参照する認証情報を収集した既定のマスカーを生成する.
+    /// </summary>
+    /// <returns>既定の <see cref="SecretMasker"/>.</returns>
+    public static SecretMasker CreateDefault()
+        => new([Environment.GetEnvironmentVariable("MCP_PROBE_AUTH_TOKEN")]);
+
+    /// <summary>
+    /// マスキングルールに合致する文字列を <c>***</c> へ置換する.
+    /// </summary>
+    /// <param name="text">対象テキスト（ログ 1 行）.</param>
+    /// <returns>マスク後のテキスト.</returns>
+    public string Mask(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        string masked = text;
+        foreach (string secret in _knownSecrets)
+        {
+            masked = masked.Replace(secret, _mask, StringComparison.Ordinal);
+        }
+
+        foreach (Regex pattern in _knownTokenPatterns)
+        {
+            masked = pattern.Replace(masked, static m =>
+                m.Value.StartsWith("Bearer", StringComparison.OrdinalIgnoreCase) ? $"Bearer {_mask}" : _mask);
+        }
+
+        return masked;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/WindowPlacementCalculator.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/WindowPlacementCalculator.cs
@@ -1,0 +1,43 @@
+// <copyright file="WindowPlacementCalculator.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+/// <summary>
+/// ライブログウィンドウの初期配置を計算する（#144）。WinUI 型に依存しない純粋計算とし、
+/// DPI・マルチモニターは呼び出し側が「現在モニターの work area とウィンドウサイズを
+/// 物理ピクセルで渡す」ことで吸収する.
+/// </summary>
+internal static class WindowPlacementCalculator
+{
+    /// <summary>
+    /// work area 右下へ margin を空けて配置する座標を計算する。ウィンドウが work area より
+    /// 大きい場合でも、左上が work area 内に収まるよう clamp し、画面外配置を防ぐ.
+    /// </summary>
+    /// <param name="workAreaX">work area 左上 X（物理ピクセル）.</param>
+    /// <param name="workAreaY">work area 左上 Y（物理ピクセル）.</param>
+    /// <param name="workAreaWidth">work area 幅（物理ピクセル）.</param>
+    /// <param name="workAreaHeight">work area 高さ（物理ピクセル）.</param>
+    /// <param name="windowWidth">ウィンドウ幅（物理ピクセル）.</param>
+    /// <param name="windowHeight">ウィンドウ高さ（物理ピクセル）.</param>
+    /// <param name="margin">work area 端との余白（物理ピクセル）.</param>
+    /// <returns>ウィンドウ左上の配置座標（物理ピクセル）.</returns>
+    public static (int X, int Y) CalculateBottomRight(
+        int workAreaX,
+        int workAreaY,
+        int workAreaWidth,
+        int workAreaHeight,
+        int windowWidth,
+        int windowHeight,
+        int margin)
+    {
+        int x = workAreaX + workAreaWidth - windowWidth - margin;
+        int y = workAreaY + workAreaHeight - windowHeight - margin;
+
+        // ウィンドウが work area より大きい場合は右下基準を諦め、左上を work area 内へ収める
+        return (Math.Max(x, workAreaX), Math.Max(y, workAreaY));
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Models/AgentLogLine.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/AgentLogLine.cs
@@ -1,0 +1,13 @@
+// <copyright file="AgentLogLine.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// ライブログウィンドウに表示する 1 行（#144）。サニタイズ・マスキング適用済みのテキストを保持する.
+/// </summary>
+/// <param name="Kind">行の由来（stdout / stderr / progress）。表示上の区別に使う.</param>
+/// <param name="Text">表示テキスト.</param>
+/// <param name="Timestamp">squirrel-notifier 側で観測したイベント時刻.</param>
+internal sealed record AgentLogLine(AgentExecutionEventKind Kind, string Text, DateTimeOffset Timestamp);

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -254,6 +254,12 @@ internal sealed class SettingsService
         SaveSettings();
     }
 
+    public void UpdateLiveLogAutoCloseEnabled(bool enabled)
+    {
+        _settings.LiveLogAutoCloseEnabled = enabled;
+        SaveSettings();
+    }
+
     /// <summary>
     /// 指定した launcher スロットに現在選択されているプリセットの rateLimitAgentId を解決する（#149）。
     /// 「カスタム」設定、またはレートリミット取得手段が無いプリセット（copilot 等）の場合は
@@ -396,6 +402,10 @@ internal sealed class AppSettings
     public int LauncherTimeoutMs { get; set; } = 1800000;
 
     public string LastSkippedVersion { get; set; } = string.Empty;
+
+    // ライブログウィンドウ（#144）: 成功終了時に短い猶予の後で自動クローズするか。
+    // 失敗・キャンセル・タイムアウト時は設定に関わらず診断のため保持する
+    public bool LiveLogAutoCloseEnabled { get; set; } = true;
 
     // ローカルの statusline スクリプトがレートリミット状態を書き出すエージェント ID
     // （RateLimitAgentCatalog 参照）のうち、監視対象として選択されているもの

--- a/winui3/SquirrelNotifier.WinUI3/ViewModels/AgentExecutionViewModel.cs
+++ b/winui3/SquirrelNotifier.WinUI3/ViewModels/AgentExecutionViewModel.cs
@@ -1,0 +1,220 @@
+// <copyright file="AgentExecutionViewModel.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.ViewModels;
+
+/// <summary>
+/// ライブログウィンドウの表示ロジック（#144）。<see cref="Services.AgentExecutionSession"/> が配信する
+/// 型付きイベントを表示状態へ変換する。DispatcherQueue には依存せず、呼び出し側（Window）が
+/// UI スレッド上で <see cref="Apply"/> / <see cref="ApplyBatch"/> を呼ぶ契約とすることで単体テスト可能にする.
+/// </summary>
+internal sealed class AgentExecutionViewModel : INotifyPropertyChanged
+{
+    /// <summary>
+    /// rolling buffer の行数上限。超過した古い行から破棄し、長時間実行でも UI メモリを無制限に増やさない.
+    /// </summary>
+    public const int MaxLogLines = 1000;
+
+    private readonly SecretMasker _masker;
+    private readonly bool _autoCloseEnabled;
+
+    private bool _isRunning = true;
+    private bool _isIndeterminate = true;
+    private double _progressValue;
+    private string _statusText = "実行中...";
+    private string? _verdict;
+    private AgentExecutionOutcome? _outcome;
+
+    public AgentExecutionViewModel(string title, bool autoCloseEnabled, SecretMasker masker)
+    {
+        ArgumentNullException.ThrowIfNull(masker);
+        Title = title ?? string.Empty;
+        _autoCloseEnabled = autoCloseEnabled;
+        _masker = masker;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Gets ウィンドウタイトル（例: "owner/repo#123（レビューする）"）.</summary>
+    public string Title { get; }
+
+    /// <summary>Gets 表示用ログ行（サニタイズ・マスキング適用済み、rolling buffer 上限あり）.</summary>
+    public ObservableCollection<AgentLogLine> LogLines { get; } = new();
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        private set => SetField(ref _isRunning, value, nameof(IsRunning));
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether progress event を未受信の間は true（indeterminate 表示）。構造化イベント非対応の
+    /// ランチャーでは実行終了までこのままになる（#143 の contract）.
+    /// </summary>
+    public bool IsIndeterminate
+    {
+        get => _isIndeterminate;
+        private set => SetField(ref _isIndeterminate, value, nameof(IsIndeterminate));
+    }
+
+    /// <summary>Gets 進捗率（0〜100）。現在実行中の phase までを含めた割合.</summary>
+    public double ProgressValue
+    {
+        get => _progressValue;
+        private set => SetField(ref _progressValue, value, nameof(ProgressValue));
+    }
+
+    /// <summary>Gets 現在の状態表示（phase 表示または terminal 状態の文言）.</summary>
+    public string StatusText
+    {
+        get => _statusText;
+        private set => SetField(ref _statusText, value, nameof(StatusText));
+    }
+
+    /// <summary>Gets producer が報告した最新の Verdict（例: "APPROVED"）。未報告なら null.</summary>
+    public string? Verdict
+    {
+        get => _verdict;
+        private set => SetField(ref _verdict, value, nameof(Verdict));
+    }
+
+    /// <summary>Gets 実行終了時の結果分類。実行中は null.</summary>
+    public AgentExecutionOutcome? Outcome => _outcome;
+
+    /// <summary>Gets a value indicating whether 実行が終了したかどうか.</summary>
+    public bool IsCompleted => _outcome != null;
+
+    /// <summary>Gets a value indicating whether 成功終了かつ自動クローズが有効な場合のみ true。失敗時は診断のため保持する.</summary>
+    public bool ShouldAutoClose => _outcome == AgentExecutionOutcome.Succeeded && _autoCloseEnabled;
+
+    /// <summary>
+    /// 実行イベントを 1 件適用する。UI スレッド上で呼ぶこと.
+    /// </summary>
+    /// <param name="executionEvent">セッションから受信したイベント.</param>
+    public void Apply(AgentExecutionEvent executionEvent)
+    {
+        ArgumentNullException.ThrowIfNull(executionEvent);
+
+        switch (executionEvent.Kind)
+        {
+            case AgentExecutionEventKind.Stdout:
+            case AgentExecutionEventKind.Stderr:
+                AppendLogLine(executionEvent.Kind, executionEvent.Text ?? string.Empty, executionEvent.Timestamp);
+                break;
+
+            case AgentExecutionEventKind.Progress:
+                ApplyProgress(executionEvent);
+                break;
+
+            case AgentExecutionEventKind.Completed:
+                ApplyCompleted(executionEvent);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// 実行イベントをまとめて適用する（UI 更新のバッチ化用）。UI スレッド上で呼ぶこと.
+    /// </summary>
+    /// <param name="events">セッションから受信したイベント列.</param>
+    public void ApplyBatch(IReadOnlyList<AgentExecutionEvent> events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        foreach (AgentExecutionEvent executionEvent in events)
+        {
+            Apply(executionEvent);
+        }
+    }
+
+    private void ApplyProgress(AgentExecutionEvent executionEvent)
+    {
+        AgentProgressEvent? progress = executionEvent.Progress;
+        if (progress == null)
+        {
+            return;
+        }
+
+        IsIndeterminate = false;
+
+        // phaseIndex は 0 始まり。現在実行中の phase を含めた進捗率として表示する
+        int displayPhase = Math.Min(progress.PhaseIndex + 1, progress.TotalPhases);
+        ProgressValue = Math.Clamp(displayPhase * 100.0 / progress.TotalPhases, 0, 100);
+
+        string phaseText = string.Format(
+            CultureInfo.InvariantCulture, "Phase {0}/{1}: {2}", displayPhase, progress.TotalPhases, progress.PhaseLabel);
+        StatusText = phaseText;
+
+        if (!string.IsNullOrWhiteSpace(progress.Verdict))
+        {
+            Verdict = progress.Verdict;
+        }
+
+        string logText = string.IsNullOrWhiteSpace(progress.Message)
+            ? phaseText
+            : $"{phaseText} — {progress.Message}";
+        AppendLogLine(AgentExecutionEventKind.Progress, logText, executionEvent.Timestamp);
+    }
+
+    private void ApplyCompleted(AgentExecutionEvent executionEvent)
+    {
+        _outcome = executionEvent.Outcome;
+        IsRunning = false;
+
+        LauncherResult? result = executionEvent.Result;
+        StatusText = executionEvent.Outcome switch
+        {
+            AgentExecutionOutcome.Succeeded => "完了しました",
+            AgentExecutionOutcome.Cancelled => "キャンセルされました",
+            AgentExecutionOutcome.TimedOut => "タイムアウトしました",
+            _ => BuildFailedStatusText(result),
+        };
+
+        RaisePropertyChanged(nameof(Outcome));
+        RaisePropertyChanged(nameof(IsCompleted));
+        RaisePropertyChanged(nameof(ShouldAutoClose));
+    }
+
+    private static string BuildFailedStatusText(LauncherResult? result)
+    {
+        if (result != null && !string.IsNullOrWhiteSpace(result.ErrorMessage))
+        {
+            return $"失敗しました: {result.ErrorMessage}";
+        }
+
+        return result?.ExitCode is int exitCode
+            ? string.Format(CultureInfo.InvariantCulture, "失敗しました（終了コード: {0}）", exitCode)
+            : "失敗しました";
+    }
+
+    private void AppendLogLine(AgentExecutionEventKind kind, string rawText, DateTimeOffset timestamp)
+    {
+        string text = _masker.Mask(AnsiControlSanitizer.Sanitize(rawText));
+        LogLines.Add(new AgentLogLine(kind, text, timestamp));
+
+        while (LogLines.Count > MaxLogLines)
+        {
+            LogLines.RemoveAt(0);
+        }
+    }
+
+    private void SetField<T>(ref T field, T value, string propertyName)
+    {
+        if (!EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            RaisePropertyChanged(propertyName);
+        }
+    }
+
+    private void RaisePropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}


### PR DESCRIPTION
Part of #144（第1弾: ロジック層。Window / XAML と MainWindow 統合は第2弾の PR で行い、そちらで #144 を Close する）

## 概要

エージェント実行ライブログウィンドウ（#144）の実装を 2 PR に分割し、本 PR では単体テスト可能な表示ロジック層のみを追加する。UI（Window / XAML）からの参照は次の PR まで存在しない。

## 設計論点の確定内容（実装前に確認済み）

| 論点 | 決定 |
|---|---|
| 機密値マスキングの範囲 | (a) 既知トークン形式のパターン + (b) squirrel-notifier 自身が参照する `MCP_PROBE_AUTH_TOKEN` の値、の両方。ルール外は保護対象外として `docs/live-log-window.md` に明記 |
| カバレッジの担保層 | 表示ロジックを ViewModel / Helper 層に分離して 80% を担保。Window / XAML コードビハインドは MainWindow と同じ `[ExcludeFromCodeCoverage]` パターン（第2弾で適用） |
| PR 分割 | 2 PR（本 PR = ロジック層、次 PR = Window / XAML / MainWindow 統合） |

## 変更内容

### `ViewModels/AgentExecutionViewModel`（新規）
- #143 の `AgentExecutionEvent`（stdout / stderr / progress / completed）を表示状態へ変換
  - phase 進捗（0 始まり index → `Phase N/M: label` 表示と 0〜100 の進捗率、1 始まり producer は clamp で吸収）
  - progress 未受信の間は `IsIndeterminate = true`（構造化イベント非対応ランチャーのフォールバック表示）
  - Verdict の保持（verdict 無しの後続イベントで上書きしない）
  - terminal 状態（成功 / 失敗 / キャンセル / タイムアウト）の文言と `ShouldAutoClose` 判定（成功 × 自動クローズ有効のみ true。失敗時は診断のため保持）
- 行数上限 1000 行の rolling buffer（古い行から破棄）で長時間実行でも UI メモリを無制限に増やさない
- DispatcherQueue 非依存。「UI スレッド上で `Apply` / `ApplyBatch` を呼ぶ」契約とし、バッチ化の入口（`ApplyBatch`)を提供

### `Helpers/AnsiControlSanitizer`（新規）
- ANSI エスケープ（CSI / OSC / Fe、未終端含む）と C0 制御文字・DEL を除去（`\t` のみ整形用に保持）

### `Helpers/SecretMasker`（新規）
- (a) 既知トークンパターン: GitHub トークン（`gh[pousr]_` / `github_pat_`）、sk- 形式 API キー（`sk-ant-` / `sk-proj-` 包含）、Bearer ヘッダ → `***` へ置換
- (b) コンストラクタへ渡された既知秘密値（既定は `MCP_PROBE_AUTH_TOKEN` の値）との完全一致

### `Helpers/WindowPlacementCalculator`（新規）
- work area 右下配置の純粋計算（物理ピクセル、マルチモニターの負座標対応、work area より大きい場合は左上へ clamp）

### 設定・docs
- `AppSettings.LiveLogAutoCloseEnabled`（既定 true）+ `SettingsService.UpdateLiveLogAutoCloseEnabled`
- `docs/live-log-window.md`: 表示仕様・サニタイズ・マスキングルールと**保護対象外の明記**

## テスト

- 全てパラメータ化中心の新規テスト 73 件（Sanitizer 16 / Masker 15 / PlacementCalculator 7 / ViewModel 27 / Settings 2 ほか）
- 433 件全テスト合格、カバレッジ Line 90.18% / Branch 86.67% / Method 94.96%
- `dotnet format --verify-no-changes` / `dotnet build` / `dotnet test` すべて成功

## 確認方法

本 PR はロジック層のみのため、動作確認は単体テストで行う（`dotnet test`）。実ウィンドウでの表示確認は第2弾 PR で実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)