### PR TITLE
feat: エージェント実行ライブログウィンドウを追加（#144 第2弾）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- エージェント実行ライブログウィンドウを追加した（#144 第2弾）。「レビューする」「レビューに対応」の実行時に、従来のモーダルダイアログ（実行中 ContentDialog + 終了後の結果ダイアログ）に代えて専用サブウィンドウを表示し、stdout / stderr / progress を色分けした逐次ログ、phase 進捗（ProgressBar、非対応ランチャーは indeterminate）、Verdict と terminal 状態（InfoBar）をリアルタイム表示する。ウィンドウは現在モニターの work area 内・右下へ DPI を考慮して配置され、最前面ピン留めトグルを持つ。成功時は 3 秒後に自動クローズ（Settings の「ライブログ自動クローズ」トグルで無効化可能）、失敗・キャンセル・タイムアウト時は診断のため保持する。「キャンセル」ボタンと実行中のウィンドウクローズで実行をキャンセルできる（従来ダイアログのキャンセル動作を踏襲）。イベント反映は DispatcherQueue への coalescing バッチ化で UI 更新頻度を抑制する
+
+### Added
 - エージェント実行ライブログウィンドウ（#144）の表示ロジック層を追加した（第1弾。Window / XAML と MainWindow 統合は次の PR）。`AgentExecutionViewModel` が #143 の型付きイベントを表示状態（phase 進捗・Verdict・terminal 状態・ログ行）へ変換し、行数上限 1000 行の rolling buffer で長時間実行でも UI メモリを無制限に増やさない。表示前の各行には ANSI エスケープ・制御文字の除去（`AnsiControlSanitizer`）と機密値マスキング（`SecretMasker`）を適用する。マスキング対象は「既知トークン形式のパターン（GitHub PAT / sk- 系 API キー / Bearer ヘッダ）」と「squirrel-notifier 自身が参照する `MCP_PROBE_AUTH_TOKEN` の値」に明示的に限定し、ルール外の機密値は保護対象外であることを `docs/live-log-window.md` に明記した。あわせて work area 内右下へ clamp 配置する `WindowPlacementCalculator` と、成功時自動クローズの設定（`LiveLogAutoCloseEnabled`、既定有効）を追加した
 
 ### Fixed

--- a/docs/live-log-window.md
+++ b/docs/live-log-window.md
@@ -10,6 +10,14 @@
 - 成功終了時は短い猶予の後に自動クローズする（Settings の `LiveLogAutoCloseEnabled` で無効化可能）。失敗・キャンセル・タイムアウト時は診断のため保持する
 - ログは行数上限付きの rolling buffer（`AgentExecutionViewModel.MaxLogLines` = 1000 行）で管理し、長時間実行でも UI メモリが無制限に増加しない
 
+## ウィンドウの挙動（`AgentExecutionWindow`）
+
+- 通知またはイベント行からエージェントを起動した時点で表示され、現在モニターの work area 内・右下へ DPI を考慮して配置される（`WindowPlacementCalculator`）
+- 最前面ピン留めトグル（`OverlappedPresenter.IsAlwaysOnTop`）を提供する
+- セッションのイベントは DispatcherQueue へ集約反映（coalescing バッチ化）され、UI 更新頻度が抑制される
+- 「キャンセル」ボタン、および実行中のウィンドウクローズで実行をキャンセルする（バックグラウンド継続はしない）
+- 同時実行抑止（単一実行）は launcher 側で維持されており、ウィンドウも同時に 1 つのみ表示される
+
 ## ログのサニタイズ
 
 表示前に各行へ以下を適用する（`Helpers/AnsiControlSanitizer`）:

--- a/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml
@@ -1,0 +1,79 @@
+<Window
+    x:Class="SquirrelNotifier.WinUI3.AgentExecutionWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:SquirrelNotifier.WinUI3.Models"
+    xmlns:converters="using:SquirrelNotifier.WinUI3.Converters"
+    mc:Ignorable="d"
+    Title="エージェント実行">
+    <Grid Padding="12"
+          RowDefinitions="Auto,Auto,Auto,*,Auto"
+          RowSpacing="8">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <TextBlock Grid.Column="0"
+                       x:Name="TitleText"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center"
+                       TextTrimming="CharacterEllipsis"/>
+            <ToggleButton Grid.Column="1"
+                          x:Name="PinToggle"
+                          AutomationProperties.Name="最前面にピン留め"
+                          ToolTipService.ToolTip="最前面にピン留め"
+                          Click="OnPinToggleClick">
+                <FontIcon Glyph="&#xE718;" FontSize="14"/>
+            </ToggleButton>
+        </Grid>
+
+        <StackPanel Grid.Row="1" Spacing="4">
+            <ProgressBar x:Name="PhaseProgressBar"
+                         IsIndeterminate="True"
+                         Minimum="0"
+                         Maximum="100"/>
+            <TextBlock x:Name="StatusTextBlock"
+                       FontSize="12"
+                       TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <InfoBar Grid.Row="2"
+                 x:Name="ResultInfoBar"
+                 IsOpen="False"
+                 IsClosable="False"/>
+
+        <ListView Grid.Row="3"
+                  x:Name="LogListView"
+                  SelectionMode="None"
+                  Background="{ThemeResource ControlFillColorDefaultBrush}"
+                  BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="MinHeight" Value="0"/>
+                    <Setter Property="Padding" Value="8,1,8,1"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="models:AgentLogLine">
+                    <TextBlock Text="{x:Bind Text}"
+                               FontFamily="Consolas"
+                               FontSize="12"
+                               TextWrapping="Wrap"
+                               IsTextSelectionEnabled="True"
+                               Foreground="{x:Bind converters:LogLineKindBrush.For(Kind)}"/>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <StackPanel Grid.Row="4"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8">
+            <Button x:Name="CancelButton"
+                    Content="キャンセル"
+                    Click="OnCancelClick"/>
+            <Button Content="閉じる" Click="OnCloseClick"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml.cs
@@ -1,0 +1,213 @@
+// <copyright file="AgentExecutionWindow.xaml.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SquirrelNotifier.WinUI3.Helpers;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using SquirrelNotifier.WinUI3.ViewModels;
+
+namespace SquirrelNotifier.WinUI3;
+
+/// <summary>
+/// エージェント実行セッションの進捗とログをリアルタイム表示する小型サブウィンドウ（#144）。
+/// 表示ロジックは <see cref="AgentExecutionViewModel"/> に分離しており、本クラスは
+/// イベント購読・DispatcherQueue へのバッチ反映・配置・lifecycle のみを担う.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed partial class AgentExecutionWindow : Window
+{
+    private const int _windowWidthLogical = 480;
+    private const int _windowHeightLogical = 380;
+    private const int _placementMarginPhysical = 16;
+    private static readonly TimeSpan _autoCloseDelay = TimeSpan.FromSeconds(3);
+
+    private readonly AgentExecutionSession _session;
+    private readonly Action _cancelAction;
+    private readonly CancellationTokenSource _readCts = new();
+    private readonly object _pendingLock = new();
+    private readonly List<AgentExecutionEvent> _pending = new();
+    private readonly Microsoft.UI.Windowing.AppWindow _appWindow;
+    private bool _flushScheduled;
+    private bool _terminalHandled;
+    private bool _isClosed;
+    private DispatcherQueueTimer? _autoCloseTimer;
+
+    public AgentExecutionWindow(AgentExecutionSession session, AgentExecutionViewModel viewModel, Action cancelAction)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(viewModel);
+        ArgumentNullException.ThrowIfNull(cancelAction);
+
+        _session = session;
+        ViewModel = viewModel;
+        _cancelAction = cancelAction;
+
+        InitializeComponent();
+
+        // Window 直下では x:Bind Mode=OneWay が使えない（Window は FrameworkElement ではない）ため、
+        // 静的な初期値はここで設定し、動的な更新は FlushPendingEvents が一括で反映する
+        Title = viewModel.Title;
+        TitleText.Text = viewModel.Title;
+        StatusTextBlock.Text = viewModel.StatusText;
+        LogListView.ItemsSource = viewModel.LogLines;
+
+        nint hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hwnd);
+        _appWindow = Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
+        ConfigurePlacement(hwnd, windowId);
+
+        Closed += OnWindowClosed;
+
+        _ = ConsumeEventsAsync();
+    }
+
+    internal AgentExecutionViewModel ViewModel { get; }
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(nint hwnd);
+
+    // 現在モニターの work area 内・右下へ DPI を考慮した物理ピクセルで配置する
+    private void ConfigurePlacement(nint hwnd, Microsoft.UI.WindowId windowId)
+    {
+        double scale = GetDpiForWindow(hwnd) / 96.0;
+        int width = (int)(_windowWidthLogical * scale);
+        int height = (int)(_windowHeightLogical * scale);
+
+        var displayArea = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(windowId, Microsoft.UI.Windowing.DisplayAreaFallback.Nearest);
+        Windows.Graphics.RectInt32 workArea = displayArea.WorkArea;
+        (int x, int y) = WindowPlacementCalculator.CalculateBottomRight(
+            workArea.X, workArea.Y, workArea.Width, workArea.Height, width, height, _placementMarginPhysical);
+
+        _appWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, width, height));
+    }
+
+    private async Task ConsumeEventsAsync()
+    {
+        try
+        {
+            await foreach (AgentExecutionEvent executionEvent in _session.ReadEventsAsync(_readCts.Token).ConfigureAwait(false))
+            {
+                bool schedule;
+                lock (_pendingLock)
+                {
+                    _pending.Add(executionEvent);
+                    schedule = !_flushScheduled;
+                    _flushScheduled = true;
+                }
+
+                if (schedule)
+                {
+                    // UI 更新のバッチ化: flush 予約中に届いたイベントは同じ flush でまとめて反映される
+                    DispatcherQueue.TryEnqueue(FlushPendingEvents);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // ウィンドウクローズによる購読中断。実行自体のキャンセルは OnWindowClosed が担う
+        }
+    }
+
+    private void FlushPendingEvents()
+    {
+        if (_isClosed)
+        {
+            return;
+        }
+
+        List<AgentExecutionEvent> batch;
+        lock (_pendingLock)
+        {
+            batch = new List<AgentExecutionEvent>(_pending);
+            _pending.Clear();
+            _flushScheduled = false;
+        }
+
+        ViewModel.ApplyBatch(batch);
+
+        PhaseProgressBar.IsIndeterminate = ViewModel.IsIndeterminate;
+        PhaseProgressBar.Value = ViewModel.ProgressValue;
+        StatusTextBlock.Text = ViewModel.StatusText;
+        CancelButton.IsEnabled = ViewModel.IsRunning;
+
+        if (ViewModel.LogLines.Count > 0)
+        {
+            LogListView.ScrollIntoView(ViewModel.LogLines[^1]);
+        }
+
+        if (ViewModel.IsCompleted && !_terminalHandled)
+        {
+            _terminalHandled = true;
+            ShowTerminalState();
+        }
+    }
+
+    private void ShowTerminalState()
+    {
+        ResultInfoBar.Severity = ViewModel.Outcome switch
+        {
+            AgentExecutionOutcome.Succeeded => InfoBarSeverity.Success,
+            AgentExecutionOutcome.Cancelled or AgentExecutionOutcome.TimedOut => InfoBarSeverity.Warning,
+            _ => InfoBarSeverity.Error,
+        };
+        ResultInfoBar.Title = ViewModel.StatusText;
+        ResultInfoBar.Message = ViewModel.Verdict is string verdict ? $"Verdict: {verdict}" : string.Empty;
+        ResultInfoBar.IsOpen = true;
+
+        // 成功時のみ短い猶予の後に自動クローズ（設定で無効化可能）。失敗時は診断のため保持する
+        if (ViewModel.ShouldAutoClose)
+        {
+            _autoCloseTimer = DispatcherQueue.CreateTimer();
+            _autoCloseTimer.Interval = _autoCloseDelay;
+            _autoCloseTimer.IsRepeating = false;
+            _autoCloseTimer.Tick += (_, _) =>
+            {
+                if (!_isClosed)
+                {
+                    Close();
+                }
+            };
+            _autoCloseTimer.Start();
+        }
+    }
+
+    private void OnPinToggleClick(object sender, RoutedEventArgs e)
+    {
+        if (_appWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+        {
+            presenter.IsAlwaysOnTop = PinToggle.IsChecked == true;
+        }
+    }
+
+    private void OnCancelClick(object sender, RoutedEventArgs e)
+        => _cancelAction();
+
+    private void OnCloseClick(object sender, RoutedEventArgs e)
+        => Close();
+
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        _isClosed = true;
+        _autoCloseTimer?.Stop();
+
+        // 実行中にウィンドウを閉じた場合は実行もキャンセルする（旧・実行中ダイアログの
+        // 「キャンセル」ボタンと同じ挙動。バックグラウンドで実行を継続させない）
+        if (ViewModel.IsRunning)
+        {
+            _cancelAction();
+        }
+
+        _readCts.Cancel();
+        _readCts.Dispose();
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Converters/LogLineKindBrush.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Converters/LogLineKindBrush.cs
@@ -1,0 +1,37 @@
+// <copyright file="LogLineKindBrush.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Converters;
+
+/// <summary>
+/// ログ行の由来（stdout / stderr / progress）を表示色へ変換する x:Bind 静的関数（#144）。
+/// Window ルートの DataTemplate では StaticResource ベースの IValueConverter が使えない
+/// （生成コードが Window を FrameworkElement として扱えない）ため、静的関数バインドにする.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class LogLineKindBrush
+{
+    private static readonly SolidColorBrush _stderrBrush = new(Microsoft.UI.Colors.OrangeRed);
+    private static readonly SolidColorBrush _progressBrush = new(Microsoft.UI.Colors.DodgerBlue);
+
+    /// <summary>
+    /// ログ行の種別に対応する文字色を返す。stdout はテーマの既定文字色を使う.
+    /// </summary>
+    /// <param name="kind">ログ行の由来.</param>
+    /// <returns>表示色.</returns>
+    public static Brush For(AgentExecutionEventKind kind)
+    {
+        return kind switch
+        {
+            AgentExecutionEventKind.Stderr => _stderrBrush,
+            AgentExecutionEventKind.Progress => _progressBrush,
+            _ => (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"],
+        };
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -40,7 +40,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="240">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -100,13 +100,18 @@
                     <TextBlock Grid.Row="11" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
                     <NumberBox Grid.Row="11" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="7200000" ValueChanged="OnTimeoutChanged"/>
 
-                    <TextBlock Grid.Row="12" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="12" Grid.Column="1" x:Name="AutoStartToggle"
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="ライブログ自動クローズ:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="12" Grid.Column="1" x:Name="LiveLogAutoCloseToggle"
+                                  OnContent="有効" OffContent="無効"
+                                  Toggled="OnLiveLogAutoCloseToggled"/>
+
+                    <TextBlock Grid.Row="13" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="13" Grid.Column="1" x:Name="AutoStartToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnAutoStartToggled"/>
 
-                    <TextBlock Grid.Row="13" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="13" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                    <TextBlock Grid.Row="14" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="14" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
                         <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
                     </StackPanel>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -46,6 +46,11 @@ internal sealed partial class MainWindow : Window
     private bool _isAutoStartToggling;
     private bool _isSyncingLauncherPresetSelection;
     private bool _isApplyingLauncherPreset;
+
+    // ライブログウィンドウ（#144）のマネージド参照。保持しないと ExecuteReviewAsync 終了後に
+    // Window ラッパーが GC 対象になり、失敗時に診断用として開き続けるべきウィンドウが死ぬ。
+    // 同時実行抑止によりウィンドウは常に 1 つのため単一フィールドで足りる
+    private AgentExecutionWindow? _agentExecutionWindow;
     private CancellationTokenSource? _copyFeedbackCts;
 
     private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
@@ -1163,6 +1168,14 @@ internal sealed partial class MainWindow : Window
             // 実行の進捗とログはライブログウィンドウ（#144）が逐次表示する。lifecycle
             // （成功時自動クローズ・失敗時保持・クローズ時キャンセル）はウィンドウ側の責務
             var window = new AgentExecutionWindow(session, viewModel, _launcherService.Cancel);
+            _agentExecutionWindow = window;
+            window.Closed += (_, _) =>
+            {
+                if (ReferenceEquals(_agentExecutionWindow, window))
+                {
+                    _agentExecutionWindow = null;
+                }
+            };
             window.Activate();
         }
         catch (Exception ex)

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -138,6 +138,7 @@ internal sealed partial class MainWindow : Window
         ReviewedPathBox.Text = settings.ReviewedLauncherCommandPath;
         ReviewedArgumentsBox.Text = settings.ReviewedLauncherArguments;
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
+        LiveLogAutoCloseToggle.IsOn = settings.LiveLogAutoCloseEnabled;
 
         ReviewerPresetComboBox.ItemsSource = Models.LauncherAgentCatalog.AllWithCustomOption;
         ReviewedPresetComboBox.ItemsSource = Models.LauncherAgentCatalog.AllWithCustomOption;
@@ -418,6 +419,16 @@ internal sealed partial class MainWindow : Window
         }
 
         SaveCurrentSettings();
+    }
+
+    private void OnLiveLogAutoCloseToggled(object sender, RoutedEventArgs e)
+    {
+        if (_isInitializing)
+        {
+            return;
+        }
+
+        _settingsService.UpdateLiveLogAutoCloseEnabled(LiveLogAutoCloseToggle.IsOn);
     }
 
     // プリセット選択（#149）: ComboBox で選んだプリセットの command / arguments を
@@ -1141,78 +1152,18 @@ internal sealed partial class MainWindow : Window
 
         try
         {
-            using CancellationTokenSource cts = new CancellationTokenSource();
+            string roleLabel = role == Models.LauncherRole.Reviewer ? "レビューする" : "レビューに対応";
+            var viewModel = new ViewModels.AgentExecutionViewModel(
+                $"{reviewEvent.Repository}#{reviewEvent.PrNumber}（{roleLabel}）",
+                _settingsService.Settings.LiveLogAutoCloseEnabled,
+                SecretMasker.CreateDefault());
 
-            ProgressRing progressRing = new ProgressRing { IsActive = true, Margin = new Thickness(0, 16, 0, 0) };
-            StackPanel panel = new StackPanel();
-            panel.Children.Add(new TextBlock { Text = $"{reviewEvent.Repository}#{reviewEvent.PrNumber} のレビューを実行しています..." });
-            panel.Children.Add(progressRing);
+            AgentExecutionSession session = _launcherService.StartSession(reviewEvent, role, CancellationToken.None);
 
-            ContentDialog dialog = new ContentDialog
-            {
-                Title = "レビュー実行中",
-                Content = panel,
-                CloseButtonText = "キャンセル",
-                XamlRoot = Content.XamlRoot,
-            };
-
-            Task<LauncherResult> launchTask = _launcherService.LaunchAsync(reviewEvent, role, cts.Token);
-            IAsyncOperation<ContentDialogResult> dialogTask = dialog.ShowAsync(ContentDialogPlacement.Popup);
-
-            Task completedTask = await Task.WhenAny(launchTask, dialogTask.AsTask()).ConfigureAwait(true);
-
-            if (completedTask == launchTask)
-            {
-                dialog.Hide();
-                LauncherResult result = await launchTask.ConfigureAwait(true);
-
-                StackPanel resultPanel = new StackPanel { Spacing = 8 };
-                if (result.Success)
-                {
-                    resultPanel.Children.Add(new TextBlock { Text = "レビューの実行に成功しました。", FontWeight = Microsoft.UI.Text.FontWeights.Bold });
-                }
-                else
-                {
-                    string err = string.IsNullOrEmpty(result.ErrorMessage) ? "レビューが異常終了しました。" : result.ErrorMessage;
-                    resultPanel.Children.Add(new TextBlock
-                    {
-                        Text = $"エラー: {err}",
-                        Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
-                    });
-                }
-
-                if (result.ExitCode.HasValue)
-                {
-                    resultPanel.Children.Add(new TextBlock { Text = $"終了コード: {result.ExitCode}" });
-                }
-
-                if (!string.IsNullOrWhiteSpace(result.Stdout))
-                {
-                    resultPanel.Children.Add(new TextBlock { Text = "標準出力:", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-                    resultPanel.Children.Add(new TextBox { Text = result.Stdout, TextWrapping = TextWrapping.Wrap, IsReadOnly = true, MaxHeight = 120, AcceptsReturn = true });
-                }
-
-                if (!string.IsNullOrWhiteSpace(result.Stderr))
-                {
-                    resultPanel.Children.Add(new TextBlock { Text = "標準エラー出力:", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
-                    resultPanel.Children.Add(new TextBox { Text = result.Stderr, TextWrapping = TextWrapping.Wrap, IsReadOnly = true, MaxHeight = 120, AcceptsReturn = true });
-                }
-
-                ContentDialog resultDialog = new ContentDialog
-                {
-                    Title = result.Success ? "レビュー実行成功" : "レビュー実行失敗",
-                    Content = resultPanel,
-                    CloseButtonText = "閉じる",
-                    XamlRoot = Content.XamlRoot,
-                };
-                await resultDialog.ShowAsync(ContentDialogPlacement.Popup);
-            }
-            else
-            {
-                cts.Cancel();
-                _launcherService.Cancel();
-                await launchTask.ConfigureAwait(true);
-            }
+            // 実行の進捗とログはライブログウィンドウ（#144）が逐次表示する。lifecycle
+            // （成功時自動クローズ・失敗時保持・クローズ時キャンセル）はウィンドウ側の責務
+            var window = new AgentExecutionWindow(session, viewModel, _launcherService.Cancel);
+            window.Activate();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #144

## 概要

#144 の第2弾（最終）。第1弾（#155）で追加した表示ロジック層（`AgentExecutionViewModel` / `AnsiControlSanitizer` / `SecretMasker` / `WindowPlacementCalculator`）を消費する WinUI 3 サブウィンドウを追加し、MainWindow の実行フローを従来のモーダルダイアログから置き換えた。

## 変更内容

### `AgentExecutionWindow`（新規、`[ExcludeFromCodeCoverage]`）
- stdout / stderr / progress を色分けした逐次ログ表示（ListView 仮想化 + `LogLineKindBrush` 静的関数バインド。issue 記載の RichTextBlock ではなく ListView を採用 — rolling buffer の先頭削除・仮想化との親和性のため。「視覚的な区別」という要件は色分けで満たす）
- ProgressBar による phase 進捗（progress event 非対応ランチャーは indeterminate のまま）と状態テキスト
- terminal 状態（成功 / 失敗 / キャンセル / タイムアウト）と Verdict を InfoBar で表示
- 現在モニターの work area 内・右下へ DPI（`GetDpiForWindow`）を考慮した物理ピクセルで配置
- 最前面ピン留めトグル（`OverlappedPresenter.IsAlwaysOnTop`）
- イベント購読は background で行い、DispatcherQueue への **coalescing バッチ化**（flush 予約中に届いたイベントは同一 flush でまとめて反映）で UI 更新頻度を抑制
- 成功時は 3 秒後に自動クローズ（`LiveLogAutoCloseEnabled` で無効化可能）、失敗時は診断のため保持
- 「キャンセル」ボタン、および実行中のウィンドウクローズで実行をキャンセル（従来ダイアログのキャンセル動作を踏襲。バックグラウンド継続はさせない）

### MainWindow 統合
- `ExecuteReviewAsync` の「実行中 ContentDialog + 結果ダイアログ」（約75行）を `StartSession` + ライブログウィンドウ表示に置換。`IsRunning` ガード（同時実行抑止 → ウィンドウも同時に1つ）は維持
- Settings に「ライブログ自動クローズ」トグルを追加

### 実装上の注意点（レビュー観点）
- WinUI 3 の `Window` は `FrameworkElement` ではないため、Window 直下の `x:Bind Mode=OneWay` と DataTemplate 内の `StaticResource` ベース IValueConverter は生成コードがコンパイルできない。動的更新はすべて `FlushPendingEvents` の一括反映（手動更新）、色分けは x:Bind 静的関数（`LogLineKindBrush.For`）で対応した

## テスト

- 表示ロジックは第1弾のテストで担保済み（本 PR のコードビハインドは `[ExcludeFromCodeCoverage]`、MainWindow と同じ扱い）
- 433 件全テスト合格、`dotnet format --verify-no-changes` / `dotnet build` / `dotnet test` すべて成功

## 確認方法（実機）

1. イベント行の「レビューする」または「レビューに対応」を実行 → 右下にライブログウィンドウが表示され、逐次ログが流れること
2. スキルに `docs/samples/skill-progress-snippet.md` を組み込んだ状態で phase 進捗（Phase N/M 表示とバー）が動くこと。未組み込みなら indeterminate 表示のまま動くこと
3. 成功時に 3 秒後自動クローズ、Settings のトグル無効化で保持されること。キャンセルボタン / ウィンドウクローズで実行が中断されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)