### PR TITLE
feat: レートリミット燃料ゲージをライブログウィンドウへ統合する (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ライブログウィンドウへレートリミット燃料ゲージを統合した（#146）。実行中の launcher に対応する agentId を最優先し、同一エージェント内では使用率が最大の枠を既定表示する。複数 agent / limit は ComboBox で手動切替でき、使用率・残量・リセット時刻・観測時刻・鮮度・実行前後の Delta を同一領域で確認できる。70% 以上を注意、90% 以上を危険としてテキストと InfoBar で明示し、stale・欠損・旧スキーマ・不整合な agentId は「取得不可」の正常系として扱う。Delta は開始／終了 snapshot が有効な場合のみ表示し、それ以外は取得不可の理由を表示する
 - レートリミットスキーマを使用率・鮮度・Delta対応へ拡張した（#145）。`RateLimitStatusPayload` / `RateLimitInfo` に `schemaVersion` / `agentId` / `observedAt` / `limits[].usedPercentage` を追加（agy の `remaining_fraction` はサンプルスクリプト側で使用率へ正規化）。`schemaVersion` 等を持たない旧形式（resetAt-only）の payload は引き続き通知予約用途で読み取れるが、使用率・Delta・freshness 判定の対象外として扱う。新スキーマの snapshot 取得には `RateLimitSnapshotService`、2つの snapshot 間の使用率差分（Delta）計算には `RateLimitDeltaCalculator` を追加し、`RateLimitDeltaUnavailableReason`（欠損・stale・reset 境界跨ぎ・usedPercentage 欠損等）により「取得不可」を例外ではなく正常系として扱う。snapshot の鮮度判定は `RateLimitFreshnessPolicy` が担い、閾値は Settings の `RateLimitFreshnessThresholdMinutes`（既定15分）で変更できる。**設計上の制約**: launcher が起動するのは `claude -p` 等のヘッドレス実行であり statusline はインタラクティブセッションの表示機構のため、ヘッドレス実行前後で fresh な snapshot が得られず Delta が「取得不可」になることが多い。Delta は best-effort と位置づけ、ヘッドレス実行でも確実に snapshot を更新する手段（Stop/SessionEnd hooks 等）は技術的前提が未検証のため別 Issue で検証してから対応する。claude-code / agy のサンプルスクリプトと `docs/statusline-integration.md` を新スキーマへ更新した
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- ライブログウィンドウへレートリミット燃料ゲージを統合した（#146）。実行中の launcher に対応する agentId を最優先し、同一エージェント内では使用率が最大の枠を既定表示する。複数 agent / limit は ComboBox で手動切替でき、使用率・残量・リセット時刻・観測時刻・鮮度・実行前後の Delta を同一領域で確認できる。70% 以上を注意、90% 以上を危険としてテキストと InfoBar で明示し、stale・欠損・旧スキーマ・不整合な agentId は「取得不可」の正常系として扱う。Delta は開始／終了 snapshot が有効な場合のみ表示し、それ以外は取得不可の理由を表示する
+- ライブログウィンドウへレートリミット燃料ゲージを統合した（#146）。実行中の launcher に対応する agentId を最優先し、同一エージェント内では使用率が最大の枠を既定表示する。複数 agent / limit は ComboBox で手動切替でき、使用率・残量・リセット時刻・観測時刻・鮮度・実行前後の Delta を同一領域で確認できる。70% 以上を注意、90% 以上を危険としてテキストと InfoBar で明示し、stale・欠損・旧スキーマ・不整合な agentId・snapshot ファイルの読み取り失敗は「取得不可」の正常系として扱い、レビュー実行本体を中断しない。Delta は開始／終了 snapshot が有効な場合のみ表示し、それ以外は取得不可の理由を表示する
 - レートリミットスキーマを使用率・鮮度・Delta対応へ拡張した（#145）。`RateLimitStatusPayload` / `RateLimitInfo` に `schemaVersion` / `agentId` / `observedAt` / `limits[].usedPercentage` を追加（agy の `remaining_fraction` はサンプルスクリプト側で使用率へ正規化）。`schemaVersion` 等を持たない旧形式（resetAt-only）の payload は引き続き通知予約用途で読み取れるが、使用率・Delta・freshness 判定の対象外として扱う。新スキーマの snapshot 取得には `RateLimitSnapshotService`、2つの snapshot 間の使用率差分（Delta）計算には `RateLimitDeltaCalculator` を追加し、`RateLimitDeltaUnavailableReason`（欠損・stale・reset 境界跨ぎ・usedPercentage 欠損等）により「取得不可」を例外ではなく正常系として扱う。snapshot の鮮度判定は `RateLimitFreshnessPolicy` が担い、閾値は Settings の `RateLimitFreshnessThresholdMinutes`（既定15分）で変更できる。**設計上の制約**: launcher が起動するのは `claude -p` 等のヘッドレス実行であり statusline はインタラクティブセッションの表示機構のため、ヘッドレス実行前後で fresh な snapshot が得られず Delta が「取得不可」になることが多い。Delta は best-effort と位置づけ、ヘッドレス実行でも確実に snapshot を更新する手段（Stop/SessionEnd hooks 等）は技術的前提が未検証のため別 Issue で検証してから対応する。claude-code / agy のサンプルスクリプトと `docs/statusline-integration.md` を新スキーマへ更新した
 
 ### Added

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSessionMonitorTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSessionMonitorTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="RateLimitSessionMonitorTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public sealed class RateLimitSessionMonitorTests : IDisposable
+{
+    private static readonly DateTimeOffset _now = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+    private readonly string _settingsDirectory = Path.Combine(Path.GetTempPath(), $"RateLimitSessionMonitorTests_{Guid.NewGuid()}");
+
+    [Fact]
+    public async Task CaptureEndAsync_ShouldCalculateDeltaForActiveAgent()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        RateLimitSessionMonitor monitor = CreateMonitor(["claude-code"], "claude-code");
+
+        IReadOnlyList<RateLimitSnapshot> start = await monitor.CaptureStartAsync(CancellationToken.None);
+        await WriteSnapshotAsync("claude-code", 55);
+        RateLimitSessionUpdate end = await monitor.CaptureEndAsync(CancellationToken.None);
+
+        start.Should().ContainSingle();
+        end.Snapshots.Should().ContainSingle();
+        end.Deltas.Should().ContainSingle();
+        end.Deltas[0].DeltaPercentage.Should().Be(15);
+    }
+
+    [Fact]
+    public async Task CaptureStartAsync_ShouldCaptureActiveAgentEvenWhenItIsNotMonitored()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        RateLimitSessionMonitor monitor = CreateMonitor([], "claude-code");
+
+        IReadOnlyList<RateLimitSnapshot> snapshots = await monitor.CaptureStartAsync(CancellationToken.None);
+
+        snapshots.Should().ContainSingle(snapshot => snapshot.AgentId == "claude-code");
+    }
+
+    [Fact]
+    public async Task CaptureStartAsync_ShouldTreatMismatchedAgentIdAsUnavailable()
+    {
+        await WriteSnapshotAsync("claude-code", 40, payloadAgentId: "agy");
+        RateLimitSessionMonitor monitor = CreateMonitor(["claude-code"], "claude-code");
+
+        IReadOnlyList<RateLimitSnapshot> snapshots = await monitor.CaptureStartAsync(CancellationToken.None);
+
+        snapshots.Should().BeEmpty();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_settingsDirectory))
+        {
+            Directory.Delete(_settingsDirectory, recursive: true);
+        }
+    }
+
+    private RateLimitSessionMonitor CreateMonitor(IReadOnlyList<string> monitoredAgentIds, string activeAgentId)
+    {
+        var timeProvider = new FixedTimeProvider(_now);
+        return new RateLimitSessionMonitor(
+            new RateLimitSnapshotService(new RateLimitFileService(_settingsDirectory)),
+            new RateLimitDeltaCalculator(timeProvider),
+            monitoredAgentIds,
+            activeAgentId,
+            TimeSpan.FromMinutes(15),
+            timeProvider);
+    }
+
+    private async Task WriteSnapshotAsync(string agentId, double usedPercentage, string? payloadAgentId = null)
+    {
+        string directory = Path.Combine(_settingsDirectory, "ratelimit-status");
+        Directory.CreateDirectory(directory);
+        string json = $$"""
+            {"schemaVersion":1,"agentId":"{{payloadAgentId ?? agentId}}","observedAt":"{{_now:O}}","limits":[{"id":"five-hour","label":"5時間枠","resetAt":"{{_now.AddHours(5):O}}","usedPercentage":{{usedPercentage.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}]}
+            """;
+        await File.WriteAllTextAsync(Path.Combine(directory, $"{agentId}.json"), json);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSessionMonitorTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSessionMonitorTests.cs
@@ -51,6 +51,33 @@ public sealed class RateLimitSessionMonitorTests : IDisposable
         snapshots.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task CaptureStartAsync_ShouldSkipAgentWhenSnapshotReadFails()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        await WriteSnapshotAsync("agy", 55);
+        RateLimitSessionMonitor monitor = CreateMonitor(["claude-code", "agy"], "claude-code");
+        string lockedPath = Path.Combine(_settingsDirectory, "ratelimit-status", "claude-code.json");
+        using FileStream exclusiveLock = new(lockedPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        IReadOnlyList<RateLimitSnapshot> snapshots = await monitor.CaptureStartAsync(CancellationToken.None);
+
+        snapshots.Should().ContainSingle(snapshot => snapshot.AgentId == "agy");
+    }
+
+    [Fact]
+    public async Task CaptureStartAsync_ShouldPropagateCancellation()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        RateLimitSessionMonitor monitor = CreateMonitor(["claude-code"], "claude-code");
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        Func<Task> act = () => monitor.CaptureStartAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_settingsDirectory))

--- a/winui3/SquirrelNotifier.WinUI3.Tests/ViewModels/RateLimitGaugeViewModelTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/ViewModels/RateLimitGaugeViewModelTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="RateLimitGaugeViewModelTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.ViewModels;
+
+namespace SquirrelNotifier.WinUI3.Tests.ViewModels;
+
+public class RateLimitGaugeViewModelTests
+{
+    private static readonly DateTimeOffset _now = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Update_ShouldPreferHighestUsageLimitForActiveAgent()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+
+        vm.Update(
+            ["claude-code", "agy"],
+            [
+                CreateSnapshot("claude-code", CreateLimit("five-hour", "5時間枠", 55), CreateLimit("weekly", "7日枠", 80)),
+                CreateSnapshot("agy", CreateLimit("monthly", "月次枠", 95)),
+            ],
+            "claude-code",
+            []);
+
+        vm.SelectedOption!.AgentId.Should().Be("claude-code");
+        vm.SelectedOption.LimitId.Should().Be("weekly");
+        vm.Severity.Should().Be(RateLimitGaugeSeverity.Warning);
+        vm.UsageText.Should().Contain("80%");
+    }
+
+    [Theory]
+    [InlineData(69.9, "Normal", "状態: 正常")]
+    [InlineData(70, "Warning", "状態: 注意")]
+    [InlineData(90, "Critical", "状態: 危険")]
+    public void Update_ShouldClassifyUsageThresholds(double usedPercentage, string expectedSeverity, string expectedStatus)
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+
+        vm.Update(
+            ["claude-code"],
+            [CreateSnapshot("claude-code", CreateLimit("five-hour", "5時間枠", usedPercentage))],
+            "claude-code",
+            []);
+
+        vm.Severity.Should().Be(Enum.Parse<RateLimitGaugeSeverity>(expectedSeverity));
+        vm.StatusText.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public void Update_ShouldKeepManualSelectionWhenSnapshotIsRefreshed()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+        RateLimitSnapshot initial = CreateSnapshot(
+            "claude-code",
+            CreateLimit("five-hour", "5時間枠", 80),
+            CreateLimit("weekly", "7日枠", 45));
+        vm.Update(["claude-code"], [initial], "claude-code", []);
+        vm.Select(vm.Options.Single(option => option.LimitId == "weekly"));
+
+        RateLimitSnapshot refreshed = CreateSnapshot(
+            "claude-code",
+            CreateLimit("five-hour", "5時間枠", 81),
+            CreateLimit("weekly", "7日枠", 46));
+        vm.Update(["claude-code"], [refreshed], "claude-code", []);
+
+        vm.SelectedOption!.LimitId.Should().Be("weekly");
+    }
+
+    [Fact]
+    public void Update_ShouldShowUnknownForStaleSnapshot()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+        RateLimitSnapshot stale = new(
+            "claude-code",
+            _now.AddMinutes(-16),
+            [CreateLimit("five-hour", "5時間枠", 80)]);
+
+        vm.Update(["claude-code"], [stale], "claude-code", []);
+
+        vm.Severity.Should().Be(RateLimitGaugeSeverity.Unknown);
+        vm.UsageText.Should().Be("使用率: 取得不可");
+        vm.TimingText.Should().Contain("古いデータ");
+    }
+
+    [Fact]
+    public void Update_ShouldKeepFreshnessWhenUsedPercentageIsMissing()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+        RateLimitInfo limitWithoutUsage = new()
+        {
+            Id = "five-hour",
+            Label = "5時間枠",
+            UsedPercentage = null,
+            ResetAt = _now.AddHours(5),
+        };
+
+        vm.Update(["claude-code"], [CreateSnapshot("claude-code", limitWithoutUsage)], "claude-code", []);
+
+        vm.Severity.Should().Be(RateLimitGaugeSeverity.Unknown);
+        vm.UsageText.Should().Be("使用率: 取得不可");
+        vm.TimingText.Should().Contain("fresh").And.NotContain("古いデータ");
+    }
+
+    [Fact]
+    public void Update_ShouldShowAvailableDeltaForSelectedActiveLimit()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+        RateLimitDeltaResult delta = new("five-hour", "5時間枠", 12.5, RateLimitDeltaUnavailableReason.None);
+
+        vm.Update(
+            ["claude-code"],
+            [CreateSnapshot("claude-code", CreateLimit("five-hour", "5時間枠", 80))],
+            "claude-code",
+            [delta]);
+
+        vm.DeltaText.Should().Be("Delta: +12.5%");
+    }
+
+    [Fact]
+    public void Update_ShouldShowUnavailableDeltaReason()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+        RateLimitDeltaResult delta = new("five-hour", "5時間枠", null, RateLimitDeltaUnavailableReason.MissingStartSnapshot);
+
+        vm.Update(
+            ["claude-code"],
+            [CreateSnapshot("claude-code", CreateLimit("five-hour", "5時間枠", 80))],
+            "claude-code",
+            [delta]);
+
+        vm.DeltaText.Should().Be("Delta: 取得不可（開始時点の情報がありません）");
+    }
+
+    [Fact]
+    public void Update_ShouldShowUnavailableWhenSnapshotDoesNotExist()
+    {
+        RateLimitGaugeViewModel vm = CreateViewModel();
+
+        vm.Update(["claude-code"], [], "claude-code", []);
+
+        vm.SelectedOption!.Severity.Should().Be(RateLimitGaugeSeverity.Unknown);
+        vm.TimingText.Should().Be("対応するレートリミット情報がありません");
+    }
+
+    private static RateLimitGaugeViewModel CreateViewModel()
+        => new(TimeSpan.FromMinutes(15), new FixedTimeProvider(_now));
+
+    private static RateLimitSnapshot CreateSnapshot(string agentId, params RateLimitInfo[] limits)
+        => new(agentId, _now, limits);
+
+    private static RateLimitInfo CreateLimit(string id, string label, double usedPercentage)
+        => new()
+        {
+            Id = id,
+            Label = label,
+            UsedPercentage = usedPercentage,
+            ResetAt = _now.AddHours(5),
+        };
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="エージェント実行">
     <Grid Padding="12"
-          RowDefinitions="Auto,Auto,Auto,*,Auto"
+          RowDefinitions="Auto,Auto,Auto,Auto,*,Auto"
           RowSpacing="8">
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="8">
             <TextBlock Grid.Column="0"
@@ -36,12 +36,33 @@
                        TextWrapping="Wrap"/>
         </StackPanel>
 
-        <InfoBar Grid.Row="2"
+        <StackPanel Grid.Row="2" Spacing="4">
+            <TextBlock Text="レートリミット"
+                       FontWeight="SemiBold"/>
+            <ComboBox x:Name="RateLimitSelector"
+                      DisplayMemberPath="DisplayName"
+                      AutomationProperties.Name="表示するレートリミット枠"
+                      SelectionChanged="OnRateLimitSelectionChanged"/>
+            <ProgressBar x:Name="RateLimitProgressBar"
+                         Minimum="0"
+                         Maximum="100"/>
+            <InfoBar x:Name="RateLimitInfoBar"
+                     IsOpen="True"
+                     IsClosable="False"/>
+            <TextBlock x:Name="RateLimitTimingTextBlock"
+                       FontSize="12"
+                       TextWrapping="Wrap"/>
+            <TextBlock x:Name="RateLimitDeltaTextBlock"
+                       FontSize="12"
+                       TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <InfoBar Grid.Row="3"
                  x:Name="ResultInfoBar"
                  IsOpen="False"
                  IsClosable="False"/>
 
-        <ListView Grid.Row="3"
+        <ListView Grid.Row="4"
                   x:Name="LogListView"
                   SelectionMode="None"
                   Background="{ThemeResource ControlFillColorDefaultBrush}"
@@ -66,7 +87,7 @@
             </ListView.ItemTemplate>
         </ListView>
 
-        <StackPanel Grid.Row="4"
+        <StackPanel Grid.Row="5"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8">

--- a/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/AgentExecutionWindow.xaml.cs
@@ -27,11 +27,13 @@ namespace SquirrelNotifier.WinUI3;
 internal sealed partial class AgentExecutionWindow : Window
 {
     private const int _windowWidthLogical = 480;
-    private const int _windowHeightLogical = 380;
+    private const int _windowHeightLogical = 520;
     private const int _placementMarginPhysical = 16;
     private static readonly TimeSpan _autoCloseDelay = TimeSpan.FromSeconds(3);
 
     private readonly AgentExecutionSession _session;
+    private readonly RateLimitGaugeViewModel _rateLimitGaugeViewModel;
+    private readonly RateLimitSessionMonitor _rateLimitSessionMonitor;
     private readonly Action _cancelAction;
     private readonly CancellationTokenSource _readCts = new();
     private readonly object _pendingLock = new();
@@ -42,14 +44,23 @@ internal sealed partial class AgentExecutionWindow : Window
     private bool _isClosed;
     private DispatcherQueueTimer? _autoCloseTimer;
 
-    public AgentExecutionWindow(AgentExecutionSession session, AgentExecutionViewModel viewModel, Action cancelAction)
+    public AgentExecutionWindow(
+        AgentExecutionSession session,
+        AgentExecutionViewModel viewModel,
+        RateLimitGaugeViewModel rateLimitGaugeViewModel,
+        RateLimitSessionMonitor rateLimitSessionMonitor,
+        Action cancelAction)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(viewModel);
+        ArgumentNullException.ThrowIfNull(rateLimitGaugeViewModel);
+        ArgumentNullException.ThrowIfNull(rateLimitSessionMonitor);
         ArgumentNullException.ThrowIfNull(cancelAction);
 
         _session = session;
         ViewModel = viewModel;
+        _rateLimitGaugeViewModel = rateLimitGaugeViewModel;
+        _rateLimitSessionMonitor = rateLimitSessionMonitor;
         _cancelAction = cancelAction;
 
         InitializeComponent();
@@ -60,6 +71,8 @@ internal sealed partial class AgentExecutionWindow : Window
         TitleText.Text = viewModel.Title;
         StatusTextBlock.Text = viewModel.StatusText;
         LogListView.ItemsSource = viewModel.LogLines;
+        RateLimitSelector.ItemsSource = _rateLimitGaugeViewModel.Options;
+        SyncRateLimitGauge();
 
         nint hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         Microsoft.UI.WindowId windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hwnd);
@@ -148,8 +161,66 @@ internal sealed partial class AgentExecutionWindow : Window
         if (ViewModel.IsCompleted && !_terminalHandled)
         {
             _terminalHandled = true;
+            _ = CaptureEndRateLimitSnapshotAsync();
             ShowTerminalState();
         }
+    }
+
+    private async Task CaptureEndRateLimitSnapshotAsync()
+    {
+        try
+        {
+            RateLimitSessionUpdate update = await _rateLimitSessionMonitor.CaptureEndAsync(_readCts.Token).ConfigureAwait(false);
+            if (!_isClosed)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    _rateLimitGaugeViewModel.Update(
+                        _rateLimitSessionMonitor.MonitoredAgentIds,
+                        update.Snapshots,
+                        _rateLimitSessionMonitor.ActiveAgentId,
+                        update.Deltas);
+                    SyncRateLimitGauge();
+                });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // ウィンドウを閉じた後の snapshot 取得中断。実行本体の状態には影響しない
+        }
+        catch (Exception ex)
+        {
+            if (!_isClosed)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    _rateLimitGaugeViewModel.SetUnavailable($"レートリミット情報を取得できませんでした: {ex.Message}");
+                    SyncRateLimitGauge();
+                });
+            }
+        }
+    }
+
+    private void SyncRateLimitGauge()
+    {
+        if (!ReferenceEquals(RateLimitSelector.SelectedItem, _rateLimitGaugeViewModel.SelectedOption))
+        {
+            RateLimitSelector.SelectedItem = _rateLimitGaugeViewModel.SelectedOption;
+        }
+
+        RateLimitProgressBar.IsIndeterminate = _rateLimitGaugeViewModel.Severity == RateLimitGaugeSeverity.Unknown;
+        RateLimitProgressBar.Value = _rateLimitGaugeViewModel.ProgressValue;
+        RateLimitInfoBar.Title = _rateLimitGaugeViewModel.StatusText;
+        RateLimitInfoBar.Message = _rateLimitGaugeViewModel.UsageText;
+        RateLimitInfoBar.Severity = _rateLimitGaugeViewModel.Severity switch
+        {
+            RateLimitGaugeSeverity.Normal => InfoBarSeverity.Success,
+            RateLimitGaugeSeverity.Warning => InfoBarSeverity.Warning,
+            RateLimitGaugeSeverity.Critical => InfoBarSeverity.Error,
+            _ => InfoBarSeverity.Informational,
+        };
+        RateLimitTimingTextBlock.Text = _rateLimitGaugeViewModel.TimingText;
+        RateLimitDeltaTextBlock.Text = _rateLimitGaugeViewModel.DeltaText;
     }
 
     private void ShowTerminalState()
@@ -191,6 +262,12 @@ internal sealed partial class AgentExecutionWindow : Window
 
     private void OnCancelClick(object sender, RoutedEventArgs e)
         => _cancelAction();
+
+    private void OnRateLimitSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        _rateLimitGaugeViewModel.Select(RateLimitSelector.SelectedItem as RateLimitGaugeOption);
+        SyncRateLimitGauge();
+    }
 
     private void OnCloseClick(object sender, RoutedEventArgs e)
         => Close();

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -1163,11 +1163,24 @@ internal sealed partial class MainWindow : Window
                 _settingsService.Settings.LiveLogAutoCloseEnabled,
                 SecretMasker.CreateDefault());
 
+            AppSettings settings = _settingsService.Settings;
+            string? activeAgentId = _settingsService.ResolveLauncherRateLimitAgentId(role);
+            TimeSpan freshnessThreshold = TimeSpan.FromMinutes(settings.RateLimitFreshnessThresholdMinutes);
+            ViewModels.RateLimitGaugeViewModel rateLimitGaugeViewModel = new(freshnessThreshold);
+            RateLimitSessionMonitor rateLimitSessionMonitor = new(
+                new RateLimitSnapshotService(_rateLimitFileService),
+                new RateLimitDeltaCalculator(),
+                settings.RateLimitMonitoredAgentIds,
+                activeAgentId,
+                freshnessThreshold);
+            IReadOnlyList<Models.RateLimitSnapshot> startSnapshots = await rateLimitSessionMonitor.CaptureStartAsync(CancellationToken.None);
+            rateLimitGaugeViewModel.Update(settings.RateLimitMonitoredAgentIds, startSnapshots, activeAgentId, []);
+
             AgentExecutionSession session = _launcherService.StartSession(reviewEvent, role, CancellationToken.None);
 
             // 実行の進捗とログはライブログウィンドウ（#144）が逐次表示する。lifecycle
             // （成功時自動クローズ・失敗時保持・クローズ時キャンセル）はウィンドウ側の責務
-            var window = new AgentExecutionWindow(session, viewModel, _launcherService.Cancel);
+            var window = new AgentExecutionWindow(session, viewModel, rateLimitGaugeViewModel, rateLimitSessionMonitor, _launcherService.Cancel);
             _agentExecutionWindow = window;
             window.Closed += (_, _) =>
             {

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSessionMonitor.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSessionMonitor.cs
@@ -74,7 +74,23 @@ internal sealed class RateLimitSessionMonitor
             .Select(id => id!)
             .Distinct(StringComparer.Ordinal))
         {
-            RateLimitSnapshot? snapshot = await _snapshotService.CaptureAsync(agentId, cancellationToken).ConfigureAwait(false);
+            RateLimitSnapshot? snapshot;
+            try
+            {
+                snapshot = await _snapshotService.CaptureAsync(agentId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                // ゲージは「取得不可」を正常系とする best-effort 機能のため、snapshot ファイルの
+                // 読み取り失敗（ロック・削除レース等）を当該 agent の取得不可として扱い、
+                // レビュー実行本体や他 agent の取得を中断しない（#146）
+                continue;
+            }
+
             if (snapshot is not null && snapshot.AgentId == agentId)
             {
                 snapshots.Add(snapshot);

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSessionMonitor.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSessionMonitor.cs
@@ -1,0 +1,90 @@
+// <copyright file="RateLimitSessionMonitor.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// 1 回のエージェント実行の開始・終了 snapshot を取得し、表示用の Delta を計算する（#146）。
+/// レビュー起動や WinUI 表示には依存しないため、snapshot の境界を単体で検証できる.
+/// </summary>
+internal sealed class RateLimitSessionMonitor
+{
+    private readonly RateLimitSnapshotService _snapshotService;
+    private readonly RateLimitDeltaCalculator _deltaCalculator;
+    private readonly TimeProvider _timeProvider;
+    private readonly IReadOnlyList<string> _monitoredAgentIds;
+    private readonly string? _activeAgentId;
+    private readonly TimeSpan _freshnessThreshold;
+    private IReadOnlyList<RateLimitSnapshot> _startSnapshots = [];
+    private DateTimeOffset _startCapturedAt;
+
+    public RateLimitSessionMonitor(
+        RateLimitSnapshotService snapshotService,
+        RateLimitDeltaCalculator deltaCalculator,
+        IReadOnlyList<string> monitoredAgentIds,
+        string? activeAgentId,
+        TimeSpan freshnessThreshold,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotService);
+        ArgumentNullException.ThrowIfNull(deltaCalculator);
+        ArgumentNullException.ThrowIfNull(monitoredAgentIds);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(freshnessThreshold, TimeSpan.Zero);
+
+        _snapshotService = snapshotService;
+        _deltaCalculator = deltaCalculator;
+        _monitoredAgentIds = monitoredAgentIds;
+        _activeAgentId = activeAgentId;
+        _freshnessThreshold = freshnessThreshold;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public IReadOnlyList<string> MonitoredAgentIds => _monitoredAgentIds;
+
+    public string? ActiveAgentId => _activeAgentId;
+
+    public async Task<IReadOnlyList<RateLimitSnapshot>> CaptureStartAsync(CancellationToken cancellationToken)
+    {
+        _startCapturedAt = _timeProvider.GetUtcNow();
+        _startSnapshots = await CaptureSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+        return _startSnapshots;
+    }
+
+    public async Task<RateLimitSessionUpdate> CaptureEndAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<RateLimitSnapshot> endSnapshots = await CaptureSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+        RateLimitSnapshot? start = _startSnapshots.FirstOrDefault(snapshot => snapshot.AgentId == _activeAgentId);
+        RateLimitSnapshot? end = endSnapshots.FirstOrDefault(snapshot => snapshot.AgentId == _activeAgentId);
+        IReadOnlyList<RateLimitDeltaResult> deltas = _startCapturedAt == default
+            ? []
+            : _deltaCalculator.Compute(start, end, _startCapturedAt, _freshnessThreshold);
+
+        return new RateLimitSessionUpdate(endSnapshots, deltas);
+    }
+
+    private async Task<IReadOnlyList<RateLimitSnapshot>> CaptureSnapshotsAsync(CancellationToken cancellationToken)
+    {
+        List<RateLimitSnapshot> snapshots = new();
+        foreach (string agentId in _monitoredAgentIds
+            .Append(_activeAgentId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal))
+        {
+            RateLimitSnapshot? snapshot = await _snapshotService.CaptureAsync(agentId, cancellationToken).ConfigureAwait(false);
+            if (snapshot is not null && snapshot.AgentId == agentId)
+            {
+                snapshots.Add(snapshot);
+            }
+        }
+
+        return snapshots;
+    }
+}
+
+internal sealed record RateLimitSessionUpdate(
+    IReadOnlyList<RateLimitSnapshot> Snapshots,
+    IReadOnlyList<RateLimitDeltaResult> Deltas);

--- a/winui3/SquirrelNotifier.WinUI3/ViewModels/RateLimitGaugeViewModel.cs
+++ b/winui3/SquirrelNotifier.WinUI3/ViewModels/RateLimitGaugeViewModel.cs
@@ -1,0 +1,275 @@
+// <copyright file="RateLimitGaugeViewModel.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+
+namespace SquirrelNotifier.WinUI3.ViewModels;
+
+internal enum RateLimitGaugeSeverity
+{
+    /// <summary>使用率・鮮度を判定できない.</summary>
+    Unknown,
+
+    /// <summary>使用率が注意閾値未満.</summary>
+    Normal,
+
+    /// <summary>使用率が注意閾値以上.</summary>
+    Warning,
+
+    /// <summary>使用率が危険閾値以上.</summary>
+    Critical,
+}
+
+internal sealed record RateLimitGaugeOption(
+    string AgentId,
+    string AgentDisplayName,
+    string? LimitId,
+    string LimitLabel,
+    double? UsedPercentage,
+    DateTimeOffset? ResetAt,
+    DateTimeOffset? ObservedAt,
+    bool IsFresh,
+    RateLimitGaugeSeverity Severity,
+    RateLimitDeltaResult? Delta)
+{
+    public string DisplayName => $"{AgentDisplayName} — {LimitLabel}";
+}
+
+/// <summary>
+/// ライブログウィンドウのレートリミット燃料ゲージ表示状態を、snapshot と Delta から組み立てる（#146）。
+/// WinUI 型に依存しないため、閾値・取得不可・選択優先順位を単体テストできる.
+/// </summary>
+internal sealed class RateLimitGaugeViewModel : INotifyPropertyChanged
+{
+    private const double _warningThreshold = 70;
+    private const double _criticalThreshold = 90;
+
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _freshnessThreshold;
+    private RateLimitGaugeOption? _selectedOption;
+    private string? _unavailableMessage;
+
+    public RateLimitGaugeViewModel(TimeSpan freshnessThreshold, TimeProvider? timeProvider = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(freshnessThreshold, TimeSpan.Zero);
+
+        _freshnessThreshold = freshnessThreshold;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ObservableCollection<RateLimitGaugeOption> Options { get; } = new();
+
+    public RateLimitGaugeOption? SelectedOption => _selectedOption;
+
+    public double ProgressValue => _selectedOption?.Severity == RateLimitGaugeSeverity.Unknown
+        ? 0
+        : _selectedOption?.UsedPercentage ?? 0;
+
+    public string StatusText => _selectedOption?.Severity switch
+    {
+        RateLimitGaugeSeverity.Normal => "状態: 正常",
+        RateLimitGaugeSeverity.Warning => "状態: 注意",
+        RateLimitGaugeSeverity.Critical => "状態: 危険",
+        _ => "状態: 取得不可",
+    };
+
+    public string UsageText => _selectedOption?.UsedPercentage is double used && _selectedOption.Severity != RateLimitGaugeSeverity.Unknown
+        ? string.Format(CultureInfo.CurrentCulture, "使用率: {0:0.#}%（残量: {1:0.#}%）", used, 100 - used)
+        : "使用率: 取得不可";
+
+    public string TimingText
+    {
+        get
+        {
+            if (_selectedOption?.ObservedAt is not DateTimeOffset observedAt)
+            {
+                return _unavailableMessage ?? "対応するレートリミット情報がありません";
+            }
+
+            string observed = observedAt.ToLocalTime().ToString("yyyy/MM/dd HH:mm", CultureInfo.CurrentCulture);
+            string reset = _selectedOption.ResetAt is DateTimeOffset resetAt
+                ? resetAt.ToLocalTime().ToString("yyyy/MM/dd HH:mm", CultureInfo.CurrentCulture)
+                : "取得不可";
+            string freshness = _selectedOption.IsFresh ? "fresh" : "古いデータ";
+            return $"観測: {observed}（{freshness}） / リセット: {reset}";
+        }
+    }
+
+    public string DeltaText
+    {
+        get
+        {
+            RateLimitDeltaResult? delta = _selectedOption?.Delta;
+            if (delta?.IsAvailable == true && delta.DeltaPercentage is double value)
+            {
+                return string.Format(CultureInfo.CurrentCulture, "Delta: {0:+0.##;-0.##;0}%", value);
+            }
+
+            return delta is null
+                ? "Delta: 取得不可"
+                : $"Delta: 取得不可（{GetUnavailableReasonText(delta.UnavailableReason)}）";
+        }
+    }
+
+    public RateLimitGaugeSeverity Severity => _selectedOption?.Severity ?? RateLimitGaugeSeverity.Unknown;
+
+    public void Update(
+        IReadOnlyList<string> monitoredAgentIds,
+        IReadOnlyList<RateLimitSnapshot> snapshots,
+        string? activeAgentId,
+        IReadOnlyList<RateLimitDeltaResult> activeAgentDeltas)
+    {
+        ArgumentNullException.ThrowIfNull(monitoredAgentIds);
+        ArgumentNullException.ThrowIfNull(snapshots);
+        ArgumentNullException.ThrowIfNull(activeAgentDeltas);
+
+        string? previousAgentId = _selectedOption?.AgentId;
+        string? previousLimitId = _selectedOption?.LimitId;
+        string[] candidateAgentIds = monitoredAgentIds
+            .Append(activeAgentId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        Dictionary<string, RateLimitSnapshot> snapshotByAgentId = snapshots.ToDictionary(snapshot => snapshot.AgentId, StringComparer.Ordinal);
+        Dictionary<string, RateLimitDeltaResult> deltasByLimitId = activeAgentDeltas
+            .GroupBy(delta => delta.LimitId)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        Options.Clear();
+        foreach (string agentId in candidateAgentIds)
+        {
+            if (!snapshotByAgentId.TryGetValue(agentId, out RateLimitSnapshot? snapshot))
+            {
+                Options.Add(CreateUnavailableOption(agentId, "レートリミット情報がありません"));
+                continue;
+            }
+
+            bool isFresh = RateLimitFreshnessPolicy.IsFresh(snapshot.ObservedAt, _timeProvider.GetUtcNow(), _freshnessThreshold);
+            foreach (IGrouping<string, RateLimitInfo> group in snapshot.Limits.GroupBy(limit => limit.Id))
+            {
+                RateLimitInfo limit = group.First();
+                bool isUnique = group.Count() == 1;
+                RateLimitGaugeSeverity severity = isFresh && isUnique && limit.UsedPercentage is double usedPercentage
+                    ? GetSeverity(usedPercentage)
+                    : RateLimitGaugeSeverity.Unknown;
+                RateLimitDeltaResult? delta = agentId == activeAgentId && isUnique && deltasByLimitId.TryGetValue(limit.Id, out RateLimitDeltaResult? result)
+                    ? result
+                    : null;
+
+                Options.Add(new RateLimitGaugeOption(
+                    agentId,
+                    GetAgentDisplayName(agentId),
+                    limit.Id,
+                    limit.Label,
+                    severity == RateLimitGaugeSeverity.Unknown ? null : limit.UsedPercentage,
+                    limit.ResetAt,
+                    snapshot.ObservedAt,
+                    isFresh,
+                    severity,
+                    delta));
+            }
+        }
+
+        _unavailableMessage = null;
+        _selectedOption = FindPreferredOption(previousAgentId, previousLimitId, activeAgentId);
+        RaiseGaugePropertiesChanged();
+    }
+
+    public void SetUnavailable(string message)
+    {
+        _unavailableMessage = string.IsNullOrWhiteSpace(message) ? "レートリミット情報を取得できません" : message;
+        Options.Clear();
+        _selectedOption = null;
+        RaiseGaugePropertiesChanged();
+    }
+
+    public void Select(RateLimitGaugeOption? option)
+    {
+        if (option is null || !Options.Contains(option) || EqualityComparer<RateLimitGaugeOption?>.Default.Equals(_selectedOption, option))
+        {
+            return;
+        }
+
+        _selectedOption = option;
+        RaiseGaugePropertiesChanged();
+    }
+
+    private RateLimitGaugeOption? FindPreferredOption(string? previousAgentId, string? previousLimitId, string? activeAgentId)
+    {
+        RateLimitGaugeOption? previous = Options.FirstOrDefault(option => option.AgentId == previousAgentId && option.LimitId == previousLimitId);
+        if (previous is not null)
+        {
+            return previous;
+        }
+
+        IEnumerable<RateLimitGaugeOption> activeOptions = Options.Where(option => option.AgentId == activeAgentId);
+        return activeOptions
+            .OrderByDescending(option => option.Severity != RateLimitGaugeSeverity.Unknown)
+            .ThenByDescending(option => option.UsedPercentage)
+            .FirstOrDefault()
+            ?? Options
+                .OrderByDescending(option => option.Severity != RateLimitGaugeSeverity.Unknown)
+                .ThenByDescending(option => option.UsedPercentage)
+                .FirstOrDefault();
+    }
+
+    private static RateLimitGaugeOption CreateUnavailableOption(string agentId, string message)
+        => new(agentId, GetAgentDisplayName(agentId), null, message, null, null, null, IsFresh: false, RateLimitGaugeSeverity.Unknown, null);
+
+    private static RateLimitGaugeSeverity GetSeverity(double usedPercentage)
+    {
+        if (usedPercentage >= _criticalThreshold)
+        {
+            return RateLimitGaugeSeverity.Critical;
+        }
+
+        return usedPercentage >= _warningThreshold ? RateLimitGaugeSeverity.Warning : RateLimitGaugeSeverity.Normal;
+    }
+
+    private static string GetAgentDisplayName(string agentId)
+        => RateLimitAgentCatalog.All.FirstOrDefault(agent => agent.Id == agentId)?.DisplayName ?? agentId;
+
+    private static string GetUnavailableReasonText(RateLimitDeltaUnavailableReason reason)
+    {
+        return reason switch
+        {
+            RateLimitDeltaUnavailableReason.MissingStartSnapshot => "開始時点の情報がありません",
+            RateLimitDeltaUnavailableReason.MissingEndSnapshot => "終了時点の情報がありません",
+            RateLimitDeltaUnavailableReason.StartSnapshotStale => "開始時点の情報が古すぎます",
+            RateLimitDeltaUnavailableReason.EndSnapshotStale => "終了時点の情報が古すぎます",
+            RateLimitDeltaUnavailableReason.LimitMissingInStart => "開始時点に同じ枠がありません",
+            RateLimitDeltaUnavailableReason.LimitMissingInEnd => "終了時点に同じ枠がありません",
+            RateLimitDeltaUnavailableReason.UsedPercentageMissing => "使用率がありません",
+            RateLimitDeltaUnavailableReason.ResetBoundaryCrossed => "リセットを跨ぎました",
+            RateLimitDeltaUnavailableReason.DuplicateLimitId => "重複した枠があります",
+            _ => "不明な理由です",
+        };
+    }
+
+    private void RaiseGaugePropertiesChanged()
+    {
+        foreach (string propertyName in new[]
+        {
+            nameof(SelectedOption),
+            nameof(ProgressValue),
+            nameof(StatusText),
+            nameof(UsageText),
+            nameof(TimingText),
+            nameof(DeltaText),
+            nameof(Severity),
+        })
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
## 概要

ライブログウィンドウ（#144）へ、ローカルレートリミット snapshot を表示する燃料ゲージを統合する。使用率の正規化・鮮度判定・Delta 計算は #145 のスキーマ拡張が提供する型付き結果を利用し、本 PR は表示責務に限定する。

Closes #146

## 変更内容

- **`RateLimitGaugeViewModel`**（新規）: WinUI 型に依存しない表示ロジック層
  - 使用率の閾値判定: 70% 未満 Normal / 70% 以上 Warning / 90% 以上 Critical / stale・欠損・重複 limit・usedPercentage 欠損は Unknown
  - 複数 agent / limit の表示優先順位: 手動選択の維持 > 実行中セッションの agent > 使用率降順
  - Delta 取得不可は理由テキスト付きで正常系として表示（エラー風にしない）
- **`RateLimitSessionMonitor`**（新規）: 実行開始・終了時の snapshot 取得と Delta 計算。監視対象外でも実行中 agent は取得対象に含める
- **`AgentExecutionWindow`**: ゲージ領域（ComboBox 切替・ProgressBar・InfoBar・観測/リセット時刻・Delta）を追加。色だけに依存せず InfoBar のテキストと severity を併用
- **`MainWindow`**: launcher 起動時に開始 snapshot を取得してゲージへ反映し、実行完了時に終了 snapshot と Delta を反映

## 設計論点への対応

| 論点 | 対応 |
|---|---|
| 複数 agent / limit の表示優先順位 | 実行中 agent（`ResolveLauncherRateLimitAgentId`）を最優先し、その中で使用率最大の limit を既定表示。ComboBox で手動切替可能、手動選択は snapshot 更新後も維持 |
| Delta 取得不可の表示 | `RateLimitDeltaUnavailableReason` を日本語の理由テキストへ変換し、InfoBar ではなく通常テキストで表示 |
| カバレッジの担保層 | 表示ロジックを `RateLimitGaugeViewModel` へ分離して単体テストで担保。XAML コードビハインドは ViewModel の同期のみ |

## 検証

- `dotnet build`: 成功（0 警告 / 0 エラー）
- `dotnet test`（カバレッジ閾値 80%）: 497 件成功、line 90.42% / branch 84.63% / method 93.68%
- `dotnet format --verify-no-changes`: 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)