### PR TITLE
fix: レートリミット「更新」時に Auto-Pause gate を再評価する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- レートリミット一覧の「更新」ボタンで Auto-Pause gate が再評価されず、fresh な使用率 95% 未満への回復が反映されない不具合を修正した（#167）。`OnRefreshRateLimitClick` に reviewer / reviewed 両スロットの `rateLimitAgentId` を対象とした `AutoPauseGate.Evaluate` 呼び出しを追加し、「更新」実行時点で Paused の解除（および開始）を InfoBar に即時反映する。実行中プロセス・MCP subscription・thread-owl queue には作用しない
+
 ## [0.4.0] - 2026-07-11
 
 ### Added

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotResolverTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotResolverTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="RateLimitSnapshotResolverTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public sealed class RateLimitSnapshotResolverTests : IDisposable
+{
+    private static readonly DateTimeOffset _now = new(2026, 7, 13, 12, 0, 0, TimeSpan.Zero);
+    private readonly string _settingsDirectory = Path.Combine(Path.GetTempPath(), $"RateLimitSnapshotResolverTests_{Guid.NewGuid()}");
+
+    [Fact]
+    public async Task ResolveAsync_ShouldReuseCapturedSnapshotWithoutRefetching()
+    {
+        // ファイルは書き出さない。CaptureAsync 経由で再取得すると必ず null になる状態で
+        // capturedSnapshots 側の値がそのまま使われることを確認する（#167 レビュー対応）。
+        RateLimitSnapshotResolver resolver = CreateResolver();
+        RateLimitSnapshot captured = CreateSnapshot("claude-code", 40);
+        var capturedSnapshots = new Dictionary<string, RateLimitSnapshot> { ["claude-code"] = captured };
+
+        IReadOnlyList<RateLimitSnapshot> resolved = await resolver.ResolveAsync(["claude-code"], capturedSnapshots, CancellationToken.None);
+
+        resolved.Should().ContainSingle().Which.Should().BeSameAs(captured);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldFetchUncapturedAgentFromSnapshotService()
+    {
+        await WriteSnapshotAsync("agy", 55);
+        RateLimitSnapshotResolver resolver = CreateResolver();
+
+        IReadOnlyList<RateLimitSnapshot> resolved = await resolver.ResolveAsync(["agy"], new Dictionary<string, RateLimitSnapshot>(), CancellationToken.None);
+
+        resolved.Should().ContainSingle(snapshot => snapshot.AgentId == "agy");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldSkipAgentWhenSnapshotReadFails()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        await WriteSnapshotAsync("agy", 55);
+        RateLimitSnapshotResolver resolver = CreateResolver();
+        string lockedPath = Path.Combine(_settingsDirectory, "ratelimit-status", "claude-code.json");
+        using FileStream exclusiveLock = new(lockedPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        IReadOnlyList<RateLimitSnapshot> resolved = await resolver.ResolveAsync(
+            ["claude-code", "agy"],
+            new Dictionary<string, RateLimitSnapshot>(),
+            CancellationToken.None);
+
+        resolved.Should().ContainSingle(snapshot => snapshot.AgentId == "agy");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldPropagateCancellation()
+    {
+        await WriteSnapshotAsync("claude-code", 40);
+        RateLimitSnapshotResolver resolver = CreateResolver();
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        Func<Task> act = () => resolver.ResolveAsync(["claude-code"], new Dictionary<string, RateLimitSnapshot>(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_settingsDirectory))
+        {
+            Directory.Delete(_settingsDirectory, recursive: true);
+        }
+    }
+
+    private RateLimitSnapshotResolver CreateResolver()
+        => new(new RateLimitSnapshotService(new RateLimitFileService(_settingsDirectory)));
+
+    private static RateLimitSnapshot CreateSnapshot(string agentId, double usedPercentage)
+        => new(
+            agentId,
+            _now,
+            [new RateLimitInfo { Id = "five-hour", Label = "5時間枠", ResetAt = _now.AddHours(5), UsedPercentage = usedPercentage }]);
+
+    private async Task WriteSnapshotAsync(string agentId, double usedPercentage)
+    {
+        string directory = Path.Combine(_settingsDirectory, "ratelimit-status");
+        Directory.CreateDirectory(directory);
+        string json = $$"""
+            {"schemaVersion":1,"agentId":"{{agentId}}","observedAt":"{{_now:O}}","limits":[{"id":"five-hour","label":"5時間枠","resetAt":"{{_now.AddHours(5):O}}","usedPercentage":{{usedPercentage.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}]}
+            """;
+        await File.WriteAllTextAsync(Path.Combine(directory, $"{agentId}.json"), json);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotResolverTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotResolverTests.cs
@@ -39,6 +39,31 @@ public sealed class RateLimitSnapshotResolverTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveAsync_ShouldExcludeCapturedSnapshotWhenAgentIdMismatches()
+    {
+        // capturedSnapshots のキー（agentId）と snapshot 自身の AgentId が食い違う場合、
+        // 辞書引きだけで採用すると別 agent の snapshot が混入する（レビュー指摘対応）。
+        RateLimitSnapshotResolver resolver = CreateResolver();
+        RateLimitSnapshot mismatched = CreateSnapshot("agy", 40);
+        var capturedSnapshots = new Dictionary<string, RateLimitSnapshot> { ["claude-code"] = mismatched };
+
+        IReadOnlyList<RateLimitSnapshot> resolved = await resolver.ResolveAsync(["claude-code"], capturedSnapshots, CancellationToken.None);
+
+        resolved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldExcludeFetchedSnapshotWhenAgentIdMismatches()
+    {
+        await WriteSnapshotAsync("claude-code", 40, payloadAgentId: "agy");
+        RateLimitSnapshotResolver resolver = CreateResolver();
+
+        IReadOnlyList<RateLimitSnapshot> resolved = await resolver.ResolveAsync(["claude-code"], new Dictionary<string, RateLimitSnapshot>(), CancellationToken.None);
+
+        resolved.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ResolveAsync_ShouldSkipAgentWhenSnapshotReadFails()
     {
         await WriteSnapshotAsync("claude-code", 40);
@@ -85,12 +110,12 @@ public sealed class RateLimitSnapshotResolverTests : IDisposable
             _now,
             [new RateLimitInfo { Id = "five-hour", Label = "5時間枠", ResetAt = _now.AddHours(5), UsedPercentage = usedPercentage }]);
 
-    private async Task WriteSnapshotAsync(string agentId, double usedPercentage)
+    private async Task WriteSnapshotAsync(string agentId, double usedPercentage, string? payloadAgentId = null)
     {
         string directory = Path.Combine(_settingsDirectory, "ratelimit-status");
         Directory.CreateDirectory(directory);
         string json = $$"""
-            {"schemaVersion":1,"agentId":"{{agentId}}","observedAt":"{{_now:O}}","limits":[{"id":"five-hour","label":"5時間枠","resetAt":"{{_now.AddHours(5):O}}","usedPercentage":{{usedPercentage.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}]}
+            {"schemaVersion":1,"agentId":"{{payloadAgentId ?? agentId}}","observedAt":"{{_now:O}}","limits":[{"id":"five-hour","label":"5時間枠","resetAt":"{{_now.AddHours(5):O}}","usedPercentage":{{usedPercentage.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}]}
             """;
         await File.WriteAllTextAsync(Path.Combine(directory, $"{agentId}.json"), json);
     }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -812,6 +812,49 @@ internal sealed partial class MainWindow : Window
             info.IsReminderScheduled = _rateLimitReminderService.IsScheduled(info.ReminderKey);
             _rateLimits.Add(info);
         }
+
+        await RefreshAutoPauseGateAsync().ConfigureAwait(true);
+    }
+
+    // Auto-Pause gate（#147）は起動試行時にしか再評価されず、「更新」で fresh な
+    // snapshot を取得しても 95% 未満への解除が反映されなかった（#167）。reviewer /
+    // reviewed 両スロットの rateLimitAgentId を、実行中プロセス・MCP subscription・
+    // queue には作用しない読み取り専用の再評価として反映する.
+    private async Task RefreshAutoPauseGateAsync()
+    {
+        AppSettings settings = _settingsService.Settings;
+        TimeSpan freshnessThreshold = TimeSpan.FromMinutes(settings.RateLimitFreshnessThresholdMinutes);
+        List<string> gateAgentIds = new[]
+            {
+                _settingsService.ResolveLauncherRateLimitAgentId(Models.LauncherRole.Reviewer),
+                _settingsService.ResolveLauncherRateLimitAgentId(Models.LauncherRole.Reviewed),
+            }
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (gateAgentIds.Count == 0)
+        {
+            return;
+        }
+
+        var gateSnapshots = new List<Models.RateLimitSnapshot>();
+        foreach (string agentId in gateAgentIds)
+        {
+            Models.RateLimitSnapshot? snapshot = await _rateLimitSnapshotService.CaptureAsync(agentId, CancellationToken.None).ConfigureAwait(true);
+            if (snapshot is not null)
+            {
+                gateSnapshots.Add(snapshot);
+            }
+        }
+
+        foreach (string agentId in gateAgentIds)
+        {
+            _autoPauseGate.Evaluate(agentId, gateSnapshots, freshnessThreshold);
+        }
+
+        UpdateAutoPauseInfoBar();
     }
 
     private void OnRateLimitAgentOptionChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -40,6 +40,7 @@ internal sealed partial class MainWindow : Window
     private readonly IRateLimitReminderService _rateLimitReminderService;
     private readonly RateLimitFileService _rateLimitFileService;
     private readonly RateLimitSnapshotService _rateLimitSnapshotService;
+    private readonly RateLimitSnapshotResolver _rateLimitSnapshotResolver;
     private readonly AutoPauseGate _autoPauseGate = new();
     private readonly ObservableCollection<Models.RateLimitInfo> _rateLimits = new();
     private readonly ObservableCollection<Models.RateLimitAgentOption> _rateLimitAgentOptions = new();
@@ -126,6 +127,7 @@ internal sealed partial class MainWindow : Window
         _rateLimitReminderService = rateLimitReminderService;
         _rateLimitFileService = rateLimitFileService;
         _rateLimitSnapshotService = new RateLimitSnapshotService(rateLimitFileService);
+        _rateLimitSnapshotResolver = new RateLimitSnapshotResolver(_rateLimitSnapshotService);
         _service.StatusTextChanged += OnStatusTextChanged;
         _service.StateChanged += OnStateChanged;
         _loggingService.LogAppended += OnLogAppended;
@@ -716,6 +718,10 @@ internal sealed partial class MainWindow : Window
     {
         var fetchedLimits = new List<Models.RateLimitInfo>();
 
+        // Auto-Pause gate（#147/#167）の再評価に使う snapshot。表示取得と同じ操作内で
+        // 取得したものを再利用し、gate 用に同じ agent を二重取得しない（#167 レビュー対応）。
+        var capturedSnapshots = new Dictionary<string, Models.RateLimitSnapshot>(StringComparer.Ordinal);
+
         // 1. ローカルファイル経由（statusline フック連携、#139）または App Server 経由（codex、#163）
         // IsAvailable=false は settings.json の手動編集等で IsMonitored=true に
         // なっていても読み取りの対象にしない。
@@ -736,6 +742,8 @@ internal sealed partial class MainWindow : Window
                         continue;
                     }
 
+                    capturedSnapshots[agent.Id] = snapshot;
+
                     string sourceUri = Services.RateLimitFileService.BuildSourceIdentifier(agent.Id);
                     foreach (Models.RateLimitInfo info in snapshot.Limits)
                     {
@@ -753,6 +761,12 @@ internal sealed partial class MainWindow : Window
                         "レートリミット情報がありません",
                         $"{agent.DisplayName} のレートリミット情報がまだありません。statusline スクリプトの拡張が必要です。詳細は docs/statusline-integration.md を参照してください。");
                     continue;
+                }
+
+                Models.RateLimitSnapshot? parsedSnapshot = Services.RateLimitStatusParser.ParseSnapshot(json);
+                if (parsedSnapshot is not null)
+                {
+                    capturedSnapshots[agent.Id] = parsedSnapshot;
                 }
 
                 fetchedLimits.AddRange(Services.RateLimitStatusParser.Parse(json, Services.RateLimitFileService.BuildSourceIdentifier(agent.Id)));
@@ -813,14 +827,15 @@ internal sealed partial class MainWindow : Window
             _rateLimits.Add(info);
         }
 
-        await RefreshAutoPauseGateAsync().ConfigureAwait(true);
+        await RefreshAutoPauseGateAsync(capturedSnapshots).ConfigureAwait(true);
     }
 
     // Auto-Pause gate（#147）は起動試行時にしか再評価されず、「更新」で fresh な
     // snapshot を取得しても 95% 未満への解除が反映されなかった（#167）。reviewer /
     // reviewed 両スロットの rateLimitAgentId を、実行中プロセス・MCP subscription・
-    // queue には作用しない読み取り専用の再評価として反映する.
-    private async Task RefreshAutoPauseGateAsync()
+    // queue には作用しない読み取り専用の再評価として反映する。snapshot の取得・
+    // 再利用ロジックは RateLimitSnapshotResolver に委譲する（#167 レビュー対応）.
+    private async Task RefreshAutoPauseGateAsync(IReadOnlyDictionary<string, Models.RateLimitSnapshot> capturedSnapshots)
     {
         AppSettings settings = _settingsService.Settings;
         TimeSpan freshnessThreshold = TimeSpan.FromMinutes(settings.RateLimitFreshnessThresholdMinutes);
@@ -839,15 +854,9 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
-        var gateSnapshots = new List<Models.RateLimitSnapshot>();
-        foreach (string agentId in gateAgentIds)
-        {
-            Models.RateLimitSnapshot? snapshot = await _rateLimitSnapshotService.CaptureAsync(agentId, CancellationToken.None).ConfigureAwait(true);
-            if (snapshot is not null)
-            {
-                gateSnapshots.Add(snapshot);
-            }
-        }
+        IReadOnlyList<Models.RateLimitSnapshot> gateSnapshots = await _rateLimitSnapshotResolver
+            .ResolveAsync(gateAgentIds, capturedSnapshots, CancellationToken.None)
+            .ConfigureAwait(true);
 
         foreach (string agentId in gateAgentIds)
         {

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotResolver.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotResolver.cs
@@ -1,0 +1,75 @@
+// <copyright file="RateLimitSnapshotResolver.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// Auto-Pause gate（#147）の評価に使う snapshot を agent 単位で解決する（#167 レビュー対応）。
+/// 呼び出し元が別経路（表示更新等）で既に取得済みの snapshot は再取得せずそのまま使い、
+/// 未取得の agent のみ <see cref="RateLimitSnapshotService"/> から取得する。取得済み snapshot を
+/// 再利用しないと、同一操作内で 2 回取得した snapshot の一方だけ一時的に取得不可になった場合に
+/// 表示と gate の判定結果が食い違う（#167 の再発）。cancellation 以外の取得失敗は
+/// <see cref="RateLimitSessionMonitor"/> と同様に当該 agent の取得不可として扱い、呼び出し元の
+/// イベントハンドラーへ例外を伝播させない.
+/// </summary>
+internal sealed class RateLimitSnapshotResolver
+{
+    private readonly RateLimitSnapshotService _snapshotService;
+
+    public RateLimitSnapshotResolver(RateLimitSnapshotService snapshotService)
+    {
+        ArgumentNullException.ThrowIfNull(snapshotService);
+        _snapshotService = snapshotService;
+    }
+
+    /// <summary>
+    /// 指定した agentId 群の snapshot を解決する。.
+    /// </summary>
+    /// <param name="agentIds">解決対象の agentId 一覧.</param>
+    /// <param name="capturedSnapshots">別経路で既に取得済みの snapshot（agentId をキーとする）.</param>
+    /// <param name="cancellationToken">キャンセル用トークン.</param>
+    /// <returns>解決できた snapshot 一覧。取得不可だった agent は含まれない.</returns>
+    public async Task<IReadOnlyList<RateLimitSnapshot>> ResolveAsync(
+        IReadOnlyList<string> agentIds,
+        IReadOnlyDictionary<string, RateLimitSnapshot> capturedSnapshots,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(agentIds);
+        ArgumentNullException.ThrowIfNull(capturedSnapshots);
+
+        var resolved = new List<RateLimitSnapshot>();
+        foreach (string agentId in agentIds)
+        {
+            if (capturedSnapshots.TryGetValue(agentId, out RateLimitSnapshot? cached))
+            {
+                resolved.Add(cached);
+                continue;
+            }
+
+            RateLimitSnapshot? snapshot;
+            try
+            {
+                snapshot = await _snapshotService.CaptureAsync(agentId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                // 取得不可は正常系として扱い、他 agent の解決を継続する（RateLimitSessionMonitor と同様の方針）
+                continue;
+            }
+
+            if (snapshot is not null)
+            {
+                resolved.Add(snapshot);
+            }
+        }
+
+        return resolved;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotResolver.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotResolver.cs
@@ -45,7 +45,16 @@ internal sealed class RateLimitSnapshotResolver
         {
             if (capturedSnapshots.TryGetValue(agentId, out RateLimitSnapshot? cached))
             {
-                resolved.Add(cached);
+                // agentId をキーにした辞書引きだけでは、payload 内の agentId が実際のファイル名
+                // （agentId）と食い違う場合に別 agent の snapshot が混入しうる。
+                // RateLimitSessionMonitor と同じ契約（snapshot.AgentId == agentId）で採用可否を判定する。
+                // ここでは表示取得済みの結果を再利用する方針（#167）を優先し、mismatch を検出しても
+                // 再取得はせず当該 agent の取得不可として扱う。
+                if (cached.AgentId == agentId)
+                {
+                    resolved.Add(cached);
+                }
+
                 continue;
             }
 
@@ -64,7 +73,7 @@ internal sealed class RateLimitSnapshotResolver
                 continue;
             }
 
-            if (snapshot is not null)
+            if (snapshot is not null && snapshot.AgentId == agentId)
             {
                 resolved.Add(snapshot);
             }


### PR DESCRIPTION
## Summary
- `OnRefreshRateLimitClick` は表示用のレートリミット一覧を更新するのみで `AutoPauseGate.Evaluate` を呼んでおらず、fresh な使用率 95% 未満への回復が次回のレビュー起動試行まで InfoBar に反映されなかった
- `RefreshAutoPauseGateAsync` を追加し、「更新」実行時に reviewer / reviewed 両スロットの `rateLimitAgentId` について snapshot を取得して gate を再評価するようにした
- 実行中プロセス・MCP subscription・thread-owl queue には作用しない（既存の gate の設計方針を踏襲）

## Test plan
- [x] `dotnet build`（x64）成功
- [x] `dotnet test`: 547件全て成功
- [ ] 新規ユニットテスト（`OnRefreshRateLimitClick` はコードビハインドのため未追加。レビューで死角の指摘を求める）
- [ ] 実機での Auto-Pause 解除確認（#166 シナリオ4 で再検証予定）

Refs #167 #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)