### PR TITLE
feat: 開発ビルドで通知登録失敗時にフォールバック通知を表示する (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- 開発ビルド（unpackaged 実行）で `AppNotificationManager.Register()` が `Insights.Resource.dll` 読み込み失敗（8007007E）で失敗した場合に、トレイバルーン通知と InfoBar（「トースト通知が無効です」）でフォールバック表示するようにした（#169）。従来は WARN ログのみでユーザーへのフィードバックがなく、トースト通知が無効なことに気づきにくかった。正規配布物（MSI / セットアップ Zip）ではこの制約は発生しない想定で、`README.md` の手動起動セクションに既知の制約として明記した
 - statusline snapshot が旧形式（`schemaVersion` 等を欠く resetAt-only）のままの場合に警告する InfoBar を追加した（#168）。旧形式はレートリミット一覧には引き続き表示されるため気づきにくいが、`RateLimitSnapshotService` は常に `null` を返すため Auto-Pause（#147）が silent に無効化されていた。`RateLimitStatusParser.IsLegacySchema` で検出し、「レートリミット状態」セクションの「更新」実行時に対象エージェント名を明示する。`docs/statusline-integration.md` に旧形式 → 新スキーマの移行手順を追記した
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ uninstall.cmd -KeepSettings
 
 または、Visual Studioから `F5` でデバッグ実行できます。
 
+> **既知の制約:** 開発ビルド（unpackaged、`dotnet build` / `dotnet run` / `F5` デバッグ実行）では `AppNotificationManager.Register()` が `Microsoft.WindowsAppRuntime.Insights.Resource.dll` の読み込み失敗（8007007E）で失敗し、Windows のトースト通知が一切表示されません（#169）。アプリ内のイベント行 UI とトレイバルーン通知がフォールバックとして機能しますが、トースト起点の導線（「PRを開く」「レビューする」ボタン付き通知）を確認する場合は、MSI インストーラーまたはセットアップ Zip から配布物としてインストールしたビルドを使用してください。
+
 ### 設定
 
 アプリケーションを起動後、「Settings」セクションから以下の設定が可能です:

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -14,6 +14,7 @@ namespace SquirrelNotifier.WinUI3;
 public partial class App : Application
 {
     private MainWindow? _window;
+    private readonly bool _notificationRegistrationFailed;
     private readonly NotificationService _notificationService = new();
     private readonly LoggingService _loggingService = new();
     private readonly SettingsService _settingsService = new();
@@ -61,7 +62,10 @@ public partial class App : Application
         }
         catch (System.Runtime.InteropServices.COMException ex) when (ex.Message.Contains("Insights.Resource.dll", StringComparison.Ordinal))
         {
-            // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題
+            // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題（#169）。
+            // トースト通知が一切表示できなくなるため、MainWindow 側でトレイバルーンと
+            // InfoBar によるフォールバック通知を出す
+            _notificationRegistrationFailed = true;
             _ = _loggingService.WriteAsync($"[WARN] AppNotificationManager.Register() 失敗（{ex.HResult:X8}）: {ex.Message}");
         }
 
@@ -85,7 +89,7 @@ public partial class App : Application
         bool showWindow = isNotificationActivation
             || (!commandLineArgs.Contains("--tray") && !commandLineArgs.Contains("-t"));
 
-        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, _enqueueReviewService, _rateLimitReminderService, _rateLimitFileService, showWindow);
+        _window = new MainWindow(_subscriptionService, _loggingService, _settingsService, _autoUpdateService, _notificationService, _launcherService, _taskSchedulerService, _enqueueReviewService, _rateLimitReminderService, _rateLimitFileService, showWindow, _notificationRegistrationFailed);
         _window.Closed += OnWindowClosed;
 
         _window.Activate();

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -27,6 +27,13 @@
                     <Button Content="設定へ移動" Click="OnGoToSettingsClick"/>
                 </InfoBar.ActionButton>
             </InfoBar>
+            <InfoBar x:Name="NotificationDisabledInfoBar"
+                     Title="トースト通知が無効です"
+                     Message="開発ビルド（unpackaged 実行）では Windows のトースト通知を利用できません。イベントはアプリ内のイベント行でご確認ください。正規配布物（MSI / セットアップ Zip）ではこの制限はありません。"
+                     Severity="Warning"
+                     IsOpen="False"
+                     IsClosable="True"
+                     Margin="0,4,0,0"/>
             <InfoBar x:Name="CopyFeedbackInfoBar"
                      Severity="Success"
                      IsOpen="False"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -29,7 +29,7 @@
             </InfoBar>
             <InfoBar x:Name="NotificationDisabledInfoBar"
                      Title="トースト通知が無効です"
-                     Message="開発ビルド（unpackaged 実行）では Windows のトースト通知を利用できません。イベントはアプリ内のイベント行でご確認ください。正規配布物（MSI / セットアップ Zip）ではこの制限はありません。"
+                     Message="開発ビルド（unpackaged 実行）では Windows のトースト通知を利用できません。イベントはアプリ内のイベント行でご確認ください。正規配布物（MSI / セットアップ Zip）ではこの制限は発生しない想定です。"
                      Severity="Warning"
                      IsOpen="False"
                      IsClosable="True"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -98,9 +98,15 @@ internal sealed partial class MainWindow : Window
         EnqueueReviewService enqueueReviewService,
         IRateLimitReminderService rateLimitReminderService,
         RateLimitFileService rateLimitFileService,
-        bool showWindow = true)
+        bool showWindow = true,
+        bool notificationRegistrationFailed = false)
     {
         InitializeComponent();
+
+        if (notificationRegistrationFailed)
+        {
+            NotificationDisabledInfoBar.IsOpen = true;
+        }
 
         // Auto-Pause（#147）の状態はセッション終了時（ライブログウィンドウ側の評価）にも
         // 変わるため、イベント経由でメイン UI の表示へ反映する
@@ -183,6 +189,11 @@ internal sealed partial class MainWindow : Window
         _trayIconService.LeftClick += OnTrayIconLeftClick;
         _trayIconService.RightClick += OnTrayIconRightClick;
         _trayIconService.AddIcon("Squirrel Notifier");
+
+        if (notificationRegistrationFailed)
+        {
+            _trayIconService.ShowBalloonTip("Squirrel Notifier", "開発ビルドではトースト通知が無効です。イベントはアプリ内のイベント行でご確認ください。");
+        }
 
         // Hook window messages to process tray icon messages
         _newWndProcDelegate = new WndProcDelegate(NewWndProc);


### PR DESCRIPTION
## Summary
- 開発ビルド（unpackaged 実行）で `AppNotificationManager.Register()` が `Insights.Resource.dll` 読み込み失敗（8007007E）で失敗した場合、従来は WARN ログのみでユーザーへのフィードバックがなかった問題に対応
- トレイバルーン通知（その場での即時通知）と InfoBar「トースト通知が無効です」（常設の警告表示、既存の `OnboardingInfoBar` 等と同じパターン）の両方でフォールバック表示する
- README.md の手動起動セクションに既知の制約として明記し、CHANGELOG.md に変更を記載

## Issue #169 の対応状況
1. ✅ Register() 失敗時のフォールバック → トレイバルーン + InfoBar を実装
2. ✅ 「#166 系ランブックの確認項目」への追加 → Issue #166 の本文（シナリオ1 確認項目）にトースト通知確認項目を追記済み
3. ✅ 開発者向けドキュメント → README.md に既知の制約として記載

## 実装詳細
- `App.xaml.cs`: `Register()` 失敗を `_notificationRegistrationFailed`（readonly）で保持し、`MainWindow` へ渡す
- `MainWindow.xaml.cs` / `MainWindow.xaml`: フラグが true の場合、起動時に `TrayIconService.ShowBalloonTip` と新規 `NotificationDisabledInfoBar`（`IsOpen=true`）でユーザーに明示
- 正規配布物（MSI / セットアップ Zip）では発生しない想定の既知の制約として扱う

## Test plan
- [x] `dotnet build winui3\SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64` が成功することを確認
- [x] `dotnet test winui3\SquirrelNotifier.WinUI3.sln` — 562件全て成功、カバレッジ基準（80%）を満たす
- [x] `dotnet format --verify-no-changes` — フォーマット差分なし
- [x] pre-commit / pre-push フック（build / format / test+coverage）が通過

Refs #169