### PR TITLE
fix: v0.5.0 E2E検証で見つかった4件の不具合・改善点に対応する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- UIスレッド・AppDomain・未observeなTaskの未処理例外をグローバルに捕捉し、`winui3.log` へ記録するようにした（#174）。従来はグローバル例外ハンドラが存在せず、真に未捕捉の例外が発生した場合はログに一切証跡が残らずアプリが終了していた。原因不明の「予期しないエラー」報告の切り分けに必要な最低限の証跡を残す
+- 旧形式ステータスライン警告とトースト通知無効警告の InfoBar に `ActionButton` を追加し、それぞれ `docs/statusline-integration.md` と README の既知の制約セクションを外部ブラウザで開けるようにした（#174）。従来は参照先をドキュメント名で案内するのみでクリック導線がなかった
+- codex レートリミット取得不可時のエラーメッセージを原因ごとに分離した（#174）。`CodexAppServerRateLimitClient.CaptureWithFailureReasonAsync` が「CLI 未検出」「タイムアウト」「その他（未ログインの可能性を含む）」を区別して返すようにし、`codex` コマンド未インストールやタイムアウトの場合まで一律「ログイン済みか確認してください」と表示していた問題を解消した。JSON-RPC error の code/message は codex CLI バージョンにより変わりうるため、確実に判別できないケースは断定的な理由を出さない
+
+### Fixed
+- MSI インストーラー / セットアップ Zip による正規インストールでも「トースト通知が無効です」警告が発生しうることを README と InfoBar の文言に反映した（#174）。本アプリは `WindowsPackageType=None` かつ self-contained でビルドされており、正規インストールも実行形態としては unpackaged であるため、`AppNotificationManager.Register()` の `Insights.Resource.dll` 読み込み失敗（#169）は配布形態に関わらず発生しうる。#169 時点の「正規配布物では発生しない想定」という記述は誤りだった
+
 ## [0.5.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - UIスレッド・AppDomain・未observeなTaskの未処理例外をグローバルに捕捉し、`winui3.log` へ記録するようにした（#174）。従来はグローバル例外ハンドラが存在せず、真に未捕捉の例外が発生した場合はログに一切証跡が残らずアプリが終了していた。原因不明の「予期しないエラー」報告の切り分けに必要な最低限の証跡を残す
 - 旧形式ステータスライン警告とトースト通知無効警告の InfoBar に `ActionButton` を追加し、それぞれ `docs/statusline-integration.md` と README の既知の制約セクションを外部ブラウザで開けるようにした（#174）。従来は参照先をドキュメント名で案内するのみでクリック導線がなかった
-- codex レートリミット取得不可時のエラーメッセージを原因ごとに分離した（#174）。`CodexAppServerRateLimitClient.CaptureWithFailureReasonAsync` が「CLI 未検出」「タイムアウト」「その他（未ログインの可能性を含む）」を区別して返すようにし、`codex` コマンド未インストールやタイムアウトの場合まで一律「ログイン済みか確認してください」と表示していた問題を解消した。JSON-RPC error の code/message は codex CLI バージョンにより変わりうるため、確実に判別できないケースは断定的な理由を出さない
+- codex レートリミット取得不可時のエラーメッセージを原因ごとに分離した（#174）。`CodexAppServerRateLimitClient.CaptureWithFailureReasonAsync` が「CLI 未検出」「タイムアウト」「その他（未ログインの可能性を含む）」を区別して返すようにし、`codex` コマンド未インストールやタイムアウトの場合まで一律「ログイン済みか確認してください」と表示していた問題を解消した。JSON-RPC error の code/message は codex CLI バージョンにより変わりうるため、確実に判別できないケースは断定的な理由を出さない。「CLI 未検出」は `Win32Exception.NativeErrorCode` が `ERROR_FILE_NOT_FOUND` / `ERROR_PATH_NOT_FOUND` の場合のみとし、アクセス拒否等コマンド自体は存在するケースを誤って「未インストール」と案内しないようにした
 
 ### Fixed
 - MSI インストーラー / セットアップ Zip による正規インストールでも「トースト通知が無効です」警告が発生しうることを README と InfoBar の文言に反映した（#174）。本アプリは `WindowsPackageType=None` かつ self-contained でビルドされており、正規インストールも実行形態としては unpackaged であるため、`AppNotificationManager.Register()` の `Insights.Resource.dll` 読み込み失敗（#169）は配布形態に関わらず発生しうる。#169 時点の「正規配布物では発生しない想定」という記述は誤りだった

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uninstall.cmd -KeepSettings
 
 または、Visual Studioから `F5` でデバッグ実行できます。
 
-> **既知の制約:** 開発ビルド（unpackaged、`dotnet build` / `dotnet run` / `F5` デバッグ実行）では `AppNotificationManager.Register()` が `Microsoft.WindowsAppRuntime.Insights.Resource.dll` の読み込み失敗（8007007E）で失敗し、Windows のトースト通知が一切表示されません（#169）。アプリ内のイベント行 UI とトレイバルーン通知がフォールバックとして機能しますが、トースト起点の導線（「PRを開く」「レビューする」ボタン付き通知）を確認する場合は、MSI インストーラーまたはセットアップ Zip から配布物としてインストールしたビルドを使用してください。
+> **既知の制約:** 本アプリは `WindowsPackageType=None` かつ self-contained（`WindowsAppSDKSelfContained=true`）でビルドされており、MSI インストーラー / セットアップ Zip による正規インストールも実行形態としては unpackaged です。そのため `AppNotificationManager.Register()` が `Microsoft.WindowsAppRuntime.Insights.Resource.dll` の読み込み失敗（8007007E）で失敗し、Windows のトースト通知が一切表示されない事象は、開発ビルドに限らず MSI / セットアップ Zip からの正規インストールでも発生しえます（#169、#174）。発生した場合はアプリ内のイベント行 UI とトレイバルーン通知がフォールバックとして機能します。
 
 ### 設定
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
@@ -224,6 +224,83 @@ public class CodexAppServerRateLimitClientTests
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    // ---- CaptureWithFailureReasonAsync（#174: 取得不可理由の区別）----
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnNullReason_WhenSnapshotSucceeds()
+    {
+        (Mock<IProcessInstance> process, _) = CreateMockProcess(
+            BuildStdout(_initializeResponseLine, $$"""{"id":2,"result":{{_sampleReadResultJson.Trim()}}}"""));
+        CodexAppServerRateLimitClient client = CreateClient(process, out _);
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().NotBeNull();
+        failureReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnCommandNotFound_WhenProcessStartFails()
+    {
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Throws(new System.ComponentModel.Win32Exception("codex not found"));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.CommandNotFound);
+    }
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnTimeout_WhenRoundTripTimesOut()
+    {
+        (Mock<IProcessInstance> process, _) = CreateMockProcess(stdoutStream: new BlockingStream());
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
+        CodexAppServerRateLimitClient client = new(
+            runner.Object, new FixedTimeProvider(_now), roundTripTimeout: TimeSpan.FromMilliseconds(200));
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.Timeout);
+    }
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnUnknown_WhenReadRespondsWithJsonRpcError()
+    {
+        (Mock<IProcessInstance> process, _) = CreateMockProcess(BuildStdout(
+            _initializeResponseLine,
+            """{"id":2,"error":{"code":-32000,"message":"not logged in"}}"""));
+        CodexAppServerRateLimitClient client = CreateClient(process, out _);
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.Unknown);
+    }
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldPropagateExternalCancellation()
+    {
+        (Mock<IProcessInstance> process, _) = CreateMockProcess(stdoutStream: new BlockingStream());
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        using CancellationTokenSource cts = new();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        Func<Task> act = () => client.CaptureWithFailureReasonAsync("codex", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private static CodexRateLimitsReadResult Deserialize(string json)
         => System.Text.Json.JsonSerializer.Deserialize<CodexRateLimitsReadResult>(json)!;
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
@@ -240,12 +240,14 @@ public class CodexAppServerRateLimitClientTests
         failureReason.Should().BeNull();
     }
 
-    [Fact]
-    public async Task CaptureWithFailureReasonAsync_ShouldReturnCommandNotFound_WhenProcessStartFails()
+    [Theory]
+    [InlineData(2)] // ERROR_FILE_NOT_FOUND
+    [InlineData(3)] // ERROR_PATH_NOT_FOUND
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnCommandNotFound_WhenProcessStartFailsWithFileOrPathNotFound(int nativeErrorCode)
     {
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
-            .Throws(new System.ComponentModel.Win32Exception("codex not found"));
+            .Throws(new System.ComponentModel.Win32Exception(nativeErrorCode, "codex not found"));
         CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
 
         (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
@@ -253,6 +255,22 @@ public class CodexAppServerRateLimitClientTests
 
         snapshot.Should().BeNull();
         failureReason.Should().Be(CodexRateLimitFailureReason.CommandNotFound);
+    }
+
+    [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnUnknown_WhenProcessStartFailsWithAccessDenied()
+    {
+        // ERROR_ACCESS_DENIED (5): コマンド自体は存在するため CommandNotFound と誤誘導しない
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Throws(new System.ComponentModel.Win32Exception(5, "access denied"));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.Unknown);
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
@@ -127,7 +127,7 @@ public class RateLimitSnapshotServiceTests : IDisposable
     {
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
-            .Throws(new System.ComponentModel.Win32Exception("codex not found"));
+            .Throws(new System.ComponentModel.Win32Exception(2, "codex not found")); // ERROR_FILE_NOT_FOUND
         var service = new RateLimitSnapshotService(
             new RateLimitFileService(_settingsDirectory),
             new CodexAppServerRateLimitClient(runner.Object));

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
@@ -121,4 +121,31 @@ public class RateLimitSnapshotServiceTests : IDisposable
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task CaptureCodexWithFailureReasonAsync_ShouldReturnCommandNotFound_WhenAppServerIsUnavailable()
+    {
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Throws(new System.ComponentModel.Win32Exception("codex not found"));
+        var service = new RateLimitSnapshotService(
+            new RateLimitFileService(_settingsDirectory),
+            new CodexAppServerRateLimitClient(runner.Object));
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await service.CaptureCodexWithFailureReasonAsync(RateLimitSnapshotService.CodexAgentId, CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.CommandNotFound);
+    }
+
+    [Fact]
+    public async Task CaptureCodexWithFailureReasonAsync_ShouldThrow_WhenAgentIdIsNotCodex()
+    {
+        var service = new RateLimitSnapshotService(new RateLimitFileService(_settingsDirectory));
+
+        Func<Task> act = () => service.CaptureCodexWithFailureReasonAsync("claude-code", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -31,6 +31,8 @@ public partial class App : Application
     {
         InitializeComponent();
 
+        UnhandledException += OnApplicationUnhandledException;
+
         try
         {
             _cacheService = new CacheService();
@@ -138,5 +140,11 @@ public partial class App : Application
         {
             _window.DispatcherQueue.TryEnqueue(() => _window.ShowWindowFromTray());
         }
+    }
+
+    private void OnApplicationUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+    {
+        // クラッシュ直前のため、原因特定用の証跡を確実に残すべく同期的にログ書き込みを待つ（#174）
+        _loggingService.WriteAsync($"[FATAL] UIスレッドで未処理例外が発生しました: {e.Exception.GetType().FullName}: {e.Message}{Environment.NewLine}{e.Exception.StackTrace}").GetAwaiter().GetResult();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -29,11 +29,15 @@
             </InfoBar>
             <InfoBar x:Name="NotificationDisabledInfoBar"
                      Title="トースト通知が無効です"
-                     Message="開発ビルド（unpackaged 実行）では Windows のトースト通知を利用できません。イベントはアプリ内のイベント行でご確認ください。正規配布物（MSI / セットアップ Zip）ではこの制限は発生しない想定です。"
+                     Message="Windows のトースト通知を利用できません（MSI / セットアップ Zip の正規インストールでも発生することがあります）。イベントはアプリ内のイベント行でご確認ください。"
                      Severity="Warning"
                      IsOpen="False"
                      IsClosable="True"
-                     Margin="0,4,0,0"/>
+                     Margin="0,4,0,0">
+                <InfoBar.ActionButton>
+                    <Button Content="詳細を見る" Click="OnOpenNotificationDocsClick"/>
+                </InfoBar.ActionButton>
+            </InfoBar>
             <InfoBar x:Name="CopyFeedbackInfoBar"
                      Severity="Success"
                      IsOpen="False"
@@ -164,7 +168,11 @@
                          IsOpen="False"
                          IsClosable="False"
                          Severity="Warning"
-                         Title="statusline snapshot が旧形式です"/>
+                         Title="statusline snapshot が旧形式です">
+                    <InfoBar.ActionButton>
+                        <Button Content="移行手順を見る" Click="OnOpenStatuslineDocsClick"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
                 <TextBlock Text="監視対象:" FontSize="11" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"/>
                 <ItemsControl x:Name="RateLimitAgentList">
                     <ItemsControl.ItemsPanel>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -748,12 +748,13 @@ internal sealed partial class MainWindow : Window
                 if (agent.Id == RateLimitSnapshotService.CodexAgentId)
                 {
                     // codex は statusline を持たないため App Server（account/rateLimits/read）から取得する
-                    Models.RateLimitSnapshot? snapshot = await _rateLimitSnapshotService.CaptureAsync(agent.Id, CancellationToken.None).ConfigureAwait(true);
+                    (Models.RateLimitSnapshot? snapshot, Services.CodexRateLimitFailureReason? failureReason) =
+                        await _rateLimitSnapshotService.CaptureCodexWithFailureReasonAsync(agent.Id, CancellationToken.None).ConfigureAwait(true);
                     if (snapshot == null)
                     {
                         await ShowAlertDialogAsync(
                             "レートリミット情報を取得できません",
-                            $"{agent.DisplayName} のレートリミット情報を Codex App Server から取得できませんでした。codex にログイン済みか確認してください。");
+                            BuildCodexFailureMessage(agent.DisplayName, failureReason));
                         continue;
                     }
 
@@ -848,6 +849,22 @@ internal sealed partial class MainWindow : Window
 
         UpdateLegacySchemaInfoBar(legacySchemaAgentNames);
         await RefreshAutoPauseGateAsync(capturedSnapshots).ConfigureAwait(true);
+    }
+
+    // codex の取得不可理由を原因ごとに出し分ける（#174）。JSON-RPC error の code/message は
+    // codex CLI バージョンにより変わりうるため確実に判別できず、Unknown を「未ログインの可能性を
+    // 含む」表現に留め、断定しない。
+    private static string BuildCodexFailureMessage(string agentDisplayName, Services.CodexRateLimitFailureReason? failureReason)
+    {
+        return failureReason switch
+        {
+            Services.CodexRateLimitFailureReason.CommandNotFound =>
+                $"{agentDisplayName} の codex コマンドが見つかりませんでした。codex CLI がインストールされ、PATH が通っているか確認してください。",
+            Services.CodexRateLimitFailureReason.Timeout =>
+                $"{agentDisplayName} の Codex App Server が応答しませんでした（タイムアウト）。しばらく待ってから再試行してください。",
+            _ =>
+                $"{agentDisplayName} のレートリミット情報を Codex App Server から取得できませんでした。codex にログイン済みか確認するか、しばらく待って再試行してください。",
+        };
     }
 
     // 旧形式 snapshot は一覧表示できてしまうため気づかれにくく、Auto-Pause gate（#147）が
@@ -1071,7 +1088,7 @@ internal sealed partial class MainWindow : Window
             ContentDialogResult dialogResult = await updateDialog.ShowAsync(ContentDialogPlacement.Popup);
             if (dialogResult == ContentDialogResult.Primary)
             {
-                TryOpenReleasePage(result.ReleaseUrl);
+                TryOpenUrl(result.ReleaseUrl);
             }
             else if (dialogResult == ContentDialogResult.Secondary)
             {
@@ -1088,9 +1105,9 @@ internal sealed partial class MainWindow : Window
         }
     }
 
-    private void TryOpenReleasePage(string releaseUrl)
+    private void TryOpenUrl(string url)
     {
-        if (string.IsNullOrWhiteSpace(releaseUrl))
+        if (string.IsNullOrWhiteSpace(url))
         {
             return;
         }
@@ -1099,7 +1116,7 @@ internal sealed partial class MainWindow : Window
         {
             Process.Start(new ProcessStartInfo
             {
-                FileName = releaseUrl,
+                FileName = url,
                 UseShellExecute = true,
             });
         }
@@ -1107,6 +1124,16 @@ internal sealed partial class MainWindow : Window
         {
             // ignore
         }
+    }
+
+    private void OnOpenStatuslineDocsClick(object sender, RoutedEventArgs e)
+    {
+        TryOpenUrl("https://github.com/scottlz0310/squirrel-notifier/blob/main/docs/statusline-integration.md");
+    }
+
+    private void OnOpenNotificationDocsClick(object sender, RoutedEventArgs e)
+    {
+        TryOpenUrl("https://github.com/scottlz0310/squirrel-notifier#手動起動");
     }
 
     private void OnReviewEventReceived(object? sender, Models.ReviewEvent e)

--- a/winui3/SquirrelNotifier.WinUI3/Program.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Program.cs
@@ -54,6 +54,9 @@ internal static class Program
     {
         WinRT.ComWrappersSupport.InitializeComWrappers();
 
+        AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
         if (DecideRedirection())
         {
             return;
@@ -124,5 +127,21 @@ internal static class Program
         });
 
         redirectCompleted.WaitOne();
+    }
+
+    private static void OnAppDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+    {
+        // IsTerminating の場合プロセスは直後に終了するため、原因特定用の証跡を確実に残すべく同期的に待つ（#174）
+        var ex = e.ExceptionObject as Exception;
+        string detail = ex != null
+            ? $"{ex.GetType().FullName}: {ex.Message}{Environment.NewLine}{ex.StackTrace}"
+            : e.ExceptionObject?.ToString() ?? "unknown";
+        new LoggingService().WriteAsync($"[FATAL] AppDomain で未処理例外が発生しました（IsTerminating={e.IsTerminating}）: {detail}").GetAwaiter().GetResult();
+    }
+
+    private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        _ = new LoggingService().WriteAsync($"[ERROR] 未observeなTask例外が発生しました: {e.Exception.GetType().FullName}: {e.Exception.Message}{Environment.NewLine}{e.Exception.StackTrace}");
+        e.SetObserved();
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
@@ -41,6 +41,11 @@ internal sealed class CodexAppServerRateLimitClient
     private const string _commandArguments = "app-server";
     private const int _initializeRequestId = 1;
     private const int _readRequestId = 2;
+
+    // Win32Exception.NativeErrorCode（CommandNotFound と確実に判別できる範囲のみ。
+    // ERROR_ACCESS_DENIED 等はコマンド自体は存在するため Unknown 扱いにする）
+    private const int _errorFileNotFound = 2;
+    private const int _errorPathNotFound = 3;
     private static readonly TimeSpan _defaultRoundTripTimeout = TimeSpan.FromSeconds(15);
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
@@ -99,15 +104,16 @@ internal sealed class CodexAppServerRateLimitClient
             // round-trip タイムアウト（外部キャンセルではない、_roundTripTimeout 到達）
             return (null, CodexRateLimitFailureReason.Timeout);
         }
-        catch (System.ComponentModel.Win32Exception)
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode is _errorFileNotFound or _errorPathNotFound)
         {
-            // codex CLI が見つからない・実行できない
+            // codex CLI が見つからない（ERROR_FILE_NOT_FOUND / ERROR_PATH_NOT_FOUND）
             return (null, CodexRateLimitFailureReason.CommandNotFound);
         }
         catch (Exception)
         {
-            // 未ログイン・プロトコル不整合等、それ以外は「取得不可」の正常系として扱う
-            // （#163。#146/#147 のパターンに準拠）
+            // 未ログイン・プロトコル不整合・Win32Exception のその他のエラー（アクセス拒否・
+            // 実行形式不正等、コマンド自体は存在する）は原因を確実に判別できないため
+            // 「取得不可」の正常系として扱う（#163。#146/#147 のパターンに準拠）
             return (null, CodexRateLimitFailureReason.Unknown);
         }
     }

--- a/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
@@ -10,6 +10,23 @@ using SquirrelNotifier.WinUI3.Models;
 namespace SquirrelNotifier.WinUI3.Services;
 
 /// <summary>
+/// <see cref="CodexAppServerRateLimitClient.CaptureWithFailureReasonAsync"/> が返す、取得不可の推定理由（#174）.
+/// JSON-RPC error の code/message は codex CLI バージョンにより変わりうるため確実に判別できない。
+/// そのため「未ログイン」を断定する種別は設けず、確実に判別できるものだけを区別する.
+/// </summary>
+internal enum CodexRateLimitFailureReason
+{
+    /// <summary>未ログイン・JSON-RPC error・プロトコル不整合等、原因を確実に判別できない場合.</summary>
+    Unknown,
+
+    /// <summary><c>codex</c> コマンドが見つからない、または実行できない（プロセス起動失敗）.</summary>
+    CommandNotFound,
+
+    /// <summary>round-trip タイムアウトに到達した.</summary>
+    Timeout,
+}
+
+/// <summary>
 /// Codex App Server（<c>codex app-server</c>、stdio JSON-RPC）からレートリミット snapshot を
 /// 取得する（#163）。statusline フックと異なり任意タイミングで呼べるため、observedAt は常に
 /// 取得時刻（= fresh）になる。呼び出しごとにプロセスを起動し、initialize →
@@ -49,21 +66,49 @@ internal sealed class CodexAppServerRateLimitClient
 
     public async Task<RateLimitSnapshot?> CaptureAsync(string agentId, CancellationToken cancellationToken)
     {
+        (RateLimitSnapshot? snapshot, _) = await CaptureWithFailureReasonAsync(agentId, cancellationToken).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    /// <summary>
+    /// <see cref="CaptureAsync"/> と同じ取得処理を行うが、取得不可時の理由（推定）も返す（#174）。
+    /// 「未ログイン」「App Server 起動失敗」「タイムアウト」「プロトコル不整合」を一括りに
+    /// 「取得不可」としていたため、ユーザー向けメッセージが原因に関わらず「ログインを確認してください」
+    /// になっていた点を改善する目的。JSON-RPC error の code/message は codex CLI バージョンにより
+    /// 変わりうるため、確実に判別できる「CLI 未検出」「タイムアウト」以外は <see cref="CodexRateLimitFailureReason.Unknown"/>
+    /// として扱い、誤って断定的な理由を示さない.
+    /// </summary>
+    /// <param name="agentId">snapshot に記録する agentId.</param>
+    /// <param name="cancellationToken">キャンセル用トークン.</param>
+    /// <returns>取得できた場合は snapshot と <see langword="null"/> の理由。取得不可の場合は <see langword="null"/> snapshot と推定理由.</returns>
+    public async Task<(RateLimitSnapshot? Snapshot, CodexRateLimitFailureReason? FailureReason)> CaptureWithFailureReasonAsync(string agentId, CancellationToken cancellationToken)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
 
         try
         {
-            return await CaptureCoreAsync(agentId, cancellationToken).ConfigureAwait(false);
+            RateLimitSnapshot? snapshot = await CaptureCoreAsync(agentId, cancellationToken).ConfigureAwait(false);
+            return (snapshot, snapshot is null ? CodexRateLimitFailureReason.Unknown : null);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
+        catch (OperationCanceledException)
+        {
+            // round-trip タイムアウト（外部キャンセルではない、_roundTripTimeout 到達）
+            return (null, CodexRateLimitFailureReason.Timeout);
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // codex CLI が見つからない・実行できない
+            return (null, CodexRateLimitFailureReason.CommandNotFound);
+        }
         catch (Exception)
         {
-            // 未ログイン・App Server 起動失敗・round-trip タイムアウト・プロトコル不整合は
-            // すべて「取得不可」の正常系として扱う（#163。#146/#147 のパターンに準拠）
-            return null;
+            // 未ログイン・プロトコル不整合等、それ以外は「取得不可」の正常系として扱う
+            // （#163。#146/#147 のパターンに準拠）
+            return (null, CodexRateLimitFailureReason.Unknown);
         }
     }
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/RateLimitSnapshotService.cs
@@ -46,4 +46,21 @@ internal sealed class RateLimitSnapshotService
         string? json = await _fileService.ReadAgentStatusAsync(agentId, cancellationToken).ConfigureAwait(false);
         return RateLimitStatusParser.ParseSnapshot(json);
     }
+
+    /// <summary>
+    /// codex エージェント向け。<see cref="CaptureAsync"/> と同じ取得処理を行うが、取得不可時の
+    /// 理由（推定）も返す（#174）。UI 側でエラーメッセージを原因ごとに出し分けるために使う.
+    /// </summary>
+    /// <param name="agentId"><see cref="CodexAgentId"/> であること.</param>
+    /// <param name="cancellationToken">キャンセル用トークン.</param>
+    /// <returns>取得できた場合は snapshot と <see langword="null"/> の理由。取得不可の場合は <see langword="null"/> snapshot と推定理由.</returns>
+    public Task<(RateLimitSnapshot? Snapshot, CodexRateLimitFailureReason? FailureReason)> CaptureCodexWithFailureReasonAsync(string agentId, CancellationToken cancellationToken)
+    {
+        if (agentId != CodexAgentId)
+        {
+            throw new ArgumentException($"'{agentId}' は codex エージェントではありません。", nameof(agentId));
+        }
+
+        return _codexClient.CaptureWithFailureReasonAsync(agentId, cancellationToken);
+    }
 }


### PR DESCRIPTION
## Summary

#166 のコメントで報告された v0.5.0 MSI インストール後の手動検証での4件の指摘に対応する（#174）。

- グローバル例外ハンドラが存在せず、真に未捕捉の例外がログに一切残らなかった問題を修正
- MSI インストーラー / セットアップ Zip でも「トースト通知が無効です」警告が発生しうることが判明したため、README・InfoBar の「正規配布物では発生しない想定」という誤った記述を修正
- 旧形式ステータスライン警告・トースト通知警告の InfoBar に `ActionButton` を追加し、ドキュメントへの導線を改善
- codex レートリミット取得不可のエラーメッセージを、CLI 未検出・タイムアウト・その他（未ログインの可能性を含む）で分離

## Test plan

- [x] `dotnet build winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64` 成功
- [x] `dotnet test` 全569件成功（カバレッジ Line 92.31% / Branch 86.6% / Method 94.04%、基準80%を維持）
- [x] `dotnet format --verify-no-changes` 通過
- [ ] MSI インストール版での InfoBar ActionButton・トースト通知警告文言の実機確認（#166 系ランブックで別途実施）

Refs #174, #166, #169

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>