### PR TITLE
fix: codexコマンド未検出とトースト通知警告文言の誤りを修正する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- codex レートリミット取得が PATHEXT 非解決で `CommandNotFound` になる問題を修正した（#177）。`CodexAppServerRateLimitClient` は `FileName="codex"` かつ `UseShellExecute=false` で `Process.Start` していたため、npm 経由でインストールされた `codex.cmd` シム環境では Win32 `CreateProcessW` が `.exe` のみを暗黙補完し、ターミナルでは実行できるのに `ERROR_FILE_NOT_FOUND` で失敗していた。PATH / PATHEXT を自前で解決し、`.cmd` / `.bat` が見つかった場合は `cmd.exe /c` 経由で起動するようにした
+- 「トースト通知が無効です」という警告文言が誤りだったため、README と InfoBar・トレイバルーン通知の文言を修正した。`AppNotificationManager.Register()` の `Insights.Resource.dll` 読み込み失敗（#169、[microsoft/WindowsAppSDK#6071](https://github.com/microsoft/WindowsAppSDK/issues/6071) — Microsoft 側の self-contained 配布における既知の未解決バグ）はボタン操作（`NotificationInvoked`）の受信にのみ影響し、`AppNotificationManager.Show()` によるトースト表示自体は妨げない。実機ログ・実機確認でも `Register()` 失敗時にトースト自体は表示されることを確認した
+
 ## [0.5.1] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uninstall.cmd -KeepSettings
 
 または、Visual Studioから `F5` でデバッグ実行できます。
 
-> **既知の制約:** 本アプリは `WindowsPackageType=None` かつ self-contained（`WindowsAppSDKSelfContained=true`）でビルドされており、MSI インストーラー / セットアップ Zip による正規インストールも実行形態としては unpackaged です。そのため `AppNotificationManager.Register()` が `Microsoft.WindowsAppRuntime.Insights.Resource.dll` の読み込み失敗（8007007E）で失敗し、Windows のトースト通知が一切表示されない事象は、開発ビルドに限らず MSI / セットアップ Zip からの正規インストールでも発生しえます（#169、#174）。発生した場合はアプリ内のイベント行 UI とトレイバルーン通知がフォールバックとして機能します。
+> **既知の制約:** 本アプリは `WindowsPackageType=None` かつ self-contained（`WindowsAppSDKSelfContained=true`）でビルドされており、MSI インストーラー / セットアップ Zip による正規インストールも実行形態としては unpackaged です。そのため `AppNotificationManager.Register()` が `Microsoft.WindowsAppRuntime.Insights.Resource.dll` の読み込み失敗（8007007E）で失敗する事象は、開発ビルドに限らず MSI / セットアップ Zip からの正規インストールでも発生しえます（#169、#174、[microsoft/WindowsAppSDK#6071](https://github.com/microsoft/WindowsAppSDK/issues/6071) — Microsoft 側の self-contained 配布における既知の未解決バグ）。`Register()` はボタン操作等の通知アクティベーション（`NotificationInvoked`）を受け取るためのものであり、`AppNotificationManager.Show()` によるトースト自体の表示には影響しません。そのため `Register()` 失敗時もトースト通知は表示されますが、通知のボタン操作（「PRを開く」「レビューする」等）に反応しない場合があります。その場合はアプリ内のイベント行 UI とトレイバルーン通知がフォールバックとして機能します。
 
 ### 設定
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
@@ -274,24 +274,27 @@ public class CodexAppServerRateLimitClientTests
         runner.Verify(r => r.Start(It.IsAny<ProcessStartInfo>()), Times.Never);
     }
 
-    [Fact]
-    public async Task CaptureAsync_ShouldStartViaCmdExe_WhenCommandResolverReturnsShellScript()
+    [Theory]
+    [InlineData(@"C:\fake & tools\codex.cmd")]
+    [InlineData(@"C:\fake %TEMP% tools\codex.bat")]
+    public async Task CaptureAsync_ShouldStartViaCmdExeWithoutReinterpretingResolvedPath_WhenCommandResolverReturnsShellScript(
+        string fakeScriptPath)
     {
         // npm 経由でインストールされた codex は Windows 上では codex.cmd シムであることが多い（#177）。
-        // .cmd / .bat はネイティブ実行形式ではないため cmd.exe /c 経由で起動する
-        const string fakeCmdPath = @"C:\fake\codex.cmd";
+        // 実体パスは環境変数経由で展開し、パスに含まれる cmd.exe メタ文字の再解釈を防ぐ
         (Mock<IProcessInstance> process, _) = CreateMockProcess(
             BuildStdout(_initializeResponseLine, $$"""{"id":2,"result":{{_sampleReadResultJson.Trim()}}}"""));
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => fakeCmdPath);
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => fakeScriptPath);
 
         RateLimitSnapshot? snapshot = await client.CaptureAsync("codex", CancellationToken.None);
 
         snapshot.Should().NotBeNull();
         runner.Verify(r => r.Start(It.Is<ProcessStartInfo>(p =>
             p.FileName.EndsWith("cmd.exe", StringComparison.OrdinalIgnoreCase)
-            && p.ArgumentList.SequenceEqual(new[] { "/c", fakeCmdPath, "app-server" }))), Times.Once);
+            && p.Arguments == "/d /s /c \"\"%SQUIRREL_NOTIFIER_CODEX_COMMAND%\" app-server\""
+            && p.Environment["SQUIRREL_NOTIFIER_CODEX_COMMAND"] == fakeScriptPath)), Times.Once);
     }
 
     [Fact]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/CodexAppServerRateLimitClientTests.cs
@@ -16,6 +16,7 @@ public class CodexAppServerRateLimitClientTests
     private static readonly DateTimeOffset _now = new(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
     private const long _resetsAtPrimary = 1783768226;
     private const long _resetsAtSecondary = 1784355026;
+    private const string _fakeExePath = @"C:\fake\codex.exe";
 
     private const string _initializeResponseLine = """{"id":1,"result":{"userAgent":"test"}}""";
 
@@ -137,7 +138,7 @@ public class CodexAppServerRateLimitClientTests
         string sentPayload = Encoding.UTF8.GetString(stdin.ToArray());
         sentPayload.Should().Contain("\"method\":\"initialize\"").And.Contain("squirrel-notifier");
         sentPayload.Should().Contain("\"method\":\"account/rateLimits/read\"");
-        runner.Verify(r => r.Start(It.Is<ProcessStartInfo>(p => p.FileName == "codex" && p.Arguments == "app-server")), Times.Once);
+        runner.Verify(r => r.Start(It.Is<ProcessStartInfo>(p => p.FileName == _fakeExePath && p.Arguments == "app-server")), Times.Once);
         process.Verify(p => p.Kill(true), Times.Once);
     }
 
@@ -187,7 +188,7 @@ public class CodexAppServerRateLimitClientTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
             .Throws(new System.ComponentModel.Win32Exception("codex not found"));
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
 
         RateLimitSnapshot? snapshot = await client.CaptureAsync("codex", CancellationToken.None);
 
@@ -201,7 +202,7 @@ public class CodexAppServerRateLimitClientTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
         CodexAppServerRateLimitClient client = new(
-            runner.Object, new FixedTimeProvider(_now), roundTripTimeout: TimeSpan.FromMilliseconds(200));
+            runner.Object, new FixedTimeProvider(_now), roundTripTimeout: TimeSpan.FromMilliseconds(200), commandResolver: _ => _fakeExePath);
 
         RateLimitSnapshot? snapshot = await client.CaptureAsync("codex", CancellationToken.None);
 
@@ -215,7 +216,7 @@ public class CodexAppServerRateLimitClientTests
         (Mock<IProcessInstance> process, _) = CreateMockProcess(stdoutStream: new BlockingStream());
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
         using CancellationTokenSource cts = new();
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
@@ -248,7 +249,7 @@ public class CodexAppServerRateLimitClientTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
             .Throws(new System.ComponentModel.Win32Exception(nativeErrorCode, "codex not found"));
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
 
         (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
             await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
@@ -258,13 +259,49 @@ public class CodexAppServerRateLimitClientTests
     }
 
     [Fact]
+    public async Task CaptureWithFailureReasonAsync_ShouldReturnCommandNotFound_WhenCommandResolverCannotFindCommand()
+    {
+        // PATH / PATHEXT を解決しても実体が見つからない場合（#177）。
+        // Process.Start は一切呼ばれず、resolver の時点で CommandNotFound と確定する
+        var runner = new Mock<IProcessRunner>();
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => null);
+
+        (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
+            await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
+
+        snapshot.Should().BeNull();
+        failureReason.Should().Be(CodexRateLimitFailureReason.CommandNotFound);
+        runner.Verify(r => r.Start(It.IsAny<ProcessStartInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_ShouldStartViaCmdExe_WhenCommandResolverReturnsShellScript()
+    {
+        // npm 経由でインストールされた codex は Windows 上では codex.cmd シムであることが多い（#177）。
+        // .cmd / .bat はネイティブ実行形式ではないため cmd.exe /c 経由で起動する
+        const string fakeCmdPath = @"C:\fake\codex.cmd";
+        (Mock<IProcessInstance> process, _) = CreateMockProcess(
+            BuildStdout(_initializeResponseLine, $$"""{"id":2,"result":{{_sampleReadResultJson.Trim()}}}"""));
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => fakeCmdPath);
+
+        RateLimitSnapshot? snapshot = await client.CaptureAsync("codex", CancellationToken.None);
+
+        snapshot.Should().NotBeNull();
+        runner.Verify(r => r.Start(It.Is<ProcessStartInfo>(p =>
+            p.FileName.EndsWith("cmd.exe", StringComparison.OrdinalIgnoreCase)
+            && p.ArgumentList.SequenceEqual(new[] { "/c", fakeCmdPath, "app-server" }))), Times.Once);
+    }
+
+    [Fact]
     public async Task CaptureWithFailureReasonAsync_ShouldReturnUnknown_WhenProcessStartFailsWithAccessDenied()
     {
         // ERROR_ACCESS_DENIED (5): コマンド自体は存在するため CommandNotFound と誤誘導しない
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
             .Throws(new System.ComponentModel.Win32Exception(5, "access denied"));
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
 
         (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
             await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
@@ -280,7 +317,7 @@ public class CodexAppServerRateLimitClientTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
         CodexAppServerRateLimitClient client = new(
-            runner.Object, new FixedTimeProvider(_now), roundTripTimeout: TimeSpan.FromMilliseconds(200));
+            runner.Object, new FixedTimeProvider(_now), roundTripTimeout: TimeSpan.FromMilliseconds(200), commandResolver: _ => _fakeExePath);
 
         (RateLimitSnapshot? snapshot, CodexRateLimitFailureReason? failureReason) =
             await client.CaptureWithFailureReasonAsync("codex", CancellationToken.None);
@@ -310,7 +347,7 @@ public class CodexAppServerRateLimitClientTests
         (Mock<IProcessInstance> process, _) = CreateMockProcess(stdoutStream: new BlockingStream());
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
-        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now));
+        CodexAppServerRateLimitClient client = new(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
         using CancellationTokenSource cts = new();
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
@@ -328,7 +365,7 @@ public class CodexAppServerRateLimitClientTests
     {
         runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
-        return new CodexAppServerRateLimitClient(runner.Object, new FixedTimeProvider(_now));
+        return new CodexAppServerRateLimitClient(runner.Object, new FixedTimeProvider(_now), commandResolver: _ => _fakeExePath);
     }
 
     private static (Mock<IProcessInstance> Process, MemoryStream StdinStream) CreateMockProcess(

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/RateLimitSnapshotServiceTests.cs
@@ -98,7 +98,7 @@ public class RateLimitSnapshotServiceTests : IDisposable
         runner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(process.Object);
         var service = new RateLimitSnapshotService(
             new RateLimitFileService(_settingsDirectory),
-            new CodexAppServerRateLimitClient(runner.Object));
+            new CodexAppServerRateLimitClient(runner.Object, commandResolver: _ => @"C:\fake\codex.exe"));
 
         RateLimitSnapshot? result = await service.CaptureAsync(RateLimitSnapshotService.CodexAgentId, CancellationToken.None);
 

--- a/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/App.xaml.cs
@@ -64,9 +64,12 @@ public partial class App : Application
         }
         catch (System.Runtime.InteropServices.COMException ex) when (ex.Message.Contains("Insights.Resource.dll", StringComparison.Ordinal))
         {
-            // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題（#169）。
-            // トースト通知が一切表示できなくなるため、MainWindow 側でトレイバルーンと
-            // InfoBar によるフォールバック通知を出す
+            // self-contained モードで Insights.Resource.dll が見つからない場合の既知の問題
+            // （#169、microsoft/WindowsAppSDK#6071。Microsoft 側の未解決バグ）。
+            // Register() はボタン操作（NotificationInvoked）の受信にのみ必要であり、
+            // AppNotificationManager.Show() によるトースト表示自体には影響しない。
+            // そのためトースト自体は引き続き表示されるが、ボタン操作に反応しない場合がある旨を
+            // MainWindow 側でトレイバルーンと InfoBar により案内する
             _notificationRegistrationFailed = true;
             _ = _loggingService.WriteAsync($"[WARN] AppNotificationManager.Register() 失敗（{ex.HResult:X8}）: {ex.Message}");
         }

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -28,8 +28,8 @@
                 </InfoBar.ActionButton>
             </InfoBar>
             <InfoBar x:Name="NotificationDisabledInfoBar"
-                     Title="トースト通知が無効です"
-                     Message="Windows のトースト通知を利用できません（MSI / セットアップ Zip の正規インストールでも発生することがあります）。イベントはアプリ内のイベント行でご確認ください。"
+                     Title="通知のボタン操作に反応しない場合があります"
+                     Message="Windows App SDK の既知の制約（MSI / セットアップ Zip の正規インストールでも発生することがあります）により、トースト通知は表示されても、ボタン操作（PRを開く・レビューする等）に反応しない場合があります。反応しない場合はアプリ内のイベント行またはトレイバルーン通知をご確認ください。"
                      Severity="Warning"
                      IsOpen="False"
                      IsClosable="True"

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -192,7 +192,9 @@ internal sealed partial class MainWindow : Window
 
         if (notificationRegistrationFailed)
         {
-            _trayIconService.ShowBalloonTip("Squirrel Notifier", "開発ビルドではトースト通知が無効です。イベントはアプリ内のイベント行でご確認ください。");
+            // Register() 失敗はボタン操作（NotificationInvoked）の受信にのみ影響し、
+            // トースト自体の表示（Show()）は妨げない（README「手動起動」節参照）
+            _trayIconService.ShowBalloonTip("Squirrel Notifier", "通知のボタン操作に反応しない場合があります。イベントはアプリ内のイベント行でご確認ください。");
         }
 
         // Hook window messages to process tray icon messages

--- a/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
@@ -47,6 +47,7 @@ internal sealed class CodexAppServerRateLimitClient
     // ERROR_ACCESS_DENIED 等はコマンド自体は存在するため Unknown 扱いにする）
     private const int _errorFileNotFound = 2;
     private const int _errorPathNotFound = 3;
+    private const string _resolvedCommandEnvironmentVariable = "SQUIRREL_NOTIFIER_CODEX_COMMAND";
     private static readonly TimeSpan _defaultRoundTripTimeout = TimeSpan.FromSeconds(15);
 
     private static readonly string[] _shellScriptExtensions = [".cmd", ".bat"];
@@ -252,9 +253,11 @@ internal sealed class CodexAppServerRateLimitClient
         if (_shellScriptExtensions.Contains(Path.GetExtension(resolvedPath), StringComparer.OrdinalIgnoreCase))
         {
             startInfo.FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
-            startInfo.ArgumentList.Add("/c");
-            startInfo.ArgumentList.Add(resolvedPath);
-            startInfo.ArgumentList.Add(_commandArguments);
+
+            // 値をコマンド文字列へ直接埋め込まず、環境変数を引用符内で一度だけ展開することで、
+            // パス内の cmd.exe メタ文字や環境変数形式の文字列が再解釈されるのを防ぐ
+            startInfo.Environment[_resolvedCommandEnvironmentVariable] = resolvedPath;
+            startInfo.Arguments = $"/d /s /c \"\"%{_resolvedCommandEnvironmentVariable}%\" {_commandArguments}\"";
         }
         else
         {

--- a/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/CodexAppServerRateLimitClient.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Diagnostics;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SquirrelNotifier.WinUI3.Models;
@@ -48,6 +49,8 @@ internal sealed class CodexAppServerRateLimitClient
     private const int _errorPathNotFound = 3;
     private static readonly TimeSpan _defaultRoundTripTimeout = TimeSpan.FromSeconds(15);
 
+    private static readonly string[] _shellScriptExtensions = [".cmd", ".bat"];
+
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -56,17 +59,53 @@ internal sealed class CodexAppServerRateLimitClient
     private readonly IProcessRunner _processRunner;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _roundTripTimeout;
+    private readonly Func<string, string?> _commandResolver;
 
     public CodexAppServerRateLimitClient(
         IProcessRunner processRunner,
         TimeProvider? timeProvider = null,
-        TimeSpan? roundTripTimeout = null)
+        TimeSpan? roundTripTimeout = null,
+        Func<string, string?>? commandResolver = null)
     {
         ArgumentNullException.ThrowIfNull(processRunner);
 
         _processRunner = processRunner;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _roundTripTimeout = roundTripTimeout ?? _defaultRoundTripTimeout;
+        _commandResolver = commandResolver ?? ResolveCommandFromEnvironment;
+    }
+
+    /// <summary>
+    /// PATH / PATHEXT を自前で解決し、コマンドの実体（フルパス）を探す。<see cref="Process.Start(ProcessStartInfo)"/>
+    /// が使う Win32 <c>CreateProcessW</c> は拡張子省略時に <c>.exe</c> のみを暗黙補完し、シェル側の機能である
+    /// PATHEXT 解決（<c>.cmd</c> / <c>.bat</c> 等）は行わない。npm 経由でインストールされた <c>codex</c> は
+    /// Windows 上では <c>codex.cmd</c> シムであることが多く、ターミナルでは実行できるのに本クライアントだけ
+    /// <c>ERROR_FILE_NOT_FOUND</c> になる問題（#177）を避けるため、シェルに頼らず明示的に解決する.
+    /// </summary>
+    private static string? ResolveCommandFromEnvironment(string command)
+    {
+        string? pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVariable))
+        {
+            return null;
+        }
+
+        string pathExtVariable = Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
+        string[] extensions = pathExtVariable.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (string directory in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (string extension in extensions)
+            {
+                string candidate = Path.Combine(directory.Trim(), command + extension);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
     }
 
     public async Task<RateLimitSnapshot?> CaptureAsync(string agentId, CancellationToken cancellationToken)
@@ -193,16 +232,35 @@ internal sealed class CodexAppServerRateLimitClient
         timeoutCts.CancelAfter(_roundTripTimeout);
         CancellationToken token = timeoutCts.Token;
 
+        string? resolvedPath = _commandResolver(_commandFileName);
+        if (resolvedPath is null)
+        {
+            throw new System.ComponentModel.Win32Exception(_errorFileNotFound, $"'{_commandFileName}' is not found in PATH");
+        }
+
         ProcessStartInfo startInfo = new()
         {
-            FileName = _commandFileName,
-            Arguments = _commandArguments,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+
+        // .cmd / .bat はネイティブ実行形式ではないため、CreateProcessW に直接渡すと
+        // ERROR_BAD_EXE_FORMAT 等で失敗する。cmd.exe にシェルスクリプトとしての実行を委ねる
+        if (_shellScriptExtensions.Contains(Path.GetExtension(resolvedPath), StringComparer.OrdinalIgnoreCase))
+        {
+            startInfo.FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add(resolvedPath);
+            startInfo.ArgumentList.Add(_commandArguments);
+        }
+        else
+        {
+            startInfo.FileName = resolvedPath;
+            startInfo.Arguments = _commandArguments;
+        }
 
         using IProcessInstance process = _processRunner.Start(startInfo);
         try


### PR DESCRIPTION
## Summary
- codex レートリミット取得が PATHEXT 非解決で `CommandNotFound` になる問題を修正（#177）。npm 経由の `codex.cmd` シム環境では Win32 `CreateProcessW` が拡張子省略時に `.exe` のみ暗黙補完するため、ターミナルでは実行できるのに `ERROR_FILE_NOT_FOUND` で失敗していた。PATH / PATHEXT を自前解決し、`.cmd` / `.bat` が見つかった場合は `cmd.exe /c` 経由で起動するようにした
- 「トースト通知が無効です」という警告文言の誤りを修正。`AppNotificationManager.Register()` の `Insights.Resource.dll` 読み込み失敗（#169、[microsoft/WindowsAppSDK#6071](https://github.com/microsoft/WindowsAppSDK/issues/6071) — Microsoft 側の self-contained 配布における既知の未解決バグ）はボタン操作（`NotificationInvoked`）の受信にのみ影響し、`Show()` によるトースト表示自体は妨げないことを実機ログで確認した。README・InfoBar・トレイバルーン通知の文言を実態に合わせて修正した

## Test plan
- [x] `dotnet build` / `dotnet test`（573件全成功、カバレッジ基準クリア）
- [x] pre-commit / pre-push フック（build, format, test with coverage）通過
- [x] 実機（MSI インストール版）で codex エージェントのレートリミット取得が成功することを確認（7日枠のみ正しく表示。5時間枠が撤廃されている場合に primary が無ければ表示しない実装通りの正しい挙動）
- [x] 実機でトースト通知のボタン操作を確認。`Register()` は引き続き `Insights.Resource.dll` 読み込み失敗で失敗する状態だが、トースト上の「レビューする」ボタンをクリックしたところ `NotificationInvoked` が正しく発火し、レビュー実行（`claude -p` → thread-owl 経由のレビュー投稿）まで一連で成功した。本 PR (#178) 自体に thread-owl の `APPROVED` verdict が実際に投稿されている

Refs #166, #177, #169, #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)