### PR TITLE
fix: agy launcher の print timeout を30分に延長

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `agy` launcher プリセットが CLI 内部の既定 `--print-timeout 5m` で終了し、squirrel-notifier の Launcher Timeout（既定30分）より先にレビューが失敗する問題を修正した（#180）。reviewer / reviewed の既定引数へ `--print-timeout 30m` を追加し、既存の未変更プリセットは一回限りの migration で更新する。カスタマイズ済みの command / arguments は変更しない
+
 ## [0.5.2] - 2026-07-14
 
 ### Fixed

--- a/docs/launcher-agent-presets.md
+++ b/docs/launcher-agent-presets.md
@@ -14,7 +14,7 @@ squirrel-notifier の launcher スロット（reviewer / reviewed）が扱うの
 |---|---|---|---|
 | `claude` | `claude` | `-p "/thread-owl-pr-reviewer ..."` のようなスキル呼び出し | `claude-code` |
 | `codex` | `codex` | `exec "..."` にプロンプト全文を埋め込み（スキル機構が無いため） | `codex`（レートリミット取得は対応待ち。[docs/statusline-integration.md](statusline-integration.md) 参照） |
-| `agy` | `agy` | `-p "..."` にプロンプト全文を埋め込み | `agy` |
+| `agy` | `agy` | `--print-timeout 30m -p "..."` にプロンプト全文を埋め込み | `agy` |
 | `copilot` | `copilot` | `-p "..."` にプロンプト全文を埋め込み | `null`（レートリミット取得手段が無い） |
 
 codex / agy / copilot はスキル呼び出し機構を持たないため、claude 版スキルが行う指示内容（thread-owl MCP のツールを使ったレビュー・対応フロー）をプロンプト全文としてテンプレートに埋め込んでいる。実際に動作させるには、当該エージェントが thread-owl の MCP ツールを利用できるよう接続設定済みであることが前提（前述の責務境界により、この接続設定自体は squirrel-notifier の対象外）。
@@ -24,6 +24,7 @@ codex / agy / copilot はスキル呼び出し機構を持たないため、clau
 - reviewer / reviewed 各スロットにプリセット選択 ComboBox を用意する。選択すると command / arguments が既定値で上書きされる
 - 選択後も command / arguments は自由編集できる。保存時（`LauncherAgentCatalog.ResolvePresetId`）に現在の command / arguments を各プリセットの既定値と突き合わせ、完全一致しなければ「カスタム」として扱う。プリセット選択 ComboBox はこの判定結果を表示するだけで、選択操作そのものを永続化するわけではない
 - 既存ユーザーの設定は `LauncherPresetsMigrated` フラグで一回だけ移行し、移行時点の command / arguments がどのプリセットと一致するかを判定して `ReviewerLauncherPresetId` / `ReviewedLauncherPresetId` に記録する
+- #180 より前の `agy` 既定引数は CLI 内部の print timeout が 5 分だったため、未変更の既定値だけを `AgyPrintTimeoutMigrated` で `--print-timeout 30m` 付きへ移行する。自由編集された command / arguments は変更しない
 
 ## rateLimitAgentId の解決
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
@@ -65,6 +65,8 @@ public class LauncherAgentCatalogTests
     [Theory]
     [InlineData("claude", "-p \"/thread-owl-pr-reviewer {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "claude")]
     [InlineData("claude", "-p \"/review-raven-thread-owl-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"", "reviewed", "claude")]
+    [InlineData("agy", "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "agy")]
+    [InlineData("agy", "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"", "reviewed", "agy")]
     [InlineData("claude", "--something-else", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     [InlineData("unknown-cmd", "unknown-args", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     public void ResolvePresetId_ShouldMatchExactCommandAndArguments(string command, string arguments, string roleName, string expectedPresetId)

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -644,6 +644,106 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
+    public void AgyPrintTimeoutMigration_ShouldRewriteLegacyDefaultArguments()
+    {
+        const string legacyReviewerArgs = "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+        const string legacyReviewedArgs = "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"";
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierAgyTimeoutMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "agy",
+            ReviewerLauncherArguments = legacyReviewerArgs,
+            ReviewedLauncherCommandPath = "agy",
+            ReviewedLauncherArguments = legacyReviewedArgs,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = false,
+            AgyPrintTimeoutMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+            LauncherAgentDefinition agy = LauncherAgentCatalog.Find("agy")!;
+
+            service.Settings.ReviewerLauncherArguments.Should().Be(agy.ReviewerArgumentsTemplate);
+            service.Settings.ReviewedLauncherArguments.Should().Be(agy.ReviewedArgumentsTemplate);
+            service.Settings.ReviewerLauncherPresetId.Should().Be("agy");
+            service.Settings.ReviewedLauncherPresetId.Should().Be("agy");
+            service.Settings.AgyPrintTimeoutMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("reviewer")]
+    [InlineData("reviewed")]
+    public void AgyPrintTimeoutMigration_ShouldNotRewriteCustomizedArguments(string roleName)
+    {
+        const string customArguments = "-p custom-args";
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierAgyTimeoutMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "agy",
+            ReviewerLauncherArguments = roleName == "reviewer" ? customArguments : "unused-reviewer-args",
+            ReviewedLauncherCommandPath = "agy",
+            ReviewedLauncherArguments = roleName == "reviewed" ? customArguments : "unused-reviewed-args",
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = true,
+            AgyPrintTimeoutMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            string actualArguments = roleName == "reviewer"
+                ? service.Settings.ReviewerLauncherArguments
+                : service.Settings.ReviewedLauncherArguments;
+            actualArguments.Should().Be(customArguments);
+            service.Settings.AgyPrintTimeoutMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void AgyPrintTimeoutMigration_ShouldSkipWhenAlreadyMigrated()
+    {
+        const string legacyArgs = "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierAgyTimeoutMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "agy",
+            ReviewerLauncherArguments = legacyArgs,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = true,
+            AgyPrintTimeoutMigrated = true,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            service.Settings.ReviewerLauncherArguments.Should().Be(legacyArgs);
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
     public void Settings_ShouldDefaultReviewedLauncherArgumentsToExistingSkillName()
     {
         new AppSettings().ReviewedLauncherArguments.Should().Contain("/review-raven-thread-owl-cycle");

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
@@ -90,8 +90,8 @@ internal static class LauncherAgentCatalog
             "agy",
             "agy (Antigravity CLI)",
             "agy",
-            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
-            "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
+            "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
             "agy"),
 
         new LauncherAgentDefinition(

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -82,6 +82,29 @@ internal sealed class SettingsService
             SaveSettings();
         }
 
+        // agy の print mode は launcher 側とは別に既定 5 分で timeout する（#180）。
+        // 旧プリセットと完全一致する未変更の設定だけを 30 分指定へ移行し、自由編集された値は保持する。
+        // 後続の LauncherPresetsMigrated 判定が新しいカタログ値と一致するよう、この migration は先に実行する.
+        if (!_settings.AgyPrintTimeoutMigrated)
+        {
+            const string legacyReviewerArguments = "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+            const string legacyReviewedArguments = "-p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"";
+            LauncherAgentDefinition agy = LauncherAgentCatalog.Find("agy")!;
+
+            if (_settings.ReviewerLauncherCommandPath == agy.Command && _settings.ReviewerLauncherArguments == legacyReviewerArguments)
+            {
+                _settings.ReviewerLauncherArguments = agy.ReviewerArgumentsTemplate;
+            }
+
+            if (_settings.ReviewedLauncherCommandPath == agy.Command && _settings.ReviewedLauncherArguments == legacyReviewedArguments)
+            {
+                _settings.ReviewedLauncherArguments = agy.ReviewedArgumentsTemplate;
+            }
+
+            _settings.AgyPrintTimeoutMigrated = true;
+            SaveSettings();
+        }
+
         // launcher スロットの command / arguments がどのエージェントプリセットと一致するかを
         // 一回だけ判定して記録する（#149）。一致しない場合は「カスタム」として扱う.
         if (!_settings.LauncherPresetsMigrated)
@@ -419,6 +442,9 @@ internal sealed class AppSettings
 
     // reviewed launcher 既定値のスキル名修正（#150）を既存ユーザーへ適用する一回限り migration のフラグ
     public bool ReviewedLauncherSkillMigrated { get; set; }
+
+    // agy の print timeout 修正（#180）を既存の未変更プリセットへ適用する一回限り migration のフラグ
+    public bool AgyPrintTimeoutMigrated { get; set; }
 
     // launcher スロットに選択されているエージェントプリセット ID（LauncherAgentCatalog 参照）。
     // 自由編集でどのプリセットとも一致しなくなった場合は LauncherAgentCatalog.CustomPresetId になる.


### PR DESCRIPTION
## 概要

`agy` launcher プリセットの print mode timeout を、CLI既定の5分から30分へ延長します。

Closes #180

## 原因

squirrel-notifier の `LauncherTimeoutMs` は既定30分ですが、`agy -p` は独立した `--print-timeout 5m` を持っています。thread-owl MCPを使うレビューが5分を超えると、launcher側の上限より先にagyが `ExitCode=1` で終了していました。

## 変更内容

- reviewer / reviewed のagyプリセットへ `--print-timeout 30m` を追加
- 旧プリセットと完全一致する既存設定だけを一回限りmigration
- カスタマイズ済みのcommand / argumentsは保持
- プリセット判定・migrationのテストを追加
- launcher presetドキュメントとCHANGELOGを更新

Claudeのstream-json対応はスコープを分離し、#187で追跡します。

## 影響

既定のagyプリセットを使うレビューは、squirrel-notifierの既定Launcher Timeoutと同じ30分まで実行できます。既存のカスタム設定は変更されません。

## 検証

- `dotnet format winui3/SquirrelNotifier.WinUI3.sln --verify-no-changes --no-restore`
- `dotnet build winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64 --no-restore`
- `dotnet test winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64 --no-restore`
  - 580 tests passed
  - line 92.41% / branch 86.58% / method 94.07%
- pre-commit hook: passed
- pre-push hook: passed
