### PR TITLE
fix: launcher の作業ディレクトリを明示する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- タスクスケジューラー等から launcher を起動した際に不定な current directory（例: `C:\Windows\System32`）を継承し、Codex の Git repository check や reviewed 側の checkout 操作が失敗する問題を修正した（#186）。reviewer は Settings 配下の専用 workspace、reviewed は Settings の `owner/repo=絶対パス` mapping で解決した Git checkout を明示的な `WorkingDirectory` として起動する。reviewed の mapping 不備・非 Git directory・システム／インストール先 directory はプロセス起動前に拒否する。Codex reviewer 既定引数には `--skip-git-repo-check` を追加し、未変更の旧既定値だけを一回限りで移行する。永続ログには実効 cwd・解決済み executable・実行形式・終了コードと、非ゼロ終了時のマスク済み stderr 要約を残す
 - `agy` launcher プリセットが CLI 内部の既定 `--print-timeout 5m` で終了し、squirrel-notifier の Launcher Timeout（既定30分）より先にレビューが失敗する問題を修正した（#180）。reviewer / reviewed の既定引数へ `--print-timeout 30m` を追加し、既存の未変更プリセットは一回限りの migration で更新する。カスタマイズ済みの command / arguments は変更しない
 
 ## [0.5.2] - 2026-07-14

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ uninstall.cmd -KeepSettings
 - **Gateway URL**: mcp-gateway のエンドポイントURL（例: http://localhost:3000）
 - **Resource URI**: 監視対象の MCP リソース URI（例: queue://review/queue）
 - **Timeout (ms)**: タイムアウトミリ秒（1〜300,000 ms）
+- **Checkout Mappings**: reviewed 側の「レビューに対応」で使う checkout を `owner/repo=C:\src\repo` 形式で1行に1件指定
+
+launcher の作業ディレクトリはロールごとに固定されます。「レビューする」（reviewer）は `%LocalAppData%\SquirrelNotifier\launcher-workspace\reviewer` から起動し、対象 checkout を直接操作しません。「レビューに対応」（reviewed）は Checkout Mappings に登録した Git checkout から起動します。mapping が未設定、存在しない、Git checkout ではない、または Windows／Program Files／アプリのインストール先を指す場合は、プロセスを起動せずエラーにします。タスクスケジューラーやアプリの起動元ディレクトリには依存しません。
+
+起動時の実効作業ディレクトリ、解決済み実行ファイル、実行形式、終了コードは `winui3.log` に記録されます。非ゼロ終了時は stderr の先頭3行（最大500文字）も、ANSI 制御文字の除去と既知の機密値マスキング後に記録されます。
 
 設定は `%LocalAppData%\SquirrelNotifier\settings.json` に保存されます。
 なお、認証トークンなどの機密情報は設定ファイルには保存せず、環境変数 `MCP_PROBE_AUTH_TOKEN` から子プロセスへ渡されます。

--- a/docs/launcher-agent-presets.md
+++ b/docs/launcher-agent-presets.md
@@ -13,7 +13,7 @@ squirrel-notifier の launcher スロット（reviewer / reviewed）が扱うの
 | プリセット ID | コマンド | 引数の方式 | rateLimitAgentId |
 |---|---|---|---|
 | `claude` | `claude` | `-p "/thread-owl-pr-reviewer ..."` のようなスキル呼び出し | `claude-code` |
-| `codex` | `codex` | `exec "..."` にプロンプト全文を埋め込み（スキル機構が無いため） | `codex`（レートリミット取得は対応待ち。[docs/statusline-integration.md](statusline-integration.md) 参照） |
+| `codex` | `codex` | reviewer は `exec --skip-git-repo-check "..."`、reviewed は `exec "..."` にプロンプト全文を埋め込み | `codex`（レートリミット取得は対応待ち。[docs/statusline-integration.md](statusline-integration.md) 参照） |
 | `agy` | `agy` | `--print-timeout 30m -p "..."` にプロンプト全文を埋め込み | `agy` |
 | `copilot` | `copilot` | `-p "..."` にプロンプト全文を埋め込み | `null`（レートリミット取得手段が無い） |
 
@@ -25,6 +25,15 @@ codex / agy / copilot はスキル呼び出し機構を持たないため、clau
 - 選択後も command / arguments は自由編集できる。保存時（`LauncherAgentCatalog.ResolvePresetId`）に現在の command / arguments を各プリセットの既定値と突き合わせ、完全一致しなければ「カスタム」として扱う。プリセット選択 ComboBox はこの判定結果を表示するだけで、選択操作そのものを永続化するわけではない
 - 既存ユーザーの設定は `LauncherPresetsMigrated` フラグで一回だけ移行し、移行時点の command / arguments がどのプリセットと一致するかを判定して `ReviewerLauncherPresetId` / `ReviewedLauncherPresetId` に記録する
 - #180 より前の `agy` 既定引数は CLI 内部の print timeout が 5 分だったため、未変更の既定値だけを `AgyPrintTimeoutMigrated` で `--print-timeout 30m` 付きへ移行する。自由編集された command / arguments は変更しない
+- reviewer は対象 checkout 外の専用ディレクトリから起動するため、#186 より前の Codex reviewer 既定引数だけを `CodexReviewerWorkingDirectoryMigrated` で `--skip-git-repo-check` 付きへ移行する。自由編集された command / arguments と reviewed 側は変更しない
+
+## 作業ディレクトリ契約
+
+- reviewer は Settings 保存先配下の `launcher-workspace/reviewer` を作成し、常にそこから起動する。対象 repository の checkout mapping は参照しない
+- reviewed は Settings の Checkout Mappings（`owner/repo=絶対パス`）から対象 repository の Git checkout を解決し、そこから起動する
+- reviewed の mapping が無い、パスが存在しない、`.git` を持たない、または Windows／Program Files／アプリのインストール先配下の場合は、launcher プロセスを起動する前に失敗する
+- `ProcessStartInfo.WorkingDirectory` を常に明示するため、タスクスケジューラー、ショートカット、親プロセスの current directory には依存しない
+- 実効 working directory、解決済み executable、executable kind、終了コードを永続ログへ記録する。非ゼロ終了時は stderr の先頭3行（最大500文字）をサニタイズ・マスクして要約記録する
 
 ## rateLimitAgentId の解決
 

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/RepositoryCheckoutMappingParserTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Helpers/RepositoryCheckoutMappingParserTests.cs
@@ -1,0 +1,54 @@
+// <copyright file="RepositoryCheckoutMappingParserTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Helpers;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Helpers;
+
+public class RepositoryCheckoutMappingParserTests
+{
+    [Fact]
+    public void Parse_ShouldReadMultipleMappingsAndIgnoreRepositoryCase()
+    {
+        string firstPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "checkout-a"));
+        string secondPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "checkout-b"));
+
+        Dictionary<string, string> mappings = RepositoryCheckoutMappingParser.Parse(
+            $"Owner/Repo={firstPath}{Environment.NewLine}{Environment.NewLine}other/repo={secondPath}");
+
+        mappings.Should().HaveCount(2);
+        mappings["owner/repo"].Should().Be(firstPath);
+        mappings["OTHER/REPO"].Should().Be(secondPath);
+    }
+
+    [Theory]
+    [InlineData("owner/repo")]
+    [InlineData("owner=C:\\src\\repo")]
+    [InlineData("owner/repo=relative-path")]
+    [InlineData("owner/repo=C:\\src\\one\nOWNER/REPO=C:\\src\\two")]
+    public void Parse_ShouldRejectInvalidMapping(string text)
+    {
+        Action act = () => RepositoryCheckoutMappingParser.Parse(text);
+
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Format_ShouldSortMappingsByRepository()
+    {
+        var mappings = new Dictionary<string, string>
+        {
+            ["z-owner/z-repo"] = @"C:\src\z",
+            ["a-owner/a-repo"] = @"C:\src\a",
+        };
+
+        RepositoryCheckoutMappingParser.Format(mappings).Should().Be(
+            $"a-owner/a-repo=C:\\src\\a{Environment.NewLine}z-owner/z-repo=C:\\src\\z");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Models/LauncherAgentCatalogTests.cs
@@ -67,6 +67,8 @@ public class LauncherAgentCatalogTests
     [InlineData("claude", "-p \"/review-raven-thread-owl-cycle {owner}/{repo}#{prNumber} のレビュー指摘に対応してください\"", "reviewed", "claude")]
     [InlineData("agy", "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "agy")]
     [InlineData("agy", "--print-timeout 30m -p \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"", "reviewed", "agy")]
+    [InlineData("codex", "exec --skip-git-repo-check \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"", "reviewer", "codex")]
+    [InlineData("codex", "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"", "reviewed", "codex")]
     [InlineData("claude", "--something-else", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     [InlineData("unknown-cmd", "unknown-args", "reviewer", LauncherAgentCatalog.CustomPresetId)]
     public void ResolvePresetId_ShouldMatchExactCommandAndArguments(string command, string arguments, string roleName, string expectedPresetId)

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/LauncherWorkingDirectoryResolverTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/LauncherWorkingDirectoryResolverTests.cs
@@ -1,0 +1,110 @@
+// <copyright file="LauncherWorkingDirectoryResolverTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class LauncherWorkingDirectoryResolverTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly SettingsService _settingsService;
+    private readonly LauncherWorkingDirectoryResolver _resolver;
+
+    public LauncherWorkingDirectoryResolverTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"LauncherWorkingDirectoryResolverTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+        _settingsService = new SettingsService(_tempDirectory, pnpmBinDir: string.Empty);
+        _resolver = new LauncherWorkingDirectoryResolver(_settingsService);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldCreateDedicatedReviewerDirectory()
+    {
+        string result = _resolver.Resolve(CreateReviewEvent(), LauncherRole.Reviewer);
+
+        result.Should().Be(Path.Combine(_tempDirectory, "launcher-workspace", "reviewer"));
+        Directory.Exists(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_ShouldReturnMappedGitCheckoutIgnoringRepositoryCase()
+    {
+        string checkout = CreateGitCheckout();
+        _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>
+        {
+            ["SCOTTLZ0310/SQUIRREL-NOTIFIER"] = checkout,
+        });
+
+        string result = _resolver.Resolve(CreateReviewEvent(), LauncherRole.Reviewed);
+
+        result.Should().Be(checkout);
+    }
+
+    [Fact]
+    public void Resolve_ShouldRejectMissingReviewedMapping()
+    {
+        Action act = () => _resolver.Resolve(CreateReviewEvent(), LauncherRole.Reviewed);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*checkout mapping*");
+    }
+
+    [Fact]
+    public void Resolve_ShouldRejectNonGitDirectory()
+    {
+        string checkout = Path.Combine(_tempDirectory, "not-git");
+        Directory.CreateDirectory(checkout);
+        ConfigureMapping(checkout);
+
+        Action act = () => _resolver.Resolve(CreateReviewEvent(), LauncherRole.Reviewed);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Git checkout*");
+    }
+
+    [Fact]
+    public void Resolve_ShouldRejectProtectedDirectory()
+    {
+        ConfigureMapping(AppContext.BaseDirectory);
+
+        Action act = () => _resolver.Resolve(CreateReviewEvent(), LauncherRole.Reviewed);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*システムまたはインストール先*");
+    }
+
+    private string CreateGitCheckout()
+    {
+        string checkout = Path.Combine(_tempDirectory, "checkout");
+        Directory.CreateDirectory(Path.Combine(checkout, ".git"));
+        return checkout;
+    }
+
+    private void ConfigureMapping(string path)
+    {
+        _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>
+        {
+            ["scottlz0310/squirrel-notifier"] = path,
+        });
+    }
+
+    private static ReviewEvent CreateReviewEvent() => new()
+    {
+        Repository = "scottlz0310/squirrel-notifier",
+        PrNumber = 186,
+    };
+}

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -182,9 +182,11 @@ public class ReviewLauncherServiceTests : IDisposable
 
         // Delay mock process to simulate execution time
         Mock<IProcessInstance> mockProcess = CreateMockProcess(0, "Pending...", "", delayMs: 5000);
+        var processStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var mockRunner = new Mock<IProcessRunner>();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback(() => processStarted.SetResult())
             .Returns(mockProcess.Object);
 
         var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
@@ -193,7 +195,7 @@ public class ReviewLauncherServiceTests : IDisposable
         // Act
         Task<LauncherResult> launchTask = service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, cts.Token);
 
-        await Task.Delay(100);
+        await processStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         cts.Cancel();
 
         LauncherResult result = await launchTask;

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using SquirrelNotifier.WinUI3.Helpers;
 using SquirrelNotifier.WinUI3.Models;
 using SquirrelNotifier.WinUI3.Services;
 using Xunit;
@@ -76,6 +77,13 @@ public class ReviewLauncherServiceTests : IDisposable
             reviewedCmd, reviewedArgs,
             timeoutMs,
             "custom", "custom");
+
+        string checkoutPath = Path.Combine(_tempDir, "checkouts", "squirrel-notifier");
+        Directory.CreateDirectory(Path.Combine(checkoutPath, ".git"));
+        _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>
+        {
+            ["scottlz0310/squirrel-notifier"] = checkoutPath,
+        });
     }
 
     [Fact]
@@ -115,6 +123,8 @@ public class ReviewLauncherServiceTests : IDisposable
         capturedPsi.Should().NotBeNull();
         capturedPsi!.FileName.Should().Contain("launcher-cmd");
         capturedPsi.ArgumentList.Should().Contain("--launcher-arg");
+        capturedPsi.WorkingDirectory.Should().Be(Path.Combine(_tempDir, "launcher-workspace", "reviewer"));
+        Directory.Exists(capturedPsi.WorkingDirectory).Should().BeTrue();
         mockProcess.Verify(p => p.Dispose(), Times.Once);
     }
 
@@ -264,6 +274,53 @@ public class ReviewLauncherServiceTests : IDisposable
         // Assert
         capturedPsi.Should().NotBeNull();
         capturedPsi!.FileName.Should().Contain(expectedCmd);
+        string expectedWorkingDirectory = role == LauncherRole.Reviewer
+            ? Path.Combine(_tempDir, "launcher-workspace", "reviewer")
+            : Path.Combine(_tempDir, "checkouts", "squirrel-notifier");
+        capturedPsi.WorkingDirectory.Should().Be(expectedWorkingDirectory);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldFailBeforeStartingProcess_WhenReviewedCheckoutMappingIsMissing()
+    {
+        ReviewEvent reviewEvent = CreateReviewEvent("missing-checkout");
+        ConfigureSettings();
+        _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>());
+        var mockRunner = new Mock<IProcessRunner>();
+        var service = new ReviewLauncherService(_settingsService, _loggingService, mockRunner.Object);
+
+        LauncherResult result = await service.LaunchAsync(reviewEvent, LauncherRole.Reviewed, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("checkout mapping");
+        mockRunner.Verify(r => r.Start(It.IsAny<ProcessStartInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LaunchAsync_ShouldPersistMaskedFailureDiagnostics()
+    {
+        const string secret = "diagnostic-secret-value";
+        ReviewEvent reviewEvent = CreateReviewEvent("failed-diagnostics");
+        ConfigureSettings();
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(17, string.Empty, $"first failure {secret}\nsecond failure");
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+        var service = new ReviewLauncherService(
+            _settingsService,
+            _loggingService,
+            mockRunner.Object,
+            secretMasker: new SecretMasker([secret]));
+
+        LauncherResult result = await service.LaunchAsync(reviewEvent, LauncherRole.Reviewer, CancellationToken.None);
+        string log = await File.ReadAllTextAsync(Path.Combine(_tempDir, "winui3.log"));
+
+        result.Success.Should().BeFalse();
+        log.Should().Contain("ExitCode=17");
+        log.Should().Contain($"WorkingDirectory={Path.Combine(_tempDir, "launcher-workspace", "reviewer")}");
+        log.Should().Contain("ResolvedExecutable=");
+        log.Should().Contain("ExecutableKind=");
+        log.Should().Contain("first failure *** | second failure");
+        log.Should().NotContain(secret);
     }
 
     [Theory]

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/SettingsServiceTests.cs
@@ -744,6 +744,93 @@ public class SettingsServiceTests : IDisposable
     }
 
     [Fact]
+    public void CodexReviewerWorkingDirectoryMigration_ShouldRewriteLegacyDefaultArguments()
+    {
+        const string legacyArgs = "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierCodexWorkingDirectoryMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = "codex",
+            ReviewerLauncherArguments = legacyArgs,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = false,
+            CodexReviewerWorkingDirectoryMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            service.Settings.ReviewerLauncherArguments.Should().Be(
+                LauncherAgentCatalog.Find("codex")!.ReviewerArgumentsTemplate);
+            service.Settings.ReviewerLauncherPresetId.Should().Be("codex");
+            service.Settings.CodexReviewerWorkingDirectoryMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("custom-command", "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"")]
+    [InlineData("codex", "exec custom-arguments")]
+    public void CodexReviewerWorkingDirectoryMigration_ShouldNotRewriteCustomizedSettings(string command, string arguments)
+    {
+        string settingsDir = Path.Combine(Path.GetTempPath(), $"SquirrelNotifierCodexWorkingDirectoryMigrationTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(settingsDir);
+        var seed = new AppSettings
+        {
+            ReviewerLauncherCommandPath = command,
+            ReviewerLauncherArguments = arguments,
+            LauncherSlotsMigrated = true,
+            LauncherPresetsMigrated = true,
+            CodexReviewerWorkingDirectoryMigrated = false,
+        };
+        File.WriteAllText(Path.Combine(settingsDir, "settings.json"), System.Text.Json.JsonSerializer.Serialize(seed));
+
+        try
+        {
+            var service = new SettingsService(settingsDir, pnpmBinDir: string.Empty);
+
+            service.Settings.ReviewerLauncherCommandPath.Should().Be(command);
+            service.Settings.ReviewerLauncherArguments.Should().Be(arguments);
+            service.Settings.CodexReviewerWorkingDirectoryMigrated.Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(settingsDir, true);
+        }
+    }
+
+    [Fact]
+    public void UpdateRepositoryCheckoutMappings_ShouldPersistAndResolveIgnoringRepositoryCase()
+    {
+        string checkout = Path.Combine(_settingsDirectory, "checkout");
+        _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>
+        {
+            ["Owner/Repo"] = checkout,
+        });
+
+        var reloaded = new SettingsService(_settingsDirectory, pnpmBinDir: string.Empty);
+
+        reloaded.ResolveRepositoryCheckoutPath("owner/repo").Should().Be(Path.GetFullPath(checkout));
+    }
+
+    [Fact]
+    public void UpdateRepositoryCheckoutMappings_ShouldRejectRelativePath()
+    {
+        Action act = () => _settingsService.UpdateRepositoryCheckoutMappings(new Dictionary<string, string>
+        {
+            ["owner/repo"] = "relative-path",
+        });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
     public void Settings_ShouldDefaultReviewedLauncherArgumentsToExistingSkillName()
     {
         new AppSettings().ReviewedLauncherArguments.Should().Contain("/review-raven-thread-owl-cycle");

--- a/winui3/SquirrelNotifier.WinUI3/Helpers/RepositoryCheckoutMappingParser.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Helpers/RepositoryCheckoutMappingParser.cs
@@ -1,0 +1,65 @@
+// <copyright file="RepositoryCheckoutMappingParser.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SquirrelNotifier.WinUI3.Helpers;
+
+/// <summary>
+/// Settings UI の <c>owner/repo=絶対パス</c> 形式と永続設定の対応表を相互変換する（#186）.
+/// </summary>
+internal static class RepositoryCheckoutMappingParser
+{
+    private static readonly char[] _lineSeparators = ['\r', '\n'];
+
+    public static Dictionary<string, string> Parse(string text)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string line in text.Split(_lineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int separatorIndex = line.IndexOf('=', StringComparison.Ordinal);
+            if (separatorIndex <= 0 || separatorIndex == line.Length - 1)
+            {
+                throw new FormatException("Checkout mapping は owner/repo=絶対パス の形式で入力してください。");
+            }
+
+            string repository = line[..separatorIndex].Trim();
+            string path = line[(separatorIndex + 1)..].Trim();
+            if (!IsValidRepository(repository))
+            {
+                throw new FormatException($"Repository '{repository}' は owner/repo の形式ではありません。");
+            }
+
+            if (!Path.IsPathFullyQualified(path))
+            {
+                throw new FormatException($"Repository '{repository}' の checkout path は絶対パスで指定してください。");
+            }
+
+            if (!result.TryAdd(repository, Path.GetFullPath(path)))
+            {
+                throw new FormatException($"Repository '{repository}' が重複しています。");
+            }
+        }
+
+        return result;
+    }
+
+    public static string Format(IReadOnlyDictionary<string, string> mappings)
+    {
+        ArgumentNullException.ThrowIfNull(mappings);
+        return string.Join(Environment.NewLine, mappings
+            .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(static pair => $"{pair.Key}={pair.Value}"));
+    }
+
+    private static bool IsValidRepository(string repository)
+    {
+        string[] parts = repository.Split('/');
+        return parts.Length == 2 && parts.All(static part =>
+            !string.IsNullOrWhiteSpace(part)
+            && part.All(static c => char.IsLetterOrDigit(c) || c is '-' or '_' or '.'));
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml
@@ -51,7 +51,7 @@
                   HorizontalAlignment="Stretch"
                   HorizontalContentAlignment="Stretch">
             <ScrollViewer MaxHeight="240">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       ColumnDefinitions="Auto,*"
                       RowSpacing="8"
                       ColumnSpacing="8"
@@ -108,21 +108,29 @@
                     <TextBlock Grid.Row="10" Grid.Column="0" Text="Reviewed Args:" VerticalAlignment="Center"/>
                     <TextBox Grid.Row="10" Grid.Column="1" x:Name="ReviewedArgumentsBox" TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
-                    <NumberBox Grid.Row="11" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="7200000" ValueChanged="OnTimeoutChanged"/>
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Checkout Mappings:" VerticalAlignment="Top" Margin="0,4,0,0"/>
+                    <TextBox Grid.Row="11" Grid.Column="1" x:Name="RepositoryCheckoutMappingsBox"
+                             AcceptsReturn="True"
+                             Height="60"
+                             TextWrapping="NoWrap"
+                             PlaceholderText="owner/repo=C:\src\repo（1行に1件）"
+                             TextChanged="OnSettingChanged"/>
 
-                    <TextBlock Grid.Row="12" Grid.Column="0" Text="ライブログ自動クローズ:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="12" Grid.Column="1" x:Name="LiveLogAutoCloseToggle"
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Launcher Timeout:" VerticalAlignment="Center"/>
+                    <NumberBox Grid.Row="12" Grid.Column="1" x:Name="LauncherTimeoutBox" Minimum="1" Maximum="7200000" ValueChanged="OnTimeoutChanged"/>
+
+                    <TextBlock Grid.Row="13" Grid.Column="0" Text="ライブログ自動クローズ:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="13" Grid.Column="1" x:Name="LiveLogAutoCloseToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnLiveLogAutoCloseToggled"/>
 
-                    <TextBlock Grid.Row="13" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
-                    <ToggleSwitch Grid.Row="13" Grid.Column="1" x:Name="AutoStartToggle"
+                    <TextBlock Grid.Row="14" Grid.Column="0" Text="自動起動:" VerticalAlignment="Center"/>
+                    <ToggleSwitch Grid.Row="14" Grid.Column="1" x:Name="AutoStartToggle"
                                   OnContent="有効" OffContent="無効"
                                   Toggled="OnAutoStartToggled"/>
 
-                    <TextBlock Grid.Row="14" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
-                    <StackPanel Grid.Row="14" Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                    <TextBlock Grid.Row="15" Grid.Column="0" Text="タスク状態:" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="15" Grid.Column="1" Orientation="Horizontal" Spacing="8">
                         <TextBlock x:Name="AutoStartStatusText" VerticalAlignment="Center" Text="確認中..."/>
                         <Button x:Name="RepairAutoStartButton" Content="修復" Click="OnRepairAutoStartClick" IsEnabled="False"/>
                     </StackPanel>

--- a/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/MainWindow.xaml.cs
@@ -158,6 +158,7 @@ internal sealed partial class MainWindow : Window
         ReviewerArgumentsBox.Text = settings.ReviewerLauncherArguments;
         ReviewedPathBox.Text = settings.ReviewedLauncherCommandPath;
         ReviewedArgumentsBox.Text = settings.ReviewedLauncherArguments;
+        RepositoryCheckoutMappingsBox.Text = Helpers.RepositoryCheckoutMappingParser.Format(settings.RepositoryCheckoutMappings);
         LauncherTimeoutBox.Value = settings.LauncherTimeoutMs;
         LiveLogAutoCloseToggle.IsOn = settings.LiveLogAutoCloseEnabled;
 
@@ -1000,6 +1001,8 @@ internal sealed partial class MainWindow : Window
             string reviewerArguments = ReviewerArgumentsBox.Text;
             string reviewedPath = ReviewedPathBox.Text;
             string reviewedArguments = ReviewedArgumentsBox.Text;
+            Dictionary<string, string> repositoryCheckoutMappings =
+                Helpers.RepositoryCheckoutMappingParser.Parse(RepositoryCheckoutMappingsBox.Text);
             int launcherTimeoutMs = double.IsNaN(LauncherTimeoutBox.Value) ? 1800000 : (int)LauncherTimeoutBox.Value;
 
             string reviewerPresetId = Models.LauncherAgentCatalog.ResolvePresetId(reviewerPath, reviewerArguments, Models.LauncherRole.Reviewer);
@@ -1020,6 +1023,7 @@ internal sealed partial class MainWindow : Window
                 launcherTimeoutMs,
                 reviewerPresetId,
                 reviewedPresetId);
+            _settingsService.UpdateRepositoryCheckoutMappings(repositoryCheckoutMappings);
         }
         catch
         {

--- a/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/LauncherAgentDefinition.cs
@@ -82,7 +82,7 @@ internal static class LauncherAgentCatalog
             "codex",
             "codex",
             "codex",
-            "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
+            "exec --skip-git-repo-check \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"",
             "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} のレビュー指摘に対応し、修正・返信・resolve を行ってください\"",
             "codex"),
 

--- a/winui3/SquirrelNotifier.WinUI3/Services/LauncherWorkingDirectoryResolver.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/LauncherWorkingDirectoryResolver.cs
@@ -1,0 +1,83 @@
+// <copyright file="LauncherWorkingDirectoryResolver.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// launcher role ごとの作業ディレクトリ契約を解決する（#186）.
+/// </summary>
+internal sealed class LauncherWorkingDirectoryResolver
+{
+    private readonly SettingsService _settingsService;
+
+    public LauncherWorkingDirectoryResolver(SettingsService settingsService)
+    {
+        ArgumentNullException.ThrowIfNull(settingsService);
+        _settingsService = settingsService;
+    }
+
+    public string Resolve(ReviewEvent reviewEvent, LauncherRole role)
+    {
+        ArgumentNullException.ThrowIfNull(reviewEvent);
+
+        if (role == LauncherRole.Reviewer)
+        {
+            string reviewerDirectory = Path.Combine(_settingsService.SettingsDirectory, "launcher-workspace", "reviewer");
+            Directory.CreateDirectory(reviewerDirectory);
+            return Path.GetFullPath(reviewerDirectory);
+        }
+
+        string? configuredPath = _settingsService.ResolveRepositoryCheckoutPath(reviewEvent.Repository);
+        if (configuredPath is null)
+        {
+            throw new InvalidOperationException(
+                $"{reviewEvent.Repository} のローカル checkout mapping がありません。Settings の Checkout Mappings に owner/repo=絶対パス を設定してください。");
+        }
+
+        string fullPath = Path.GetFullPath(configuredPath);
+        if (!Directory.Exists(fullPath))
+        {
+            throw new InvalidOperationException($"{reviewEvent.Repository} の checkout directory が存在しません: {fullPath}");
+        }
+
+        if (IsProtectedDirectory(fullPath))
+        {
+            throw new InvalidOperationException($"システムまたはインストール先ディレクトリは checkout mapping に使用できません: {fullPath}");
+        }
+
+        string gitMarker = Path.Combine(fullPath, ".git");
+        if (!Directory.Exists(gitMarker) && !File.Exists(gitMarker))
+        {
+            throw new InvalidOperationException($"{reviewEvent.Repository} の mapping は Git checkout ではありません: {fullPath}");
+        }
+
+        return fullPath;
+    }
+
+    private static bool IsProtectedDirectory(string path)
+    {
+        string[] protectedRoots =
+        [
+            Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            AppContext.BaseDirectory,
+        ];
+
+        return protectedRoots
+            .Where(static root => !string.IsNullOrWhiteSpace(root))
+            .Any(root => IsSameOrDescendant(path, root));
+    }
+
+    private static bool IsSameOrDescendant(string path, string root)
+    {
+        string relativePath = Path.GetRelativePath(Path.GetFullPath(root), Path.GetFullPath(path));
+        return relativePath == "."
+            || (!relativePath.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && relativePath != ".."
+                && !Path.IsPathFullyQualified(relativePath));
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/ReviewLauncherService.cs
@@ -19,6 +19,8 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
     private readonly LoggingService _loggingService;
     private readonly IProcessRunner _processRunner;
     private readonly TimeProvider _timeProvider;
+    private readonly LauncherWorkingDirectoryResolver _workingDirectoryResolver;
+    private readonly SecretMasker _secretMasker;
     private readonly object _lock = new();
 
     private bool _isRunning;
@@ -41,12 +43,16 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
         SettingsService settingsService,
         LoggingService loggingService,
         IProcessRunner? processRunner = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        LauncherWorkingDirectoryResolver? workingDirectoryResolver = null,
+        SecretMasker? secretMasker = null)
     {
         _settingsService = settingsService;
         _loggingService = loggingService;
         _processRunner = processRunner ?? new ProcessRunner();
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _workingDirectoryResolver = workingDirectoryResolver ?? new LauncherWorkingDirectoryResolver(settingsService);
+        _secretMasker = secretMasker ?? SecretMasker.CreateDefault();
     }
 
     public async Task<LauncherResult> LaunchAsync(ReviewEvent reviewEvent, LauncherRole role, CancellationToken cancellationToken)
@@ -153,9 +159,12 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
                 throw new InvalidOperationException("Launcher command path is empty or invalid.");
             }
 
+            string workingDirectory = _workingDirectoryResolver.Resolve(reviewEvent, role);
+
             var psi = new ProcessStartInfo
             {
                 FileName = resolvedPath,
+                WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
@@ -172,7 +181,16 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
                 psi.ArgumentList.Add(arg);
             }
 
-            await LogAsync($"Launching: {commandPath} with safe arguments").ConfigureAwait(false);
+            string executableKind = Path.GetExtension(resolvedPath).ToUpperInvariant() switch
+            {
+                ".CMD" => "cmd",
+                ".BAT" => "bat",
+                ".PS1" => "powershell-script",
+                _ => "native",
+            };
+            await LogAsync(
+                $"Launching: {commandPath} with safe arguments. WorkingDirectory={workingDirectory}; ResolvedExecutable={resolvedPath}; ExecutableKind={executableKind}")
+                .ConfigureAwait(false);
 
             lock (_lock)
             {
@@ -198,7 +216,11 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
 
             int exitCode = _activeProcess.ExitCode;
 
-            await LogAsync($"Review process finished. ExitCode={exitCode}").ConfigureAwait(false);
+            await LogAsync($"Review process finished. ExitCode={exitCode}; WorkingDirectory={workingDirectory}").ConfigureAwait(false);
+            if (exitCode != 0 && !string.IsNullOrWhiteSpace(stderr))
+            {
+                await LogAsync($"Review process stderr summary: {BuildStderrSummary(stderr)}").ConfigureAwait(false);
+            }
 
             session.Complete(
                 exitCode == 0 ? AgentExecutionOutcome.Succeeded : AgentExecutionOutcome.Failed,
@@ -318,6 +340,16 @@ internal sealed class ReviewLauncherService : IReviewLauncherService
             {
             }
         }
+    }
+
+    private string BuildStderrSummary(string stderr)
+    {
+        const int maxLength = 500;
+        string summary = string.Join(" | ", stderr
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Take(3)
+            .Select(line => _secretMasker.Mask(AnsiControlSanitizer.Sanitize(line))));
+        return summary.Length <= maxLength ? summary : summary[..maxLength];
     }
 
     // スロットはユーザーが押したアクションのロールだけで決まる（#127）

--- a/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/SettingsService.cs
@@ -105,6 +105,21 @@ internal sealed class SettingsService
             SaveSettings();
         }
 
+        // reviewer は対象 checkout を直接操作せず専用ディレクトリから起動するため、Codex の
+        // Git repository check を明示的に無効化する（#186）。旧プリセットと完全一致する設定のみ移行する.
+        if (!_settings.CodexReviewerWorkingDirectoryMigrated)
+        {
+            const string legacyReviewerArguments = "exec \"thread-owl MCP のツールを使って {owner}/{repo}#{prNumber} を {reason} モードでレビューしてください\"";
+            LauncherAgentDefinition codex = LauncherAgentCatalog.Find("codex")!;
+            if (_settings.ReviewerLauncherCommandPath == codex.Command && _settings.ReviewerLauncherArguments == legacyReviewerArguments)
+            {
+                _settings.ReviewerLauncherArguments = codex.ReviewerArgumentsTemplate;
+            }
+
+            _settings.CodexReviewerWorkingDirectoryMigrated = true;
+            SaveSettings();
+        }
+
         // launcher スロットの command / arguments がどのエージェントプリセットと一致するかを
         // 一回だけ判定して記録する（#149）。一致しない場合は「カスタム」として扱う.
         if (!_settings.LauncherPresetsMigrated)
@@ -329,6 +344,32 @@ internal sealed class SettingsService
         return LauncherAgentCatalog.Find(presetId)?.ProgressEventSupport ?? ProgressEventSupport.None;
     }
 
+    public string? ResolveRepositoryCheckoutPath(string repository)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repository);
+        return _settings.RepositoryCheckoutMappings
+            .FirstOrDefault(pair => string.Equals(pair.Key, repository, StringComparison.OrdinalIgnoreCase))
+            .Value;
+    }
+
+    public void UpdateRepositoryCheckoutMappings(IReadOnlyDictionary<string, string> mappings)
+    {
+        ArgumentNullException.ThrowIfNull(mappings);
+        var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach ((string repository, string path) in mappings)
+        {
+            if (string.IsNullOrWhiteSpace(repository) || string.IsNullOrWhiteSpace(path) || !Path.IsPathFullyQualified(path))
+            {
+                throw new ArgumentException("Repository checkout mapping には owner/repo と絶対パスが必要です。", nameof(mappings));
+            }
+
+            normalized.Add(repository, Path.GetFullPath(path));
+        }
+
+        _settings.RepositoryCheckoutMappings = normalized;
+        SaveSettings();
+    }
+
     public void UpdateSettings(
         string commandPath,
         string arguments,
@@ -446,6 +487,9 @@ internal sealed class AppSettings
     // agy の print timeout 修正（#180）を既存の未変更プリセットへ適用する一回限り migration のフラグ
     public bool AgyPrintTimeoutMigrated { get; set; }
 
+    // Codex reviewer の専用 working directory 対応（#186）を既存の未変更プリセットへ適用する migration
+    public bool CodexReviewerWorkingDirectoryMigrated { get; set; }
+
     // launcher スロットに選択されているエージェントプリセット ID（LauncherAgentCatalog 参照）。
     // 自由編集でどのプリセットとも一致しなくなった場合は LauncherAgentCatalog.CustomPresetId になる.
     public string ReviewerLauncherPresetId { get; set; } = "claude";
@@ -453,6 +497,9 @@ internal sealed class AppSettings
     public string ReviewedLauncherPresetId { get; set; } = "claude";
 
     public bool LauncherPresetsMigrated { get; set; }
+
+    // reviewed-side launcher が対象 repository の checkout を一意に解決するための明示 mapping（#186）
+    public Dictionary<string, string> RepositoryCheckoutMappings { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     // 長時間のレビューサイクル（30 分超もありうる）を 5 分で強制終了しないよう既定 30 分（#143）
     public int LauncherTimeoutMs { get; set; } = 1800000;


### PR DESCRIPTION
## 概要

ISSUE #186 のうち、AI エージェント起動時の作業ディレクトリ契約と永続診断を先行して修正します。

タスクスケジューラーから起動した Squirrel Notifier が `C:\Windows\System32` を launcher へ継承し、Codex が Git 信頼チェックで即時終了する問題を解消します。

Part of #186

## 変更内容

- reviewer は Settings 保存先配下の専用 workspace を明示的な `WorkingDirectory` として使用
- reviewed は `owner/repo=絶対パス` mapping で対象 Git checkout を解決し、解決不能・非 Git・システム領域の場合はプロセス起動前に拒否
- Codex reviewer の既定引数へ `--skip-git-repo-check` を追加し、未変更の旧既定値のみ一回限りで移行
- Settings UI に Checkout Mappings を追加
- 実効 cwd、解決済み executable、実行形式、終了コード、マスク済み stderr 要約を永続ログへ記録
- mapping parser、resolver、起動前拒否、診断マスキング、migration の回帰テストを追加
- README、launcher preset 仕様、CHANGELOG を更新

## 原因

`ReviewLauncherService` が `ProcessStartInfo.WorkingDirectory` を設定しておらず、親プロセスの current directory に依存していました。タスクスケジューラー起動では System32 が継承されるため、Codex は Git repository check で終了し、他のエージェントも誤ったディレクトリを処理基点にしていました。

## 影響

- reviewer は対象 checkout を直接操作せず、安全な専用 workspace から安定して起動します
- reviewed は対象 checkout が明示設定されていない限り起動しないため、誤ったディレクトリへの Git 操作を防ぎます
- 非ゼロ終了時の原因をライブログ終了後も `winui3.log` から確認できます

## このPRに含めないもの

- PATH / PATHEXT 解決と `.cmd` / `.bat` の共通 process policy
- #184 で追跡している Windows 実機 E2E

これらは ISSUE #186 の残タスクとして後続PRで扱います。

## 検証

- `dotnet format winui3/SquirrelNotifier.WinUI3.sln --verify-no-changes --no-restore`
- `dotnet build winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64 --no-restore`
- `dotnet test winui3/SquirrelNotifier.WinUI3.sln -c Release -p:Platform=x64 --no-restore --no-build`
  - 600 tests passed
  - Line 93.36% / Branch 86.19% / Method 94.49%
- pre-commit: build / format / quality-security 成功
- pre-push: tests with coverage 成功
