### PR TITLE
test: stabilize launcher cancellation test

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.301",
+        "version": "10.0.302",
         "rollForward": "latestMinor"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.302",
+        "version": "10.0.301",
         "rollForward": "latestMinor"
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -499,7 +499,8 @@ public class ReviewLauncherServiceTests : IDisposable
     {
         // Arrange: Kill のコールバックがパイプを閉じるため、writer 側の後始末は不要
         ConfigureSettings();
-        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _);
+        var processStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _, processStarted);
 
         var mockRunner = new Mock<IProcessRunner>();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
@@ -509,7 +510,7 @@ public class ReviewLauncherServiceTests : IDisposable
 
         // Act
         AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-cancel"), LauncherRole.Reviewer, cts.Token);
-        await Task.Delay(100);
+        await processStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
         cts.Cancel();
 
         LauncherResult result = await session.Completion;

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/ReviewLauncherServiceTests.cs
@@ -406,7 +406,10 @@ public class ReviewLauncherServiceTests : IDisposable
 
     // stdout を実行中に逐次供給できる mock process。実プロセス同様、Kill でパイプが閉じて
     // 読み取り側が EOF / IOException で終了する挙動を再現する.
-    private Mock<IProcessInstance> CreatePipeMockProcess(out StreamWriter stdoutWriter, out TaskCompletionSource exitTcs)
+    private Mock<IProcessInstance> CreatePipeMockProcess(
+        out StreamWriter stdoutWriter,
+        out TaskCompletionSource exitTcs,
+        TaskCompletionSource? processStarted = null)
     {
         var server = new AnonymousPipeServerStream(PipeDirection.Out);
         var client = new AnonymousPipeClientStream(PipeDirection.In, server.ClientSafePipeHandle);
@@ -421,7 +424,11 @@ public class ReviewLauncherServiceTests : IDisposable
         mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream()));
         mockProcess.SetupGet(p => p.StandardInput).Returns(new StreamWriter(new MemoryStream()));
         mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
-            .Returns((CancellationToken t) => tcs.Task.WaitAsync(t));
+            .Returns((CancellationToken t) =>
+            {
+                processStarted?.TrySetResult();
+                return tcs.Task.WaitAsync(t);
+            });
         mockProcess.Setup(p => p.Kill(It.IsAny<bool>())).Callback(server.Dispose);
         return mockProcess;
     }
@@ -528,7 +535,8 @@ public class ReviewLauncherServiceTests : IDisposable
         // Arrange: Cancel() は内部 CTS のみを cancel し、呼び出し元トークンは cancel されない経路。
         // timeout（TimedOut）に誤分類されないことを固定する（#143 レビュー対応）
         ConfigureSettings();
-        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _);
+        var processStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Mock<IProcessInstance> mockProcess = CreatePipeMockProcess(out _, out _, processStarted);
 
         var mockRunner = new Mock<IProcessRunner>();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
@@ -537,7 +545,7 @@ public class ReviewLauncherServiceTests : IDisposable
 
         // Act
         AgentExecutionSession session = service.StartSession(CreateReviewEvent("test-stream-cancel-method"), LauncherRole.Reviewer, CancellationToken.None);
-        await Task.Delay(100);
+        await processStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
         service.Cancel();
 
         LauncherResult result = await session.Completion;


### PR DESCRIPTION
## 概要
PR #190 の CI で検出された、レビューランチャーのキャンセルテストのタイミング依存を修正します。

## 根本原因
`StartSession_ShouldEmitCancelledTerminalEvent_WhenCancelMethodInvoked` が `Task.Delay(100)` でプロセス起動完了を推測していました。カバレッジ計測や runner の負荷で起動が 100 ms を超えると、`Cancel()` がプロセス起動前に実行され、`Kill(true)` が呼ばれない正しい経路をテストが失敗と判定していました。

## 変更内容
- mock process の `WaitForExitAsync` 開始を `TaskCompletionSource` で通知
- テストが実行中状態を確実に待ってから `Cancel()` を呼ぶよう変更
- 固定遅延によるタイミング依存を除去

## 検証
- `dotnet build winui3/SquirrelNotifier.WinUI3.sln --configuration Release --no-restore -p:Platform=x64`
- `dotnet format winui3/SquirrelNotifier.WinUI3.sln --verify-no-changes --no-restore`
- CI 同等のカバレッジ実行を 3 回実施: 600/600 成功、line 93.36%、branch 86.19%、method 94.49%
- pre-commit / pre-push フック成功

## 関連
- PR #190 の CI failure 対応