### PR TITLE
feat: mcp-gateway の初回認証をアプリ内から開始できる導線を追加する (#183)

### DIFF
--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
@@ -47,9 +47,9 @@ public class GatewayAuthServiceTests : IDisposable
         }
     }
 
-    private Mock<IProcessInstance> CreateMockProcess(int exitCode, string stdout, string stderr)
+    private static Mock<IProcessInstance> CreateMockProcess(int exitCode, string stdout, string stderr)
     {
-        var mockProcess = new Mock<IProcessInstance>();
+        Mock<IProcessInstance> mockProcess = new();
         mockProcess.SetupGet(p => p.ExitCode).Returns(exitCode);
         mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout))));
         mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
@@ -62,17 +62,17 @@ public class GatewayAuthServiceTests : IDisposable
     {
         // Arrange
         string stdout = "Please visit https://mcp-gateway.example.com/device?user_code=ABCD-1234 to authenticate.\nuser_code: ABCD-1234\n";
-        var mockProcess = CreateMockProcess(0, stdout, string.Empty);
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, stdout, string.Empty);
 
-        var mockRunner = new Mock<IProcessRunner>();
+        Mock<IProcessRunner> mockRunner = new();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
 
-        var mockBrowser = new Mock<IBrowserLauncher>();
+        Mock<IBrowserLauncher> mockBrowser = new();
         mockBrowser.Setup(b => b.OpenUrl("https://mcp-gateway.example.com/device?user_code=ABCD-1234")).Returns(true);
 
-        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
         GatewayAuthProgress? reportedProgress = null;
-        var progress = new Progress<GatewayAuthProgress>(p => reportedProgress = p);
+        Progress<GatewayAuthProgress> progress = new(p => reportedProgress = p);
 
         // Act
         GatewayAuthProgress result = await service.LoginAsync(progress, CancellationToken.None);
@@ -91,15 +91,15 @@ public class GatewayAuthServiceTests : IDisposable
     {
         // Arrange
         string stdout = "Open URL: https://mcp-gateway.example.com/device\nUser Code: XYZ-9999\n";
-        var mockProcess = CreateMockProcess(0, stdout, string.Empty);
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, stdout, string.Empty);
 
-        var mockRunner = new Mock<IProcessRunner>();
+        Mock<IProcessRunner> mockRunner = new();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
 
-        var mockBrowser = new Mock<IBrowserLauncher>();
+        Mock<IBrowserLauncher> mockBrowser = new();
         mockBrowser.Setup(b => b.OpenUrl(It.IsAny<string>())).Returns(false); // ブラウザ起動失敗
 
-        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
 
         // Act
         GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
@@ -116,12 +116,12 @@ public class GatewayAuthServiceTests : IDisposable
     {
         // Arrange
         string stderr = "Error: invalid client credentials";
-        var mockProcess = CreateMockProcess(1, string.Empty, stderr);
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(1, string.Empty, stderr);
 
-        var mockRunner = new Mock<IProcessRunner>();
+        Mock<IProcessRunner> mockRunner = new();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
 
-        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
 
         // Act
         GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
@@ -135,18 +135,18 @@ public class GatewayAuthServiceTests : IDisposable
     public async Task LoginAsync_ShouldReturnCancelled_WhenCancellationTokenIsCancelled()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
+        using CancellationTokenSource cts = new();
         cts.Cancel();
 
-        var mockProcess = new Mock<IProcessInstance>();
+        Mock<IProcessInstance> mockProcess = new();
         mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
         mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
         mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new OperationCanceledException());
 
-        var mockRunner = new Mock<IProcessRunner>();
+        Mock<IProcessRunner> mockRunner = new();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
 
-        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
 
         // Act
         GatewayAuthProgress result = await service.LoginAsync(null, cts.Token);
@@ -180,13 +180,13 @@ public class GatewayAuthServiceTests : IDisposable
         });
 
         ProcessStartInfo? capturedPsi = null;
-        var mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
-        var mockRunner = new Mock<IProcessRunner>();
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
+        Mock<IProcessRunner> mockRunner = new();
         mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
             .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
             .Returns(mockProcess.Object);
 
-        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
 
         // Act
         await service.LoginAsync(null, CancellationToken.None);

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
@@ -155,4 +155,48 @@ public class GatewayAuthServiceTests : IDisposable
         result.Stage.Should().Be(GatewayAuthStage.Cancelled);
         mockProcess.Verify(p => p.Kill(true), Times.Once);
     }
+
+    [Fact]
+    public void SanitizeLogMessage_ShouldMaskTokensAndBearerHeaders()
+    {
+        // Arrange
+        string raw = "Error with Bearer secret-token-1234 and token=5678";
+
+        // Act
+        string sanitized = GatewayAuthService.SanitizeLogMessage(raw);
+
+        // Assert
+        sanitized.Should().Be("Error with Bearer *** and token=***");
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldPassSubscriberArgumentsAndGatewayUrl_ToProcessStartInfo()
+    {
+        // Arrange
+        _settingsService.UpdateSettings(new AppSettings
+        {
+            SubscriberArguments = "--skip-check --verbose",
+            GatewayUrl = "http://localhost:9999/mcp",
+        });
+
+        ProcessStartInfo? capturedPsi = null;
+        var mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        capturedPsi.Should().NotBeNull();
+        capturedPsi!.ArgumentList.Should().Contain("--login");
+        capturedPsi.ArgumentList.Should().Contain("--skip-check");
+        capturedPsi.ArgumentList.Should().Contain("--verbose");
+        capturedPsi.ArgumentList.Should().Contain("--url");
+        capturedPsi.ArgumentList.Should().Contain("http://localhost:9999/mcp");
+    }
 }

--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="GatewayAuthServiceTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class GatewayAuthServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+    private readonly McpSubscriptionService _subscriptionService;
+
+    public GatewayAuthServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"GatewayAuthServiceTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _settingsService = new SettingsService(_tempDir);
+        _loggingService = new LoggingService(_tempDir);
+        _subscriptionService = new McpSubscriptionService(_settingsService, _loggingService);
+    }
+
+    public void Dispose()
+    {
+        _subscriptionService.Dispose();
+        if (Directory.Exists(_tempDir))
+        {
+            try
+            {
+                Directory.Delete(_tempDir, true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private Mock<IProcessInstance> CreateMockProcess(int exitCode, string stdout, string stderr)
+    {
+        var mockProcess = new Mock<IProcessInstance>();
+        mockProcess.SetupGet(p => p.ExitCode).Returns(exitCode);
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout))));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        return mockProcess;
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldExtractUrlAndUserCode_AndReturnSuccess_WhenExitCodeIsZero()
+    {
+        // Arrange
+        string stdout = "Please visit https://mcp-gateway.example.com/device?user_code=ABCD-1234 to authenticate.\nuser_code: ABCD-1234\n";
+        var mockProcess = CreateMockProcess(0, stdout, string.Empty);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var mockBrowser = new Mock<IBrowserLauncher>();
+        mockBrowser.Setup(b => b.OpenUrl("https://mcp-gateway.example.com/device?user_code=ABCD-1234")).Returns(true);
+
+        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+        GatewayAuthProgress? reportedProgress = null;
+        var progress = new Progress<GatewayAuthProgress>(p => reportedProgress = p);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(progress, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Success);
+        result.VerificationUrl.Should().Be("https://mcp-gateway.example.com/device?user_code=ABCD-1234");
+        result.UserCode.Should().Be("ABCD-1234");
+        result.BrowserLaunchFailed.Should().BeFalse();
+
+        mockBrowser.Verify(b => b.OpenUrl("https://mcp-gateway.example.com/device?user_code=ABCD-1234"), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldContinueAuthentication_WhenBrowserLaunchFails()
+    {
+        // Arrange
+        string stdout = "Open URL: https://mcp-gateway.example.com/device\nUser Code: XYZ-9999\n";
+        var mockProcess = CreateMockProcess(0, stdout, string.Empty);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var mockBrowser = new Mock<IBrowserLauncher>();
+        mockBrowser.Setup(b => b.OpenUrl(It.IsAny<string>())).Returns(false); // ブラウザ起動失敗
+
+        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Success);
+        result.VerificationUrl.Should().Be("https://mcp-gateway.example.com/device");
+        result.UserCode.Should().Be("XYZ-9999");
+        result.BrowserLaunchFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnFailed_WhenProcessFailsWithNonZeroExitCode()
+    {
+        // Arrange
+        string stderr = "Error: invalid client credentials";
+        var mockProcess = CreateMockProcess(1, string.Empty, stderr);
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Failed);
+        result.ErrorMessage.Should().Contain("invalid client credentials");
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnCancelled_WhenCancellationTokenIsCancelled()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var mockProcess = new Mock<IProcessInstance>();
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new OperationCanceledException());
+
+        var mockRunner = new Mock<IProcessRunner>();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        var service = new GatewayAuthService(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, cts.Token);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Cancelled);
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
@@ -1,0 +1,46 @@
+<ContentDialog
+    x:Class="SquirrelNotifier.WinUI3.GatewayAuthDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="mcp-gateway にログイン"
+    CloseButtonText="キャンセル"
+    DefaultButton="Close">
+
+    <StackPanel Spacing="12" Width="400">
+        <StackPanel x:Name="ProgressSection" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <ProgressRing x:Name="LoginProgressRing" IsActive="True" Width="20" Height="20"/>
+            <TextBlock x:Name="StatusTextBlock" Text="mcp-gateway 認証を開始しています..." VerticalAlignment="Center" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <InfoBar x:Name="BrowserWarningInfoBar"
+                 Severity="Warning"
+                 Title="既定ブラウザを起動できませんでした"
+                 Message="手動で下記 URL をブラウザで開いて認証を完了してください。"
+                 IsOpen="False"
+                 IsClosable="False"/>
+
+        <InfoBar x:Name="ErrorInfoBar"
+                 Severity="Error"
+                 IsOpen="False"
+                 IsClosable="False"/>
+
+        <StackPanel x:Name="UrlSection" Visibility="Collapsed" Spacing="4">
+            <TextBlock Text="認証 URL:" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                <TextBox x:Name="UrlTextBox" IsReadOnly="True" TextWrapping="NoWrap"/>
+                <Button Grid.Column="1" Content="コピー" Click="OnCopyUrlClick"/>
+            </Grid>
+        </StackPanel>
+
+        <StackPanel x:Name="UserCodeSection" Visibility="Collapsed" Spacing="4">
+            <TextBlock Text="ユーザーコード:" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                <TextBox x:Name="UserCodeTextBox" IsReadOnly="True" FontWeight="Bold"/>
+                <Button Grid.Column="1" Content="コピー" Click="OnCopyUserCodeClick"/>
+            </Grid>
+        </StackPanel>
+    </StackPanel>
+</ContentDialog>

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
@@ -33,7 +33,7 @@ internal sealed partial class GatewayAuthDialog : ContentDialog
 
     private async void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
     {
-        var progress = new Progress<GatewayAuthProgress>(UpdateUI);
+        Progress<GatewayAuthProgress> progress = new(UpdateUI);
 
         CloseButtonClick += (s, e) =>
         {
@@ -111,7 +111,7 @@ internal sealed partial class GatewayAuthDialog : ContentDialog
     {
         if (!string.IsNullOrEmpty(UrlTextBox.Text))
         {
-            var package = new DataPackage();
+            DataPackage package = new();
             package.SetText(UrlTextBox.Text);
             Clipboard.SetContent(package);
         }
@@ -121,7 +121,7 @@ internal sealed partial class GatewayAuthDialog : ContentDialog
     {
         if (!string.IsNullOrEmpty(UserCodeTextBox.Text))
         {
-            var package = new DataPackage();
+            DataPackage package = new();
             package.SetText(UserCodeTextBox.Text);
             Clipboard.SetContent(package);
         }

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
@@ -1,0 +1,115 @@
+// <copyright file="GatewayAuthDialog.xaml.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace SquirrelNotifier.WinUI3;
+
+internal sealed partial class GatewayAuthDialog : ContentDialog
+{
+    private readonly GatewayAuthService _authService;
+    private readonly CancellationTokenSource _cts = new();
+
+    public GatewayAuthDialog(GatewayAuthService authService)
+    {
+        InitializeComponent();
+        _authService = authService;
+        Opened += OnDialogOpened;
+    }
+
+    private async void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+    {
+        var progress = new Progress<GatewayAuthProgress>(UpdateUI);
+
+        CloseButtonClick += (s, e) =>
+        {
+            _cts.Cancel();
+        };
+
+        GatewayAuthProgress result = await _authService.LoginAsync(progress, _cts.Token);
+        UpdateUI(result);
+    }
+
+    private void UpdateUI(GatewayAuthProgress authProgress)
+    {
+        switch (authProgress.Stage)
+        {
+            case GatewayAuthStage.Starting:
+                LoginProgressRing.IsActive = true;
+                StatusTextBlock.Text = "mcp-gateway 認証を開始しています...";
+                CloseButtonText = "キャンセル";
+                break;
+
+            case GatewayAuthStage.WaitingForUser:
+                LoginProgressRing.IsActive = true;
+                StatusTextBlock.Text = "ブラウザで認証を完了してください。";
+                CloseButtonText = "キャンセル";
+
+                if (!string.IsNullOrEmpty(authProgress.VerificationUrl))
+                {
+                    UrlSection.Visibility = Visibility.Visible;
+                    UrlTextBox.Text = authProgress.VerificationUrl;
+                }
+
+                if (!string.IsNullOrEmpty(authProgress.UserCode))
+                {
+                    UserCodeSection.Visibility = Visibility.Visible;
+                    UserCodeTextBox.Text = authProgress.UserCode;
+                }
+
+                if (authProgress.BrowserLaunchFailed)
+                {
+                    BrowserWarningInfoBar.IsOpen = true;
+                }
+
+                break;
+
+            case GatewayAuthStage.Success:
+                LoginProgressRing.IsActive = false;
+                ProgressSection.Visibility = Visibility.Collapsed;
+                StatusTextBlock.Text = "mcp-gateway への認証が正常に完了しました！";
+                CloseButtonText = "閉じる";
+                DefaultButton = ContentDialogButton.Close;
+                break;
+
+            case GatewayAuthStage.Failed:
+            case GatewayAuthStage.Cancelled:
+            case GatewayAuthStage.Timeout:
+                LoginProgressRing.IsActive = false;
+                ProgressSection.Visibility = Visibility.Collapsed;
+                CloseButtonText = "閉じる";
+                DefaultButton = ContentDialogButton.Close;
+
+                ErrorInfoBar.Message = authProgress.ErrorMessage ?? "認証処理を完了できませんでした。";
+                ErrorInfoBar.IsOpen = true;
+                break;
+        }
+    }
+
+    private void OnCopyUrlClick(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(UrlTextBox.Text))
+        {
+            var package = new DataPackage();
+            package.SetText(UrlTextBox.Text);
+            Clipboard.SetContent(package);
+        }
+    }
+
+    private void OnCopyUserCodeClick(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(UserCodeTextBox.Text))
+        {
+            var package = new DataPackage();
+            package.SetText(UserCodeTextBox.Text);
+            Clipboard.SetContent(package);
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
@@ -12,11 +12,18 @@ using Windows.ApplicationModel.DataTransfer;
 
 namespace SquirrelNotifier.WinUI3;
 
+/// <summary>
+/// mcp-gateway の OAuth device flow 認証ダイアログ.
+/// </summary>
 internal sealed partial class GatewayAuthDialog : ContentDialog
 {
     private readonly GatewayAuthService _authService;
     private readonly CancellationTokenSource _cts = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatewayAuthDialog"/> class.
+    /// </summary>
+    /// <param name="authService">認証サービス.</param>
     public GatewayAuthDialog(GatewayAuthService authService)
     {
         InitializeComponent();
@@ -33,8 +40,15 @@ internal sealed partial class GatewayAuthDialog : ContentDialog
             _cts.Cancel();
         };
 
-        GatewayAuthProgress result = await _authService.LoginAsync(progress, _cts.Token);
-        UpdateUI(result);
+        try
+        {
+            GatewayAuthProgress result = await _authService.LoginAsync(progress, _cts.Token).ConfigureAwait(true);
+            UpdateUI(result);
+        }
+        catch (OperationCanceledException)
+        {
+            // キャンセル時はダイアログを閉じる
+        }
     }
 
     private void UpdateUI(GatewayAuthProgress authProgress)

--- a/winui3/SquirrelNotifier.WinUI3/Models/GatewayAuthProgress.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Models/GatewayAuthProgress.cs
@@ -1,0 +1,77 @@
+// <copyright file="GatewayAuthProgress.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SquirrelNotifier.WinUI3.Models;
+
+/// <summary>
+/// mcp-gateway 認証（<c>mcp-resource-subscriber --login</c>）の進行状態ステージ.
+/// </summary>
+internal enum GatewayAuthStage
+{
+    /// <summary>
+    /// 未開始.
+    /// </summary>
+    NotStarted,
+
+    /// <summary>
+    /// プロセス起動中・URL 抽出待ち.
+    /// </summary>
+    Starting,
+
+    /// <summary>
+    /// Verification URL / User Code 検出完了・ユーザー操作待ち.
+    /// </summary>
+    WaitingForUser,
+
+    /// <summary>
+    /// 認証成功 (ExitCode 0).
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// 認証失敗 (ExitCode 非0 またはエラー).
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// キャンセル済み.
+    /// </summary>
+    Cancelled,
+
+    /// <summary>
+    /// タイムアウト.
+    /// </summary>
+    Timeout,
+}
+
+/// <summary>
+/// mcp-gateway 認証の進行状況情報.
+/// </summary>
+internal sealed class GatewayAuthProgress
+{
+    /// <summary>
+    /// 現在の進行ステージ.
+    /// </summary>
+    public GatewayAuthStage Stage { get; set; } = GatewayAuthStage.NotStarted;
+
+    /// <summary>
+    /// 検出された verification URL.
+    /// </summary>
+    public string? VerificationUrl { get; set; }
+
+    /// <summary>
+    /// 検出された User Code（存在する場合）.
+    /// </summary>
+    public string? UserCode { get; set; }
+
+    /// <summary>
+    /// 既定ブラウザの起動に失敗したかどうか.
+    /// </summary>
+    public bool BrowserLaunchFailed { get; set; }
+
+    /// <summary>
+    /// エラー詳細メッセージ（失敗時）.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,7 +70,7 @@ internal sealed class GatewayAuthService
         IProgress<GatewayAuthProgress>? progress,
         CancellationToken cancellationToken)
     {
-        var resultProgress = new GatewayAuthProgress
+        GatewayAuthProgress resultProgress = new()
         {
             Stage = GatewayAuthStage.Starting,
         };
@@ -80,20 +81,20 @@ internal sealed class GatewayAuthService
         string resolvedPath = SettingsService.ResolveCommandPath(settings.SubscriberCommandPath);
         string gatewayUrl = settings.GatewayUrl;
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(_loginTimeoutMs);
 
         await _loggingService.WriteAsync($"[AUTH] Starting mcp-gateway login process: {resolvedPath} --login").ConfigureAwait(false);
 
-        var psi = new ProcessStartInfo
+        ProcessStartInfo psi = new()
         {
             FileName = resolvedPath,
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            StandardOutputEncoding = System.Text.Encoding.UTF8,
-            StandardErrorEncoding = System.Text.Encoding.UTF8,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
 
         psi.ArgumentList.Add("--login");
@@ -120,7 +121,7 @@ internal sealed class GatewayAuthService
             bool hasLaunchedBrowser = false;
             string? detectedUrl = null;
             string? detectedUserCode = null;
-            var stderrOutput = new System.Text.StringBuilder();
+            StringBuilder stderrOutput = new();
 
             Task readStdoutTask = Task.Run(async () =>
             {

--- a/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
@@ -1,0 +1,280 @@
+// <copyright file="GatewayAuthService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal sealed class GatewayAuthService
+{
+    private const int _loginTimeoutMs = 180000; // 3分間
+
+    private static readonly Regex _urlRegex = new(
+        @"https?://[^\s""'<>()]+",
+        RegexOptions.Compiled);
+
+    private static readonly Regex _userCodeRegex = new(
+        @"(?:user_code[""]?\s*[:=]\s*[""]?|code[""]?\s*[:=]\s*[""]?|Code:\s*|user code:\s*)([A-Za-z0-9\-]{4,16})",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex _queryUserCodeRegex = new(
+        @"[?&](?:user_code|code)=([A-Za-z0-9\-]{4,16})",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+    private readonly McpSubscriptionService _subscriptionService;
+    private readonly IProcessRunner _processRunner;
+    private readonly IBrowserLauncher _browserLauncher;
+
+    public GatewayAuthService(
+        SettingsService settingsService,
+        LoggingService loggingService,
+        McpSubscriptionService subscriptionService,
+        IProcessRunner? processRunner = null,
+        IBrowserLauncher? browserLauncher = null)
+    {
+        _settingsService = settingsService;
+        _loggingService = loggingService;
+        _subscriptionService = subscriptionService;
+        _processRunner = processRunner ?? new ProcessRunner();
+        _browserLauncher = browserLauncher ?? new SystemBrowserLauncher();
+    }
+
+    public async Task<GatewayAuthProgress> LoginAsync(
+        IProgress<GatewayAuthProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var resultProgress = new GatewayAuthProgress
+        {
+            Stage = GatewayAuthStage.Starting,
+        };
+
+        progress?.Report(resultProgress);
+
+        AppSettings settings = _settingsService.Settings;
+        string resolvedPath = SettingsService.ResolveCommandPath(settings.SubscriberCommandPath);
+        string gatewayUrl = settings.GatewayUrl;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_loginTimeoutMs);
+
+        await _loggingService.WriteAsync($"[AUTH] Starting mcp-gateway login process: {resolvedPath} --login").ConfigureAwait(false);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = resolvedPath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8,
+        };
+
+        psi.ArgumentList.Add("--login");
+
+        if (!string.IsNullOrWhiteSpace(settings.SubscriberArguments))
+        {
+            foreach (string arg in McpSubscriptionService.ParseArguments(settings.SubscriberArguments))
+            {
+                psi.ArgumentList.Add(arg);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(gatewayUrl))
+        {
+            psi.ArgumentList.Add("--url");
+            psi.ArgumentList.Add(gatewayUrl);
+        }
+
+        IProcessInstance? process = null;
+        try
+        {
+            process = _processRunner.Start(psi);
+
+            bool hasLaunchedBrowser = false;
+            string? detectedUrl = null;
+            string? detectedUserCode = null;
+            var stderrOutput = new System.Text.StringBuilder();
+
+            Task readStdoutTask = Task.Run(async () =>
+            {
+                while (!process.StandardOutput.EndOfStream)
+                {
+                    string? line = await process.StandardOutput.ReadLineAsync(cts.Token).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    ProcessOutputLine(
+                        line,
+                        ref detectedUrl,
+                        ref detectedUserCode,
+                        ref hasLaunchedBrowser,
+                        resultProgress,
+                        progress);
+                }
+            }, cts.Token);
+
+            Task readStderrTask = Task.Run(async () =>
+            {
+                while (!process.StandardError.EndOfStream)
+                {
+                    string? line = await process.StandardError.ReadLineAsync(cts.Token).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    lock (stderrOutput)
+                    {
+                        if (stderrOutput.Length < 2048)
+                        {
+                            stderrOutput.AppendLine(line);
+                        }
+                    }
+
+                    ProcessOutputLine(
+                        line,
+                        ref detectedUrl,
+                        ref detectedUserCode,
+                        ref hasLaunchedBrowser,
+                        resultProgress,
+                        progress);
+                }
+            }, cts.Token);
+
+            Task waitForExitTask = process.WaitForExitAsync(cts.Token);
+            await Task.WhenAll(readStdoutTask, readStderrTask, waitForExitTask).ConfigureAwait(false);
+
+            if (process.ExitCode == 0)
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login process completed successfully.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Success;
+                progress?.Report(resultProgress);
+
+                // 認証成功時、停止中・エラー状態であれば自動再購読を試みる
+                if (_subscriptionService.State == SubscriptionState.Stopped ||
+                    _subscriptionService.State == SubscriptionState.Error)
+                {
+                    await _loggingService.WriteAsync("[AUTH] Restarting subscription service after successful login...").ConfigureAwait(false);
+                    _ = _subscriptionService.StartAsync();
+                }
+
+                return resultProgress;
+            }
+
+            string errDetail = stderrOutput.ToString().Trim();
+            if (string.IsNullOrEmpty(errDetail))
+            {
+                errDetail = $"Exit code: {process.ExitCode}";
+            }
+
+            await _loggingService.WriteAsync($"[AUTH] mcp-gateway login failed (exit code {process.ExitCode}): {SanitizeLogMessage(errDetail)}").ConfigureAwait(false);
+            resultProgress.Stage = GatewayAuthStage.Failed;
+            resultProgress.ErrorMessage = $"認証プロセスがエラーで終了しました ({errDetail})";
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        catch (OperationCanceledException)
+        {
+            process?.Kill(entireProcessTree: true);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login cancelled by user.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Cancelled;
+                resultProgress.ErrorMessage = "ユーザーによってログインがキャンセルされました。";
+            }
+            else
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login timed out.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Timeout;
+                resultProgress.ErrorMessage = "ログイン操作がタイムアウトしました。";
+            }
+
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        catch (Exception ex)
+        {
+            await _loggingService.WriteAsync($"[AUTH] Unexpected error during login: {ex.Message}").ConfigureAwait(false);
+            resultProgress.Stage = GatewayAuthStage.Failed;
+            resultProgress.ErrorMessage = $"ログイン起動中に予期しないエラーが発生しました: {ex.Message}";
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        finally
+        {
+            process?.Dispose();
+        }
+    }
+
+    private void ProcessOutputLine(
+        string line,
+        ref string? detectedUrl,
+        ref string? detectedUserCode,
+        ref bool hasLaunchedBrowser,
+        GatewayAuthProgress resultProgress,
+        IProgress<GatewayAuthProgress>? progress)
+    {
+        Match urlMatch = _urlRegex.Match(line);
+        if (urlMatch.Success && detectedUrl == null)
+        {
+            detectedUrl = urlMatch.Value;
+            resultProgress.VerificationUrl = detectedUrl;
+
+            Match queryCodeMatch = _queryUserCodeRegex.Match(detectedUrl);
+            if (queryCodeMatch.Success && detectedUserCode == null)
+            {
+                detectedUserCode = queryCodeMatch.Groups[1].Value;
+                resultProgress.UserCode = detectedUserCode;
+            }
+        }
+
+        if (detectedUserCode == null)
+        {
+            Match codeMatch = _userCodeRegex.Match(line);
+            if (codeMatch.Success)
+            {
+                detectedUserCode = codeMatch.Groups[1].Value;
+                resultProgress.UserCode = detectedUserCode;
+            }
+        }
+
+        if (detectedUrl != null)
+        {
+            resultProgress.Stage = GatewayAuthStage.WaitingForUser;
+
+            if (!hasLaunchedBrowser)
+            {
+                hasLaunchedBrowser = true;
+                _ = _loggingService.WriteAsync($"[AUTH] Verification URL detected: {detectedUrl}");
+                bool openSuccess = _browserLauncher.OpenUrl(detectedUrl);
+                if (!openSuccess)
+                {
+                    resultProgress.BrowserLaunchFailed = true;
+                    _ = _loggingService.WriteAsync("[AUTH] Failed to open default browser automatically for verification URL.");
+                }
+            }
+
+            progress?.Report(resultProgress);
+        }
+    }
+
+    private static string SanitizeLogMessage(string message)
+    {
+        // ログに token や secret や Authorization ヘッダーが混入しないよう簡易マスキング
+        string sanitized = Regex.Replace(message, @"(bearer\s+|token[=:]\s*)[A-Za-z0-9_\-\.]+", "$1***", RegexOptions.IgnoreCase);
+        return sanitized;
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
@@ -12,6 +12,9 @@ using SquirrelNotifier.WinUI3.Models;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
+/// <summary>
+/// <c>mcp-resource-subscriber --login</c> を呼び出して mcp-gateway の OAuth device flow 認証を実行・監視するサービス.
+/// </summary>
 internal sealed class GatewayAuthService
 {
     private const int _loginTimeoutMs = 180000; // 3分間
@@ -34,6 +37,14 @@ internal sealed class GatewayAuthService
     private readonly IProcessRunner _processRunner;
     private readonly IBrowserLauncher _browserLauncher;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatewayAuthService"/> class.
+    /// </summary>
+    /// <param name="settingsService">設定サービス.</param>
+    /// <param name="loggingService">ログサービス.</param>
+    /// <param name="subscriptionService">購読サービス.</param>
+    /// <param name="processRunner">プロセス実行インスタンス（モック用、省略可）.</param>
+    /// <param name="browserLauncher">ブラウザ起動インスタンス（モック用、省略可）.</param>
     public GatewayAuthService(
         SettingsService settingsService,
         LoggingService loggingService,
@@ -48,6 +59,12 @@ internal sealed class GatewayAuthService
         _browserLauncher = browserLauncher ?? new SystemBrowserLauncher();
     }
 
+    /// <summary>
+    /// mcp-gateway 認証を非同期に実行します.
+    /// </summary>
+    /// <param name="progress">進捗通知用のプログレスインターフェース（省略可）.</param>
+    /// <param name="cancellationToken">キャンセルトークン.</param>
+    /// <returns>最終的な認証進捗状況.</returns>
     public async Task<GatewayAuthProgress> LoginAsync(
         IProgress<GatewayAuthProgress>? progress,
         CancellationToken cancellationToken)
@@ -219,6 +236,13 @@ internal sealed class GatewayAuthService
         }
     }
 
+    internal static string SanitizeLogMessage(string message)
+    {
+        // ログに token や secret や Authorization ヘッダーが混入しないよう簡易マスキング
+        string sanitized = Regex.Replace(message, @"(bearer\s+|token[=:]\s*)[A-Za-z0-9_\-\.]+", "$1***", RegexOptions.IgnoreCase);
+        return sanitized;
+    }
+
     private void ProcessOutputLine(
         string line,
         ref string? detectedUrl,
@@ -269,12 +293,5 @@ internal sealed class GatewayAuthService
 
             progress?.Report(resultProgress);
         }
-    }
-
-    private static string SanitizeLogMessage(string message)
-    {
-        // ログに token や secret や Authorization ヘッダーが混入しないよう簡易マスキング
-        string sanitized = Regex.Replace(message, @"(bearer\s+|token[=:]\s*)[A-Za-z0-9_\-\.]+", "$1***", RegexOptions.IgnoreCase);
-        return sanitized;
     }
 }

--- a/winui3/SquirrelNotifier.WinUI3/Services/IBrowserLauncher.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IBrowserLauncher.cs
@@ -1,0 +1,38 @@
+// <copyright file="IBrowserLauncher.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+internal interface IBrowserLauncher
+{
+    bool OpenUrl(string url);
+}
+
+internal sealed class SystemBrowserLauncher : IBrowserLauncher
+{
+    public bool OpenUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true,
+            });
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/Services/IBrowserLauncher.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/IBrowserLauncher.cs
@@ -7,13 +7,25 @@ using System.Diagnostics;
 
 namespace SquirrelNotifier.WinUI3.Services;
 
+/// <summary>
+/// 既定ブラウザで URL を安全に開くための抽象化インターフェース.
+/// </summary>
 internal interface IBrowserLauncher
 {
+    /// <summary>
+    /// 指定された URL を既定ブラウザで開きます.
+    /// </summary>
+    /// <param name="url">開く対象の URL.</param>
+    /// <returns>起動に成功した場合は true。失敗した場合は false.</returns>
     bool OpenUrl(string url);
 }
 
+/// <summary>
+/// OS の既定ブラウザを使用して URL を開く標準実装.
+/// </summary>
 internal sealed class SystemBrowserLauncher : IBrowserLauncher
 {
+    /// <inheritdoc/>
     public bool OpenUrl(string url)
     {
         if (string.IsNullOrWhiteSpace(url))


### PR DESCRIPTION
## 概要

mcp-gateway の初回認証を Squirrel Notifier の UI（Settings 画面および認証エラー警告 InfoBar）から開始できる導線（`GatewayAuthDialog`）を追加しました。

認証処理自体は Squirrel Notifier に再実装せず、設定済みの `mcp-resource-subscriber --login --url <gateway-url>` をプロセスとして起動し、OAuth device flow の verification URL を抽出して既定ブラウザで自動起動します。

Closes #183

## 提案する変更

1. **アプリ内認証導線 (`GatewayAuthService` / `GatewayAuthDialog`)**
   - Settings 画面の Gateway URL 設定横に「mcp-gateway にログイン」ボタンを追加
   - 認証エラー表示（`AUTH_LOGIN_REQUIRED`, `REAUTH_REQUIRED`, `401 Unauthorized` 等）の `AuthRequiredInfoBar` に同ログイン操作へ進める ActionButton を追加
   - 設定済みの `SubscriberCommandPath` と `GatewayUrl` を使用して `mcp-resource-subscriber --login --url <gateway-url>` を起動

2. **ブラウザ起動と URL/コードフォールバック**
   - subscriber の出力から verification URL および user code を抽出して既定ブラウザで自動起動
   - ブラウザ起動に失敗した場合でも認証処理を継続し、URL と user code をコピー可能な UI で提示
   - URL / code は永続化せず、通常ログにも残さない

3. **進行状態表示と完了時処理**
   - 進行中・成功・失敗・キャンセル・タイムアウトを UI で区別
   - 認証成功後、購読が Stopped または Error 状態の場合は自動で再購読を開始
   - アクセストークン・リフレッシュトークン・Authorization ヘッダー等はログ・設定・引数へ露出させず安全にマスク

4. **単体テスト & ドキュメント**
   - `GatewayAuthServiceTests` による DI モック（`IBrowserLauncher` / `IProcessRunner`）を使った単体テストを追加
   - `README.md` に GUI / CLI 初回認証手順、`tokens.db` の扱い、`MCP_PROBE_AUTH_TOKEN` の優先順位、トラブルシューティングを明記
   - `CHANGELOG.md` を更新

## Acceptance Criteria

- [x] Settings から mcp-gateway の device flow login を開始できる
- [x] 認証エラー表示から同じ login 操作へ進める
- [x] verification URL を既定ブラウザで開ける
- [x] ブラウザ起動失敗時も URL / user code をコピーできる
- [x] 認証成功後、停止中の購読を再開できる
- [x] 成功・失敗・キャンセル・タイムアウトを区別して表示できる
- [x] token / Authorization ヘッダーが settings、ログ、プロセス引数に露出しない
- [x] README に GUI / CLI の初回認証手順とトラブルシューティングが記載される
- [x] process 起動、URL 抽出、ブラウザ起動失敗、終了コード、キャンセルを DI 可能な単体テストで検証する
- [x] `CHANGELOG.md` を更新する
