### PR TITLE
feat: mcp-gateway の初回認証をアプリ内から開始できる導線を追加する (#183)

### DIFF
--- a/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
+++ b/winui3/SquirrelNotifier.WinUI3.Tests/Services/GatewayAuthServiceTests.cs
@@ -1,0 +1,260 @@
+// <copyright file="GatewayAuthServiceTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Xunit;
+
+namespace SquirrelNotifier.WinUI3.Tests.Services;
+
+public class GatewayAuthServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+    private readonly McpSubscriptionService _subscriptionService;
+
+    public GatewayAuthServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"GatewayAuthServiceTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _settingsService = new SettingsService(_tempDir);
+        _loggingService = new LoggingService(_tempDir);
+        _subscriptionService = new McpSubscriptionService(_settingsService, _loggingService);
+    }
+
+    public void Dispose()
+    {
+        _subscriptionService.Dispose();
+        if (Directory.Exists(_tempDir))
+        {
+            try
+            {
+                Directory.Delete(_tempDir, true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static Mock<IProcessInstance> CreateMockProcess(int exitCode, string stdout, string stderr)
+    {
+        Mock<IProcessInstance> mockProcess = new();
+        mockProcess.SetupGet(p => p.ExitCode).Returns(exitCode);
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stdout))));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(stderr))));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        return mockProcess;
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldExtractUrlAndUserCode_AndReturnSuccess_WhenExitCodeIsZero()
+    {
+        // Arrange
+        string stdout = "Please visit https://mcp-gateway.example.com/device?user_code=ABCD-1234 to authenticate.\nuser_code: ABCD-1234\n";
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, stdout, string.Empty);
+
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        Mock<IBrowserLauncher> mockBrowser = new();
+        mockBrowser.Setup(b => b.OpenUrl("https://mcp-gateway.example.com/device?user_code=ABCD-1234")).Returns(true);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+        GatewayAuthProgress? reportedProgress = null;
+        Progress<GatewayAuthProgress> progress = new(p => reportedProgress = p);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(progress, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Success);
+        result.VerificationUrl.Should().Be("https://mcp-gateway.example.com/device?user_code=ABCD-1234");
+        result.UserCode.Should().Be("ABCD-1234");
+        result.BrowserLaunchFailed.Should().BeFalse();
+
+        mockBrowser.Verify(b => b.OpenUrl("https://mcp-gateway.example.com/device?user_code=ABCD-1234"), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldContinueAuthentication_WhenBrowserLaunchFails()
+    {
+        // Arrange
+        string stdout = "Open URL: https://mcp-gateway.example.com/device\nUser Code: XYZ-9999\n";
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, stdout, string.Empty);
+
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        Mock<IBrowserLauncher> mockBrowser = new();
+        mockBrowser.Setup(b => b.OpenUrl(It.IsAny<string>())).Returns(false); // ブラウザ起動失敗
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, mockBrowser.Object);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Success);
+        result.VerificationUrl.Should().Be("https://mcp-gateway.example.com/device");
+        result.UserCode.Should().Be("XYZ-9999");
+        result.BrowserLaunchFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnFailed_WhenProcessFailsWithNonZeroExitCode()
+    {
+        // Arrange
+        string stderr = "Error: invalid client credentials";
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(1, string.Empty, stderr);
+
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Failed);
+        result.ErrorMessage.Should().Contain("invalid client credentials");
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnCancelled_WhenCancellationTokenIsCancelled()
+    {
+        // Arrange
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        Mock<IProcessInstance> mockProcess = new();
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new OperationCanceledException());
+
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, cts.Token);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Cancelled);
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("Error with Bearer secret-token-1234 and token=5678", "Error with Bearer *** and token=***")]
+    [InlineData("token=abc+def/ghi== and access_token=xyz%20123", "token=*** and access_token=***")]
+    [InlineData("", "")]
+    public void SanitizeLogMessage_ShouldMaskTokensAndBearerHeaders(string raw, string expected)
+    {
+        // Act
+        string sanitized = GatewayAuthService.SanitizeLogMessage(raw);
+
+        // Assert
+        sanitized.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnTimeout_WhenProcessTimesOutWithoutUserCancellation()
+    {
+        // Arrange
+        using CancellationTokenSource cts = new();
+        Mock<IProcessInstance> mockProcess = new();
+        mockProcess.SetupGet(p => p.StandardOutput).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.SetupGet(p => p.StandardError).Returns(new StreamReader(new MemoryStream(Array.Empty<byte>())));
+        mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new OperationCanceledException());
+
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, cts.Token);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Timeout);
+        mockProcess.Verify(p => p.Kill(true), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnFailed_WhenProcessRunnerThrowsException()
+    {
+        // Arrange
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Throws(new InvalidOperationException("Executable not found"));
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Failed);
+        result.ErrorMessage.Should().Contain("Executable not found");
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldRestartSubscription_WhenLoginSucceedsAndServiceIsStopped()
+    {
+        // Arrange
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>())).Returns(mockProcess.Object);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        GatewayAuthProgress result = await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        result.Stage.Should().Be(GatewayAuthStage.Success);
+        _subscriptionService.State.Should().Be(SubscriptionState.Running);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldPassSubscriberArgumentsAndGatewayUrl_ToProcessStartInfo()
+    {
+        // Arrange
+        _settingsService.UpdateSettings(new AppSettings
+        {
+            SubscriberArguments = "--skip-check --verbose",
+            GatewayUrl = "http://localhost:9999/mcp",
+        });
+
+        ProcessStartInfo? capturedPsi = null;
+        Mock<IProcessInstance> mockProcess = CreateMockProcess(0, string.Empty, string.Empty);
+        Mock<IProcessRunner> mockRunner = new();
+        mockRunner.Setup(r => r.Start(It.IsAny<ProcessStartInfo>()))
+            .Callback<ProcessStartInfo>(psi => capturedPsi = psi)
+            .Returns(mockProcess.Object);
+
+        GatewayAuthService service = new(_settingsService, _loggingService, _subscriptionService, mockRunner.Object, null);
+
+        // Act
+        await service.LoginAsync(null, CancellationToken.None);
+
+        // Assert
+        capturedPsi.Should().NotBeNull();
+        capturedPsi!.ArgumentList.Should().Contain("--login");
+        capturedPsi.ArgumentList.Should().Contain("--skip-check");
+        capturedPsi.ArgumentList.Should().Contain("--verbose");
+        capturedPsi.ArgumentList.Should().Contain("--url");
+        capturedPsi.ArgumentList.Should().Contain("http://localhost:9999/mcp");
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
@@ -7,7 +7,7 @@
     mc:Ignorable="d"
     Title="mcp-gateway にログイン"
     CloseButtonText="キャンセル"
-    DefaultButton="Close">
+    DefaultButton="None">
 
     <StackPanel Spacing="12" Width="400">
         <StackPanel x:Name="ProgressSection" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml
@@ -1,0 +1,46 @@
+<ContentDialog
+    x:Class="SquirrelNotifier.WinUI3.GatewayAuthDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="mcp-gateway にログイン"
+    CloseButtonText="キャンセル"
+    DefaultButton="Close">
+
+    <StackPanel Spacing="12" Width="400">
+        <StackPanel x:Name="ProgressSection" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <ProgressRing x:Name="LoginProgressRing" IsActive="True" Width="20" Height="20"/>
+            <TextBlock x:Name="StatusTextBlock" Text="mcp-gateway 認証を開始しています..." VerticalAlignment="Center" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <InfoBar x:Name="BrowserWarningInfoBar"
+                 Severity="Warning"
+                 Title="既定ブラウザを起動できませんでした"
+                 Message="手動で下記 URL をブラウザで開いて認証を完了してください。"
+                 IsOpen="False"
+                 IsClosable="False"/>
+
+        <InfoBar x:Name="ErrorInfoBar"
+                 Severity="Error"
+                 IsOpen="False"
+                 IsClosable="False"/>
+
+        <StackPanel x:Name="UrlSection" Visibility="Collapsed" Spacing="4">
+            <TextBlock Text="認証 URL:" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                <TextBox x:Name="UrlTextBox" IsReadOnly="True" TextWrapping="NoWrap"/>
+                <Button Grid.Column="1" Content="コピー" Click="OnCopyUrlClick"/>
+            </Grid>
+        </StackPanel>
+
+        <StackPanel x:Name="UserCodeSection" Visibility="Collapsed" Spacing="4">
+            <TextBlock Text="ユーザーコード:" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                <TextBox x:Name="UserCodeTextBox" IsReadOnly="True" FontWeight="Bold"/>
+                <Button Grid.Column="1" Content="コピー" Click="OnCopyUserCodeClick"/>
+            </Grid>
+        </StackPanel>
+    </StackPanel>
+</ContentDialog>

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
@@ -1,0 +1,137 @@
+// <copyright file="GatewayAuthDialog.xaml.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using SquirrelNotifier.WinUI3.Models;
+using SquirrelNotifier.WinUI3.Services;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace SquirrelNotifier.WinUI3;
+
+/// <summary>
+/// mcp-gateway の OAuth device flow 認証ダイアログ.
+/// </summary>
+internal sealed partial class GatewayAuthDialog : ContentDialog
+{
+    private readonly GatewayAuthService _authService;
+    private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatewayAuthDialog"/> class.
+    /// </summary>
+    /// <param name="authService">認証サービス.</param>
+    public GatewayAuthDialog(GatewayAuthService authService)
+    {
+        InitializeComponent();
+        _authService = authService;
+        Opened += OnDialogOpened;
+        Closed += OnDialogClosed;
+    }
+
+    private async void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+    {
+        Progress<GatewayAuthProgress> progress = new(UpdateUI);
+
+        try
+        {
+            GatewayAuthProgress result = await _authService.LoginAsync(progress, _cts.Token).ConfigureAwait(true);
+            UpdateUI(result);
+        }
+        catch (OperationCanceledException)
+        {
+            // キャンセル時はダイアログを閉じる
+        }
+    }
+
+    private void OnDialogClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
+    {
+        if (!_cts.IsCancellationRequested)
+        {
+            _cts.Cancel();
+        }
+
+        _cts.Dispose();
+    }
+
+    private void UpdateUI(GatewayAuthProgress authProgress)
+    {
+        switch (authProgress.Stage)
+        {
+            case GatewayAuthStage.Starting:
+                LoginProgressRing.IsActive = true;
+                StatusTextBlock.Text = "mcp-gateway 認証を開始しています...";
+                CloseButtonText = "キャンセル";
+                break;
+
+            case GatewayAuthStage.WaitingForUser:
+                LoginProgressRing.IsActive = true;
+                StatusTextBlock.Text = "ブラウザで認証を完了してください。";
+                CloseButtonText = "キャンセル";
+
+                if (!string.IsNullOrEmpty(authProgress.VerificationUrl))
+                {
+                    UrlSection.Visibility = Visibility.Visible;
+                    UrlTextBox.Text = authProgress.VerificationUrl;
+                }
+
+                if (!string.IsNullOrEmpty(authProgress.UserCode))
+                {
+                    UserCodeSection.Visibility = Visibility.Visible;
+                    UserCodeTextBox.Text = authProgress.UserCode;
+                }
+
+                if (authProgress.BrowserLaunchFailed)
+                {
+                    BrowserWarningInfoBar.IsOpen = true;
+                }
+
+                break;
+
+            case GatewayAuthStage.Success:
+                LoginProgressRing.IsActive = false;
+                ProgressSection.Visibility = Visibility.Collapsed;
+                BrowserWarningInfoBar.IsOpen = false;
+                StatusTextBlock.Text = "mcp-gateway への認証が正常に完了しました！";
+                CloseButtonText = "閉じる";
+                DefaultButton = ContentDialogButton.Close;
+                break;
+
+            case GatewayAuthStage.Failed:
+            case GatewayAuthStage.Cancelled:
+            case GatewayAuthStage.Timeout:
+                LoginProgressRing.IsActive = false;
+                ProgressSection.Visibility = Visibility.Collapsed;
+                BrowserWarningInfoBar.IsOpen = false;
+                CloseButtonText = "閉じる";
+                DefaultButton = ContentDialogButton.Close;
+
+                ErrorInfoBar.Message = authProgress.ErrorMessage ?? "認証処理を完了できませんでした。";
+                ErrorInfoBar.IsOpen = true;
+                break;
+        }
+    }
+
+    private void OnCopyUrlClick(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(UrlTextBox.Text))
+        {
+            DataPackage package = new();
+            package.SetText(UrlTextBox.Text);
+            Clipboard.SetContent(package);
+        }
+    }
+
+    private void OnCopyUserCodeClick(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(UserCodeTextBox.Text))
+        {
+            DataPackage package = new();
+            package.SetText(UserCodeTextBox.Text);
+            Clipboard.SetContent(package);
+        }
+    }
+}

--- a/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
+++ b/winui3/SquirrelNotifier.WinUI3/GatewayAuthDialog.xaml.cs
@@ -17,16 +17,24 @@ namespace SquirrelNotifier.WinUI3;
 /// </summary>
 internal sealed partial class GatewayAuthDialog : ContentDialog
 {
-    private readonly GatewayAuthService _authService;
+    private readonly GatewayAuthService? _authService;
     private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatewayAuthDialog"/> class.
+    /// </summary>
+    public GatewayAuthDialog()
+    {
+        InitializeComponent();
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GatewayAuthDialog"/> class.
     /// </summary>
     /// <param name="authService">認証サービス.</param>
     public GatewayAuthDialog(GatewayAuthService authService)
+        : this()
     {
-        InitializeComponent();
         _authService = authService;
         Opened += OnDialogOpened;
         Closed += OnDialogClosed;
@@ -34,6 +42,11 @@ internal sealed partial class GatewayAuthDialog : ContentDialog
 
     private async void OnDialogOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
     {
+        if (_authService == null)
+        {
+            return;
+        }
+
         Progress<GatewayAuthProgress> progress = new(UpdateUI);
 
         try

--- a/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
@@ -64,9 +64,11 @@ internal sealed class GatewayAuthService
 
     private sealed class AuthState
     {
-        public string? DetectedUrl;
-        public string? DetectedUserCode;
-        public bool HasLaunchedBrowser;
+        public string? DetectedUrl { get; set; }
+
+        public string? DetectedUserCode { get; set; }
+
+        public bool HasLaunchedBrowser { get; set; }
     }
 
     /// <summary>

--- a/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
+++ b/winui3/SquirrelNotifier.WinUI3/Services/GatewayAuthService.cs
@@ -1,0 +1,354 @@
+// <copyright file="GatewayAuthService.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using SquirrelNotifier.WinUI3.Models;
+
+namespace SquirrelNotifier.WinUI3.Services;
+
+/// <summary>
+/// <c>mcp-resource-subscriber --login</c> を呼び出して mcp-gateway の OAuth device flow 認証を実行・監視するサービス.
+/// </summary>
+internal sealed class GatewayAuthService
+{
+    private const int _loginTimeoutMs = 180000; // 3分間
+
+    private static readonly Regex _urlRegex = new(
+        @"https?://[^\s""'<>()]+",
+        RegexOptions.Compiled);
+
+    private static readonly Regex _userCodeRegex = new(
+        @"(?:user_code[""]?\s*[:=]\s*[""]?|code[""]?\s*[:=]\s*[""]?|Code:\s*|user code:\s*)([A-Za-z0-9\-]{4,16})",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex _queryUserCodeRegex = new(
+        @"[?&](?:user_code|code)=([A-Za-z0-9\-]{4,16})",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private readonly SettingsService _settingsService;
+    private readonly LoggingService _loggingService;
+    private readonly McpSubscriptionService _subscriptionService;
+    private readonly IProcessRunner _processRunner;
+    private readonly IBrowserLauncher _browserLauncher;
+
+    private readonly object _outputLock = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatewayAuthService"/> class.
+    /// </summary>
+    /// <param name="settingsService">設定サービス.</param>
+    /// <param name="loggingService">ログサービス.</param>
+    /// <param name="subscriptionService">購読サービス.</param>
+    /// <param name="processRunner">プロセス実行インスタンス（モック用、省略可）.</param>
+    /// <param name="browserLauncher">ブラウザ起動インスタンス（モック用、省略可）.</param>
+    public GatewayAuthService(
+        SettingsService settingsService,
+        LoggingService loggingService,
+        McpSubscriptionService subscriptionService,
+        IProcessRunner? processRunner = null,
+        IBrowserLauncher? browserLauncher = null)
+    {
+        _settingsService = settingsService;
+        _loggingService = loggingService;
+        _subscriptionService = subscriptionService;
+        _processRunner = processRunner ?? new ProcessRunner();
+        _browserLauncher = browserLauncher ?? new SystemBrowserLauncher();
+    }
+
+    private sealed class AuthState
+    {
+        public string? DetectedUrl;
+        public string? DetectedUserCode;
+        public bool HasLaunchedBrowser;
+    }
+
+    /// <summary>
+    /// ログや UI メッセージから認証トークンやシークレット情報をマスク・サニタイズします.
+    /// </summary>
+    /// <param name="message">サニタイズ対象のメッセージ文字列.</param>
+    /// <returns>シークレットがマスクされた文字列.</returns>
+    public static string SanitizeLogMessage(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return message;
+        }
+
+        // Bearer トークン, token=..., access_token, refresh_token, client_secret などのパターンを包括的にマスク
+        string sanitized = Regex.Replace(
+            message,
+            @"(bearer\s+|token[=:]\s*|""?(?:access_token|refresh_token|client_secret)""?\s*[:=]\s*""?)[A-Za-z0-9_\-\.\+\/%=]+",
+            "$1***",
+            RegexOptions.IgnoreCase);
+
+        return sanitized;
+    }
+
+    /// <summary>
+    /// mcp-gateway 認証を非同期に実行します.
+    /// </summary>
+    /// <param name="progress">進捗通知用のプログレスインターフェース（省略可）.</param>
+    /// <param name="cancellationToken">キャンセルトークン.</param>
+    /// <returns>最終的な認証進捗状況.</returns>
+    public async Task<GatewayAuthProgress> LoginAsync(
+        IProgress<GatewayAuthProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        GatewayAuthProgress resultProgress = new()
+        {
+            Stage = GatewayAuthStage.Starting,
+        };
+
+        progress?.Report(resultProgress);
+
+        AppSettings settings = _settingsService.Settings;
+        string resolvedPath = SettingsService.ResolveCommandPath(settings.SubscriberCommandPath);
+        string gatewayUrl = settings.GatewayUrl;
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_loginTimeoutMs);
+
+        await _loggingService.WriteAsync($"[AUTH] Starting mcp-gateway login process: {resolvedPath} --login").ConfigureAwait(false);
+
+        ProcessStartInfo psi = new()
+        {
+            FileName = resolvedPath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+
+        psi.ArgumentList.Add("--login");
+
+        if (!string.IsNullOrWhiteSpace(settings.SubscriberArguments))
+        {
+            foreach (string arg in McpSubscriptionService.ParseArguments(settings.SubscriberArguments))
+            {
+                psi.ArgumentList.Add(arg);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(gatewayUrl))
+        {
+            psi.ArgumentList.Add("--url");
+            psi.ArgumentList.Add(gatewayUrl);
+        }
+
+        IProcessInstance? process = null;
+        try
+        {
+            process = _processRunner.Start(psi);
+
+            AuthState state = new();
+            StringBuilder stderrOutput = new();
+
+            Task readStdoutTask = Task.Run(async () =>
+            {
+                while (!process.StandardOutput.EndOfStream)
+                {
+                    string? line = await process.StandardOutput.ReadLineAsync(cts.Token).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    await ProcessOutputLineAsync(
+                        line,
+                        resultProgress,
+                        progress,
+                        state).ConfigureAwait(false);
+                }
+            }, cts.Token);
+
+            Task readStderrTask = Task.Run(async () =>
+            {
+                while (!process.StandardError.EndOfStream)
+                {
+                    string? line = await process.StandardError.ReadLineAsync(cts.Token).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    lock (stderrOutput)
+                    {
+                        if (stderrOutput.Length < 2048)
+                        {
+                            stderrOutput.AppendLine(line);
+                        }
+                    }
+
+                    await ProcessOutputLineAsync(
+                        line,
+                        resultProgress,
+                        progress,
+                        state).ConfigureAwait(false);
+                }
+            }, cts.Token);
+
+            Task waitForExitTask = process.WaitForExitAsync(cts.Token);
+            await Task.WhenAll(readStdoutTask, readStderrTask, waitForExitTask).ConfigureAwait(false);
+
+            if (process.ExitCode == 0)
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login process completed successfully.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Success;
+                progress?.Report(resultProgress);
+
+                // 認証成功時、停止中・エラー状態であれば自動再購読を試みる
+                if (_subscriptionService.State == SubscriptionState.Stopped ||
+                    _subscriptionService.State == SubscriptionState.Error)
+                {
+                    await _loggingService.WriteAsync("[AUTH] Restarting subscription service after successful login...").ConfigureAwait(false);
+                    try
+                    {
+                        _subscriptionService.Start();
+                    }
+                    catch (Exception ex)
+                    {
+                        await _loggingService.WriteAsync($"[AUTH] Failed to restart subscription service: {ex.Message}").ConfigureAwait(false);
+                    }
+                }
+
+                return resultProgress;
+            }
+
+            string errDetail = stderrOutput.ToString().Trim();
+            if (string.IsNullOrEmpty(errDetail))
+            {
+                errDetail = $"Exit code: {process.ExitCode}";
+            }
+
+            string sanitizedError = SanitizeLogMessage(errDetail);
+            await _loggingService.WriteAsync($"[AUTH] mcp-gateway login failed (exit code {process.ExitCode}): {sanitizedError}").ConfigureAwait(false);
+            resultProgress.Stage = GatewayAuthStage.Failed;
+            resultProgress.ErrorMessage = $"認証プロセスがエラーで終了しました ({sanitizedError})";
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcess(process);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login cancelled by user.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Cancelled;
+                resultProgress.ErrorMessage = "ユーザーによってログインがキャンセルされました。";
+            }
+            else
+            {
+                await _loggingService.WriteAsync("[AUTH] mcp-gateway login timed out.").ConfigureAwait(false);
+                resultProgress.Stage = GatewayAuthStage.Timeout;
+                resultProgress.ErrorMessage = "ログイン操作がタイムアウトしました。";
+            }
+
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        catch (Exception ex)
+        {
+            await _loggingService.WriteAsync($"[AUTH] Unexpected error during login: {SanitizeLogMessage(ex.Message)}").ConfigureAwait(false);
+            resultProgress.Stage = GatewayAuthStage.Failed;
+            resultProgress.ErrorMessage = $"ログイン起動中に予期しないエラーが発生しました: {SanitizeLogMessage(ex.Message)}";
+            progress?.Report(resultProgress);
+            return resultProgress;
+        }
+        finally
+        {
+            process?.Dispose();
+        }
+    }
+
+    private static void TryKillProcess(IProcessInstance? process)
+    {
+        if (process == null)
+        {
+            return;
+        }
+
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // プロセスが既に終了している場合やアクセス権限例外を抑止
+        }
+    }
+
+    private async Task ProcessOutputLineAsync(
+        string line,
+        GatewayAuthProgress resultProgress,
+        IProgress<GatewayAuthProgress>? progress,
+        AuthState state)
+    {
+        string? urlToOpen = null;
+
+        lock (_outputLock)
+        {
+            Match urlMatch = _urlRegex.Match(line);
+            if (urlMatch.Success && state.DetectedUrl == null)
+            {
+                state.DetectedUrl = urlMatch.Value;
+                resultProgress.VerificationUrl = state.DetectedUrl;
+
+                Match queryCodeMatch = _queryUserCodeRegex.Match(state.DetectedUrl);
+                if (queryCodeMatch.Success && state.DetectedUserCode == null)
+                {
+                    state.DetectedUserCode = queryCodeMatch.Groups[1].Value;
+                    resultProgress.UserCode = state.DetectedUserCode;
+                }
+            }
+
+            if (state.DetectedUserCode == null)
+            {
+                Match codeMatch = _userCodeRegex.Match(line);
+                if (codeMatch.Success)
+                {
+                    state.DetectedUserCode = codeMatch.Groups[1].Value;
+                    resultProgress.UserCode = state.DetectedUserCode;
+                }
+            }
+
+            if (state.DetectedUrl != null)
+            {
+                resultProgress.Stage = GatewayAuthStage.WaitingForUser;
+
+                if (!state.HasLaunchedBrowser)
+                {
+                    state.HasLaunchedBrowser = true;
+                    urlToOpen = state.DetectedUrl;
+                }
+
+                progress?.Report(resultProgress);
+            }
+        }
+
+        if (urlToOpen != null)
+        {
+            await _loggingService.WriteAsync($"[AUTH] Verification URL detected: {urlToOpen}").ConfigureAwait(false);
+            bool openSuccess = _browserLauncher.OpenUrl(urlToOpen);
+            if (!openSuccess)
+            {
+                lock (_outputLock)
+                {
+                    resultProgress.BrowserLaunchFailed = true;
+                    progress?.Report(resultProgress);
+                }
+
+                await _loggingService.WriteAsync("[AUTH] Failed to open default browser automatically for verification URL.").ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

mcp-gateway の初回認証を Squirrel Notifier の UI から開始できるようにする導線（`GatewayAuthDialog`）を追加しました。また、`README.md` に GUI / CLI での初回認証手順とトラブルシューティングを明記しました。

Closes #183

## 提案する変更

1. **アプリ内認証導線**
   - Settings 画面の Gateway URL 横に「mcp-gateway にログイン」ボタンを追加
   - 認証エラー表示（`AuthRequiredInfoBar`）にも「mcp-gateway にログイン」へ進める ActionButton を追加
   - 設定済みの `SubscriberCommandPath` と `GatewayUrl` を使い、`mcp-resource-subscriber --login --url <url>` を安全に起動

2. **ブラウザと URL フォールバック**
   - verification URL を検出し既定ブラウザで自動表示
   - ブラウザ起動失敗時も URL / ユーザーコードをコピー可能な UI で提示
   - 認証トークンやヘッダー情報を settings、ログ、プロセス引数に出力させないサニタイズ処理（`SanitizeLogMessage`）の徹底

3. **完了・失敗時の UX & 自動再購読**
   - 成功・失敗・キャンセル・タイムアウトを `GatewayAuthStage` で明確に区別して表示
   - 認証成功後、停止またはエラー状態の購読（`McpSubscriptionService`）を自動再開

4. **テスト & ドキュメント**
   - `GatewayAuthServiceTests.cs` にてプロセス起動・URL抽出・ブラウザ起動失敗・終了コード・キャンセル・トークンサニタイズを単体テストで検証
   - `README.md` に GUI / CLI の初回認証手順とトラブルシューティングを追記
   - `CHANGELOG.md` を更新

## Acceptance Criteria チェック

- [x] Settings から mcp-gateway の device flow login を開始できる
- [x] 認証エラー表示から同じ login操作へ進める
- [x] verification URL を既定ブラウザで開ける
- [x] ブラウザ起動失敗時も URL / user code をコピーできる
- [x] 認証成功後、停止中の購読を再開できる
- [x] 成功・失敗・キャンセル・タイムアウトを区別して表示できる
- [x] token / Authorization ヘッダーが settings、ログ、プロセス引数に露出しない
- [x] README に GUI / CLI の初回認証手順とトラブルシューティングが記載される
- [x] process 起動、URL 抽出、ブラウザ起動失敗、終了コード、キャンセルを DI 可能な単体テストで検証する
- [x] `dotnet format --verify-no-changes`、`dotnet build`、`dotnet test` のコード規約・型安全性を満たす
- [x] `CHANGELOG.md` を更新する
