### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-01
+
 ### Added
 - 購読開始時に subscriber が返す `InitialText` を処理し、アプリ停止中や別経路から queue に登録された既存のレビュー候補を新しい notification が届く前に通知できるようにした（#210、epic #185）。`FinalText` と同じ parse・重複排除・通知・キャッシュ保存経路を使うため、両方に含まれる同一候補やキャッシュ復元済みの候補は再通知しない。`InitialText` が空または不正 JSON の場合は購読を失敗させず、正常な待機満了後も再購読を継続する
 - 購読停止中の手動レビュー登録を「購読開始 → `Running` 確認 → enqueue」の順序へ変更した（#209、epic #185）。`Stopped` / `Error` では enqueue 前に「購読を開始して登録／キャンセル」を確認し、開始失敗・タイムアウト・キャンセル時は queue を変更しない。順序制御は `ReviewRegistrationService` に集約し、確認待ちを含む一連の操作を直列化して多重クリックによる重複 enqueue を防止する。認証要求は既存の `AuthRequiredInfoBar` から mcp-gateway のログイン導線へ接続し、成功ダイアログには画面を閉じても登録済みであることを明示する
@@ -218,7 +220,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 開発用ツールセットの Python プロジェクト名を `squirrel-notifier-devtools` に変更
 - トレイ通知のイベント発生時、レビュー URL 開くボタンを（今回のスコープ外のため）一旦削除
 
-[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/scottlz0310/squirrel-notifier/compare/v0.4.0...v0.5.0

--- a/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
+++ b/winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj
@@ -5,9 +5,9 @@
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.5.2</Version>
-    <AssemblyVersion>0.5.2.0</AssemblyVersion>
-    <FileVersion>0.5.2.0</FileVersion>
+    <Version>0.6.0</Version>
+    <AssemblyVersion>0.6.0.0</AssemblyVersion>
+    <FileVersion>0.6.0.0</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\squirrel-notifier.ico</ApplicationIcon>


### PR DESCRIPTION
## 目的

v0.6.0 をリリースするための準備 PR。`Unreleased` の内容を `[0.6.0]` として切り出し、csproj のバージョンを更新する。

## 変更内容

- `CHANGELOG.md`: `## [Unreleased]` の直下に `## [0.6.0] - 2026-08-01` 見出しを追加し、リンク参照定義を更新
- `winui3/SquirrelNotifier.WinUI3/SquirrelNotifier.WinUI3.csproj`: `Version` / `AssemblyVersion` / `FileVersion` を `0.5.2` → `0.6.0`

コード変更は含まない。

## バージョンを minor にした理由

`Unreleased` に `### Added` が 4 件（#210 / #209 / #208 / #183）含まれるため、CHANGELOG が宣言している Semantic Versioning に従って patch ではなく minor を上げる。

## リリース内容の内訳

| 区分 | 件数 | 主なもの |
|---|---|---|
| Added | 4 | #210 `InitialText` 処理、#209 購読開始→登録の順序制御、#208 `StartAsync` API、#183 gateway ログイン導線 |
| Changed | 2 | #220 PR CI 壁時計の削減（中央値 368 秒 / -29.0%）、#211 購読操作ボタンの日本語化 |
| Fixed | 8 | #202 トレイメニューのテーマ追従・活性制御、#201 subscriber 子プロセスのエラーハンドリング、#200 ログインダイアログ、#199 `TrayPopup` クラッシュ、#181 トースト通知導線、#187 claude の phase 逐次表示、#186 working directory、#180 agy の print-timeout |

## 検証状況

HEAD 4539cbb の publish 成果物に対して #166 のシナリオ 1〜4 を実機検証済み（[結果コメント](https://github.com/scottlz0310/squirrel-notifier/issues/166#issuecomment-5151078788)）。レビュー登録 → 通知 → エージェント起動 → ライブログ → 終了処理の中核ループ、マスキング、キャンセル時の子プロセス停止、Auto-Pause の発動・強行・自動解除・旧形式 payload 判定はすべて期待どおり動作することを確認した。

なお正規配布物（MSI / セットアップ Zip）での検証は本リリース後になる。

## 既知の問題（本リリースには未修正で含まれる）

実機検証で検出し、今回は修正せず次以降へ送ることを合意済み。

| Issue | 内容 | 影響 |
|---|---|---|
| #229 | 起動時に `XamlParseException`（`TaskbarIcon.TrayPopup`）で異常終了することがある（27 回中 1 回、cold start 疑い） | 起動不能。再起動で復帰するが自動再起動はない |
| #233 | カスタムランチャープリセットでは Auto-Pause が無効になるが UI に表示がない | プリセットのまま使う限り影響なし |
| #231 | `cmd`/`bat` ランチャーの出力が文字化けする | 失敗時の原因メッセージが読めない |
| #230 | 空キュー `[]` を Malformed 警告として約 60 秒ごとに記録 | ログノイズ |
| #232 | 「Recent activity」が最新行へ自動スクロールしない | UX |

優先度は #229 → #233 → #231 → #230 → #232。

## マージ後の手順

1. `main` へマージ
2. `v0.6.0` タグを作成して push
3. `release.yml` が MSI / セットアップ Zip / checksums をビルドし、`scripts/extract-release-notes.ps1` が生成したリリースノートで Release を公開

リリースノート生成はローカルで `./scripts/extract-release-notes.ps1 -Version 0.6.0` を実行し、`[0.6.0]` 節の抽出と前バージョン（0.5.2）の compare リンクが正しく組み立てられることを確認済み。

## 確認事項

- [x] CHANGELOG.md を更新した
- [x] csproj の `<Version>` と CHANGELOG の節が一致する（changelog-guard 対応）
- [x] pre-commit（build / format / quality-and-security）が通る
- [x] pre-push（dotnet test）が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqg1SqZQcqpc6jTfFjHBBk
